### PR TITLE
feat(goose): implement agent configuration for workspace preparation

### DIFF
--- a/extensions/goose/package.json
+++ b/extensions/goose/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@openkaiden/api": "workspace:*",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/extensions/goose/package.json
+++ b/extensions/goose/package.json
@@ -23,7 +23,8 @@
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "@openkaiden/api": "workspace:*"
+    "@openkaiden/api": "workspace:*",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "adm-zip": "^0.5.16",

--- a/extensions/goose/package.json
+++ b/extensions/goose/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@openkaiden/api": "workspace:*",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "adm-zip": "^0.5.16",

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -80,6 +80,13 @@ describe('activate', () => {
   });
 
   describe('preWorkspaceStart', () => {
+    let agent: ReturnType<typeof vi.mocked<typeof agents.registerAgent>>['mock']['calls'][0][0];
+
+    beforeEach(async () => {
+      await activate(extensionContextMock);
+      agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    });
+
     function createContext(
       configFiles: AgentConfigurationFile[],
       options: {
@@ -100,18 +107,18 @@ describe('activate', () => {
           endpoint,
         },
         configurationFiles: configFiles,
-        workspace: { ...(mcp ? { mcp } : {}) },
+        workspace: { mcp },
       };
     }
 
     function createConfigFile(content = ''): AgentConfigurationFile & { updateMock: ReturnType<typeof vi.fn> } {
       const updateMock = vi.fn();
-      const file: AgentConfigurationFile = {
+      return {
         path: GOOSE_CONFIG_PATH,
         read: vi.fn().mockResolvedValue(content),
         update: updateMock,
+        updateMock,
       };
-      return Object.assign(file, { updateMock });
     }
 
     function parseWritten(updateMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
@@ -119,9 +126,6 @@ describe('activate', () => {
     }
 
     test('writes model configuration into config.yaml', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile]));
 
@@ -131,9 +135,6 @@ describe('activate', () => {
     });
 
     test('preserves existing configuration fields', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile('GOOSE_PROVIDER: openai\nGOOSE_MODEL: old-model\n');
       await agent.preWorkspaceStart(createContext([configFile], { modelLabel: 'claude-sonnet' }));
 
@@ -143,9 +144,6 @@ describe('activate', () => {
     });
 
     test('handles empty config file', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile('');
       await agent.preWorkspaceStart(createContext([configFile], { modelLabel: 'gemini-2.5-pro' }));
 
@@ -154,9 +152,6 @@ describe('activate', () => {
     });
 
     test('does not set GOOSE_PROVIDER when no provider is given', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile]));
 
@@ -165,9 +160,6 @@ describe('activate', () => {
     });
 
     test('sets GOOSE_PROVIDER from llmMetadata', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], { provider: 'anthropic', modelLabel: 'claude-sonnet' }),
@@ -179,9 +171,6 @@ describe('activate', () => {
     });
 
     test('maps gemini provider to google', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile], { provider: 'gemini', modelLabel: 'gemini-2.5-pro' }));
 
@@ -190,9 +179,6 @@ describe('activate', () => {
     });
 
     test('passes through unknown providers as-is', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile], { provider: 'ollama', modelLabel: 'llama3' }));
 
@@ -201,9 +187,6 @@ describe('activate', () => {
     });
 
     test('sets OPENAI_BASE_URL when endpoint is provided', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -218,9 +201,6 @@ describe('activate', () => {
     });
 
     test('does not set OPENAI_BASE_URL when no endpoint', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile], { provider: 'openai', modelLabel: 'gpt-4o' }));
 
@@ -229,9 +209,6 @@ describe('activate', () => {
     });
 
     test('sets vertexai env vars to route through inference proxy', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       const context = createContext([configFile], { provider: 'vertexai', modelLabel: 'claude-sonnet-4' });
       await agent.preWorkspaceStart(context);
@@ -247,9 +224,6 @@ describe('activate', () => {
     });
 
     test('sets GOOSE_PROVIDER to anthropic in config for vertexai', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], { provider: 'vertexai', modelLabel: 'claude-sonnet-4' }),
@@ -261,9 +235,6 @@ describe('activate', () => {
     });
 
     test('does not set vertexai env vars for non-vertexai providers', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       const context = createContext([configFile], { provider: 'anthropic', modelLabel: 'claude-sonnet-4' });
       await agent.preWorkspaceStart(context);
@@ -272,9 +243,6 @@ describe('activate', () => {
     });
 
     test('does nothing when config file is not in context', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const updateMock = vi.fn();
       const otherFile: AgentConfigurationFile = {
         path: 'some/other/path.yaml',
@@ -288,9 +256,6 @@ describe('activate', () => {
     });
 
     test('writes remote MCP servers as streamable_http extensions', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -311,9 +276,6 @@ describe('activate', () => {
     });
 
     test('writes remote MCP servers with headers as envs', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -341,9 +303,6 @@ describe('activate', () => {
     });
 
     test('writes local MCP commands as stdio extensions', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -365,9 +324,6 @@ describe('activate', () => {
     });
 
     test('writes local MCP commands with env variables', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -397,9 +353,6 @@ describe('activate', () => {
     });
 
     test('writes both remote and local MCP servers together', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -428,9 +381,6 @@ describe('activate', () => {
     });
 
     test('merges MCP extensions with existing extensions', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const existingConfig =
         'GOOSE_MODEL: old\nextensions:\n  existing:\n    name: existing\n    type: stdio\n    cmd: existing-cmd\n    enabled: true\n';
       const configFile = createConfigFile(existingConfig);
@@ -460,9 +410,6 @@ describe('activate', () => {
     });
 
     test('does not write extensions key when workspace has no MCP config', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile]));
 
@@ -471,9 +418,6 @@ describe('activate', () => {
     });
 
     test('preserves existing extensions when workspace has no MCP config', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const existingConfig =
         'extensions:\n  existing:\n    name: existing\n    type: stdio\n    cmd: my-cmd\n    enabled: true\n';
       const configFile = createConfigFile(existingConfig);
@@ -490,9 +434,6 @@ describe('activate', () => {
     });
 
     test('omits envs when remote MCP server has empty headers', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -508,9 +449,6 @@ describe('activate', () => {
     });
 
     test('omits envs when local MCP command has empty env', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Disposable, ExtensionContext } from '@openkaiden/api';
+import type { AgentConfigurationFile, AgentWorkspaceContext, Disposable, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
+import { load } from 'js-yaml';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { activate } from './extension';
+import { activate, GOOSE_CONFIG_PATH } from './extension';
 
 const AGENT_DISPOSABLE_MOCK: Disposable = { dispose: vi.fn() };
 
@@ -58,11 +59,438 @@ describe('activate', () => {
     expect(extensionContextMock.subscriptions).toContain(AGENT_DISPOSABLE_MOCK);
   });
 
+  // TODO: enable openshell runtime once goose is wired into the image builder
+
   test('registered agent supports all model types', async () => {
     await activate(extensionContextMock);
 
     const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
     expect(agent.isSupportedModelType!({ name: 'gemini' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(true);
+  });
+
+  test('registers agent with config.yaml configuration file', async () => {
+    await activate(extensionContextMock);
+
+    const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    expect(agent.configurationFiles).toHaveLength(1);
+    expect(agent.configurationFiles[0]!.path).toBe(GOOSE_CONFIG_PATH);
+  });
+
+  describe('preWorkspaceStart', () => {
+    function createContext(
+      configFiles: AgentConfigurationFile[],
+      options: {
+        modelLabel?: string;
+        provider?: string;
+        endpoint?: string;
+        mcp?: {
+          servers?: { name: string; url: string; headers?: Record<string, string> }[];
+          commands?: { name: string; command: string; args?: string[]; env?: Record<string, string> }[];
+        };
+      } = {},
+    ): AgentWorkspaceContext {
+      const { modelLabel = 'gpt-4o', provider, endpoint, mcp } = options;
+      return {
+        model: {
+          model: { label: modelLabel },
+          llmMetadata: provider ? { name: provider } : undefined,
+          endpoint,
+        },
+        configurationFiles: configFiles,
+        workspace: { ...(mcp ? { mcp } : {}) },
+      };
+    }
+
+    function createConfigFile(content = ''): AgentConfigurationFile & { updateMock: ReturnType<typeof vi.fn> } {
+      const updateMock = vi.fn();
+      const file: AgentConfigurationFile = {
+        path: GOOSE_CONFIG_PATH,
+        read: vi.fn().mockResolvedValue(content),
+        update: updateMock,
+      };
+      return Object.assign(file, { updateMock });
+    }
+
+    function parseWritten(updateMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+      return load(updateMock.mock.calls[0]![0] as string) as Record<string, unknown>;
+    }
+
+    test('writes model configuration into config.yaml', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(configFile.updateMock).toHaveBeenCalledOnce();
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_MODEL).toBe('gpt-4o');
+    });
+
+    test('preserves existing configuration fields', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile('GOOSE_PROVIDER: openai\nGOOSE_MODEL: old-model\n');
+      await agent.preWorkspaceStart(createContext([configFile], { modelLabel: 'claude-sonnet' }));
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_PROVIDER).toBe('openai');
+      expect(written.GOOSE_MODEL).toBe('claude-sonnet');
+    });
+
+    test('handles empty config file', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile('');
+      await agent.preWorkspaceStart(createContext([configFile], { modelLabel: 'gemini-2.5-pro' }));
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_MODEL).toBe('gemini-2.5-pro');
+    });
+
+    test('does not set GOOSE_PROVIDER when no provider is given', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_PROVIDER).toBeUndefined();
+    });
+
+    test('sets GOOSE_PROVIDER from llmMetadata', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], { provider: 'anthropic', modelLabel: 'claude-sonnet' }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_PROVIDER).toBe('anthropic');
+      expect(written.GOOSE_MODEL).toBe('claude-sonnet');
+    });
+
+    test('maps gemini provider to google', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile], { provider: 'gemini', modelLabel: 'gemini-2.5-pro' }));
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_PROVIDER).toBe('google');
+    });
+
+    test('maps vertexai provider to gcp-vertex', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], { provider: 'vertexai', modelLabel: 'gemini-2.5-pro' }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_PROVIDER).toBe('gcp-vertex');
+    });
+
+    test('passes through unknown providers as-is', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile], { provider: 'ollama', modelLabel: 'llama3' }));
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_PROVIDER).toBe('ollama');
+    });
+
+    test('sets OPENAI_BASE_URL when endpoint is provided', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          provider: 'openai',
+          modelLabel: 'gpt-4o',
+          endpoint: 'http://localhost:11434/v1',
+        }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.OPENAI_BASE_URL).toBe('http://localhost:11434/v1');
+    });
+
+    test('does not set OPENAI_BASE_URL when no endpoint', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile], { provider: 'openai', modelLabel: 'gpt-4o' }));
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.OPENAI_BASE_URL).toBeUndefined();
+    });
+
+    test('does nothing when config file is not in context', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const otherFile: AgentConfigurationFile = {
+        path: 'some/other/path.yaml',
+        read: vi.fn(),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([otherFile]));
+
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    test('writes remote MCP servers as streamable_http extensions', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'my-remote', url: 'https://mcp.example.com' }],
+          },
+        }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      const extensions = written.extensions as Record<string, Record<string, unknown>>;
+      expect(extensions['my-remote']).toEqual({
+        name: 'my-remote',
+        type: 'streamable_http',
+        url: 'https://mcp.example.com',
+        enabled: true,
+      });
+    });
+
+    test('writes remote MCP servers with headers as envs', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [
+              {
+                name: 'authed-server',
+                url: 'https://mcp.example.com',
+                headers: { Authorization: 'Bearer token123' },
+              },
+            ],
+          },
+        }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      const extensions = written.extensions as Record<string, Record<string, unknown>>;
+      expect(extensions['authed-server']).toEqual({
+        name: 'authed-server',
+        type: 'streamable_http',
+        url: 'https://mcp.example.com',
+        enabled: true,
+        envs: { Authorization: 'Bearer token123' },
+      });
+    });
+
+    test('writes local MCP commands as stdio extensions', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [{ name: 'my-local', command: 'npx', args: ['-y', 'my-mcp-server'] }],
+          },
+        }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      const extensions = written.extensions as Record<string, Record<string, unknown>>;
+      expect(extensions['my-local']).toEqual({
+        name: 'my-local',
+        type: 'stdio',
+        cmd: 'npx',
+        args: ['-y', 'my-mcp-server'],
+        enabled: true,
+      });
+    });
+
+    test('writes local MCP commands with env variables', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [
+              {
+                name: 'github-mcp',
+                command: 'npx',
+                args: ['@modelcontextprotocol/server-github'],
+                env: { GITHUB_TOKEN: 'ghp_test123' },
+              },
+            ],
+          },
+        }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      const extensions = written.extensions as Record<string, Record<string, unknown>>;
+      expect(extensions['github-mcp']).toEqual({
+        name: 'github-mcp',
+        type: 'stdio',
+        cmd: 'npx',
+        args: ['@modelcontextprotocol/server-github'],
+        enabled: true,
+        envs: { GITHUB_TOKEN: 'ghp_test123' },
+      });
+    });
+
+    test('writes both remote and local MCP servers together', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'remote-one', url: 'https://mcp.example.com' }],
+            commands: [{ name: 'local-one', command: 'npx', args: ['my-server'] }],
+          },
+        }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      const extensions = written.extensions as Record<string, Record<string, unknown>>;
+      expect(extensions['remote-one']).toEqual({
+        name: 'remote-one',
+        type: 'streamable_http',
+        url: 'https://mcp.example.com',
+        enabled: true,
+      });
+      expect(extensions['local-one']).toEqual({
+        name: 'local-one',
+        type: 'stdio',
+        cmd: 'npx',
+        args: ['my-server'],
+        enabled: true,
+      });
+    });
+
+    test('merges MCP extensions with existing extensions', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const existingConfig =
+        'GOOSE_MODEL: old\nextensions:\n  existing:\n    name: existing\n    type: stdio\n    cmd: existing-cmd\n    enabled: true\n';
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [{ name: 'new-ext', command: 'npx', args: ['new-server'] }],
+          },
+        }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      const extensions = written.extensions as Record<string, Record<string, unknown>>;
+      expect(extensions['existing']).toEqual({
+        name: 'existing',
+        type: 'stdio',
+        cmd: 'existing-cmd',
+        enabled: true,
+      });
+      expect(extensions['new-ext']).toEqual({
+        name: 'new-ext',
+        type: 'stdio',
+        cmd: 'npx',
+        args: ['new-server'],
+        enabled: true,
+      });
+    });
+
+    test('does not write extensions key when workspace has no MCP config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.extensions).toBeUndefined();
+    });
+
+    test('preserves existing extensions when workspace has no MCP config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const existingConfig =
+        'extensions:\n  existing:\n    name: existing\n    type: stdio\n    cmd: my-cmd\n    enabled: true\n';
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = parseWritten(configFile.updateMock);
+      const extensions = written.extensions as Record<string, Record<string, unknown>>;
+      expect(extensions['existing']).toEqual({
+        name: 'existing',
+        type: 'stdio',
+        cmd: 'my-cmd',
+        enabled: true,
+      });
+    });
+
+    test('omits envs when remote MCP server has empty headers', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'no-headers', url: 'https://mcp.example.com', headers: {} }],
+          },
+        }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      const extensions = written.extensions as Record<string, Record<string, unknown>>;
+      expect(extensions['no-headers']).not.toHaveProperty('envs');
+    });
+
+    test('omits envs when local MCP command has empty env', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [{ name: 'minimal', command: 'my-server', args: [], env: {} }],
+          },
+        }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      const extensions = written.extensions as Record<string, Record<string, unknown>>;
+      expect(extensions['minimal']).not.toHaveProperty('envs');
+    });
   });
 });

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -61,12 +61,14 @@ describe('activate', () => {
 
   // TODO: enable openshell runtime once goose is wired into the image builder
 
-  test('registered agent supports all model types', async () => {
+  test('registered agent supports non-vertexai model types', async () => {
     await activate(extensionContextMock);
 
     const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-    expect(agent.isSupportedModelType!({ name: 'gemini' })).toBe(true);
-    expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(true);
+    expect(agent.isSupportedModelType!({ name: 'gemini' })).toBeTruthy();
+    expect(agent.isSupportedModelType!({ name: 'openai' })).toBeTruthy();
+    expect(agent.isSupportedModelType!({ name: 'anthropic' })).toBeTruthy();
+    expect(agent.isSupportedModelType!({ name: 'vertexai' })).toBeFalsy();
   });
 
   test('registers agent with config.yaml configuration file', async () => {
@@ -187,19 +189,6 @@ describe('activate', () => {
       expect(written.GOOSE_PROVIDER).toBe('google');
     });
 
-    test('maps vertexai provider to gcp-vertex', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
-      const configFile = createConfigFile();
-      await agent.preWorkspaceStart(
-        createContext([configFile], { provider: 'vertexai', modelLabel: 'gemini-2.5-pro' }),
-      );
-
-      const written = parseWritten(configFile.updateMock);
-      expect(written.GOOSE_PROVIDER).toBe('gcp-vertex');
-    });
-
     test('passes through unknown providers as-is', async () => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
@@ -237,6 +226,49 @@ describe('activate', () => {
 
       const written = parseWritten(configFile.updateMock);
       expect(written.OPENAI_BASE_URL).toBeUndefined();
+    });
+
+    test('sets vertexai env vars to route through inference proxy', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      const context = createContext([configFile], { provider: 'vertexai', modelLabel: 'claude-sonnet-4' });
+      await agent.preWorkspaceStart(context);
+
+      const env = context.workspace.environment!;
+      expect(env).toEqual(
+        expect.arrayContaining([
+          { name: 'GOOSE_PROVIDER', value: 'anthropic' },
+          { name: 'ANTHROPIC_HOST', value: 'https://inference.local' },
+          { name: 'ANTHROPIC_API_KEY', value: 'unused' },
+        ]),
+      );
+    });
+
+    test('sets GOOSE_PROVIDER to anthropic in config for vertexai', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], { provider: 'vertexai', modelLabel: 'claude-sonnet-4' }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_PROVIDER).toBe('anthropic');
+      expect(written.OPENAI_BASE_URL).toBeUndefined();
+    });
+
+    test('does not set vertexai env vars for non-vertexai providers', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      const context = createContext([configFile], { provider: 'anthropic', modelLabel: 'claude-sonnet-4' });
+      await agent.preWorkspaceStart(context);
+
+      expect(context.workspace.environment).toBeUndefined();
     });
 
     test('does nothing when config file is not in context', async () => {

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -48,6 +48,8 @@ describe('activate', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { dark: './icon_dark.png', light: './icon_light.png' } }),
         destinationSkillsFolder: '${HOME}/.agents/skills',
+        baseImage:
+          'ghcr.io/openkaiden/openshell-image-goose@sha256:e23918ed2ee0e7e13dc5dc52d753ac187ff5508fc0fdd4b5fd1f2e43e147584f',
         isSupportedModelType: expect.any(Function),
       }),
     );
@@ -132,6 +134,14 @@ describe('activate', () => {
       expect(configFile.updateMock).toHaveBeenCalledOnce();
       const written = parseWritten(configFile.updateMock);
       expect(written.GOOSE_MODEL).toBe('gpt-4o');
+    });
+
+    test('disables telemetry without prompting', async () => {
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written.GOOSE_TELEMETRY_ENABLED).toBe(false);
     });
 
     test('preserves existing configuration fields', async () => {

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -208,40 +208,6 @@ describe('activate', () => {
       expect(written.OPENAI_BASE_URL).toBeUndefined();
     });
 
-    test('sets vertexai env vars to route through inference proxy', async () => {
-      const configFile = createConfigFile();
-      const context = createContext([configFile], { provider: 'vertexai', modelLabel: 'claude-sonnet-4' });
-      await agent.preWorkspaceStart(context);
-
-      const env = context.workspace.environment!;
-      expect(env).toEqual(
-        expect.arrayContaining([
-          { name: 'GOOSE_PROVIDER', value: 'anthropic' },
-          { name: 'ANTHROPIC_HOST', value: 'https://inference.local' },
-          { name: 'ANTHROPIC_API_KEY', value: 'unused' },
-        ]),
-      );
-    });
-
-    test('sets GOOSE_PROVIDER to anthropic in config for vertexai', async () => {
-      const configFile = createConfigFile();
-      await agent.preWorkspaceStart(
-        createContext([configFile], { provider: 'vertexai', modelLabel: 'claude-sonnet-4' }),
-      );
-
-      const written = parseWritten(configFile.updateMock);
-      expect(written.GOOSE_PROVIDER).toBe('anthropic');
-      expect(written.OPENAI_BASE_URL).toBeUndefined();
-    });
-
-    test('does not set vertexai env vars for non-vertexai providers', async () => {
-      const configFile = createConfigFile();
-      const context = createContext([configFile], { provider: 'anthropic', modelLabel: 'claude-sonnet-4' });
-      await agent.preWorkspaceStart(context);
-
-      expect(context.workspace.environment).toBeUndefined();
-    });
-
     test('does nothing when config file is not in context', async () => {
       const updateMock = vi.fn();
       const otherFile: AgentConfigurationFile = {
@@ -270,12 +236,12 @@ describe('activate', () => {
       expect(extensions['my-remote']).toEqual({
         name: 'my-remote',
         type: 'streamable_http',
-        url: 'https://mcp.example.com',
+        uri: 'https://mcp.example.com',
         enabled: true,
       });
     });
 
-    test('writes remote MCP servers with headers as envs', async () => {
+    test('writes remote MCP servers with headers', async () => {
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -296,9 +262,9 @@ describe('activate', () => {
       expect(extensions['authed-server']).toEqual({
         name: 'authed-server',
         type: 'streamable_http',
-        url: 'https://mcp.example.com',
+        uri: 'https://mcp.example.com',
         enabled: true,
-        envs: { Authorization: 'Bearer token123' },
+        headers: { Authorization: 'Bearer token123' },
       });
     });
 
@@ -368,7 +334,7 @@ describe('activate', () => {
       expect(extensions['remote-one']).toEqual({
         name: 'remote-one',
         type: 'streamable_http',
-        url: 'https://mcp.example.com',
+        uri: 'https://mcp.example.com',
         enabled: true,
       });
       expect(extensions['local-one']).toEqual({
@@ -433,7 +399,7 @@ describe('activate', () => {
       });
     });
 
-    test('omits envs when remote MCP server has empty headers', async () => {
+    test('omits headers when remote MCP server has empty headers', async () => {
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -445,7 +411,7 @@ describe('activate', () => {
 
       const written = parseWritten(configFile.updateMock);
       const extensions = written.extensions as Record<string, Record<string, unknown>>;
-      expect(extensions['no-headers']).not.toHaveProperty('envs');
+      expect(extensions['no-headers']).not.toHaveProperty('headers');
     });
 
     test('omits envs when local MCP command has empty env', async () => {

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -161,6 +161,31 @@ describe('activate', () => {
       expect(written.GOOSE_MODEL).toBe('gemini-2.5-pro');
     });
 
+    test('replaces malformed YAML with generated configuration', async () => {
+      const configFile = createConfigFile('extensions:\n  invalid: [');
+      await agent.preWorkspaceStart(
+        createContext([configFile], { provider: 'anthropic', modelLabel: 'claude-sonnet' }),
+      );
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written).toEqual({
+        GOOSE_MODEL: 'claude-sonnet',
+        GOOSE_TELEMETRY_ENABLED: false,
+        GOOSE_PROVIDER: 'anthropic',
+      });
+    });
+
+    test('replaces non-object YAML with generated configuration', async () => {
+      const configFile = createConfigFile('invalid');
+      await agent.preWorkspaceStart(createContext([configFile], { modelLabel: 'gpt-4o' }));
+
+      const written = parseWritten(configFile.updateMock);
+      expect(written).toEqual({
+        GOOSE_MODEL: 'gpt-4o',
+        GOOSE_TELEMETRY_ENABLED: false,
+      });
+    });
+
     test('does not set GOOSE_PROVIDER when no provider is given', async () => {
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile]));

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -205,20 +205,22 @@ describe('activate', () => {
       expect(written.GOOSE_MODEL).toBe('claude-sonnet');
     });
 
-    test('maps gemini provider to google', async () => {
+    test('maps gemini provider to openai', async () => {
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile], { provider: 'gemini', modelLabel: 'gemini-2.5-pro' }));
 
       const written = parseWritten(configFile.updateMock);
-      expect(written.GOOSE_PROVIDER).toBe('google');
+      expect(written.GOOSE_PROVIDER).toBe('openai');
     });
 
     test('passes through unknown providers as-is', async () => {
       const configFile = createConfigFile();
-      await agent.preWorkspaceStart(createContext([configFile], { provider: 'ollama', modelLabel: 'llama3' }));
+      await agent.preWorkspaceStart(
+        createContext([configFile], { provider: 'custom-provider', modelLabel: 'custom-model' }),
+      );
 
       const written = parseWritten(configFile.updateMock);
-      expect(written.GOOSE_PROVIDER).toBe('ollama');
+      expect(written.GOOSE_PROVIDER).toBe('custom-provider');
     });
 
     test('sets OPENAI_BASE_URL when endpoint is provided', async () => {

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -16,39 +16,53 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
+import type { AgentWorkspaceContext, ExtensionContext, ModelType } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 import { dump, load } from 'js-yaml';
+import { z } from 'zod';
 
 export const GOOSE_CONFIG_PATH = '.config/goose/config.yaml';
 
 const GOOSE_PROVIDER_MAPPING: Record<string, string> = {
   gemini: 'google',
-  vertexai: 'gcp-vertex',
 };
 
-interface GooseExtensionEntry {
-  name: string;
-  type: string;
-  enabled: boolean;
-  cmd?: string;
-  args?: string[];
-  envs?: Record<string, string>;
-  url?: string;
-  timeout?: number;
-}
+const GooseExtensionEntrySchema = z.looseObject({
+  name: z.string(),
+  type: z.string(),
+  enabled: z.boolean(),
+  cmd: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  envs: z.record(z.string(), z.string()).optional(),
+  url: z.string().optional(),
+  timeout: z.number().optional(),
+});
 
-interface GooseConfig {
-  [key: string]: unknown;
-  extensions?: Record<string, GooseExtensionEntry>;
-}
+type GooseExtensionEntry = z.infer<typeof GooseExtensionEntrySchema>;
 
-function parseGooseConfig(content: string): GooseConfig {
-  if (!content.trim()) {
-    return {};
-  }
-  return (load(content) as GooseConfig) ?? {};
-}
+const GooseConfigSchema = z.looseObject({
+  extensions: z.record(z.string(), GooseExtensionEntrySchema).optional(),
+});
+
+const GooseConfigCodec = z.codec(z.string(), GooseConfigSchema, {
+  decode: (yamlString, ctx) => {
+    if (!yamlString.trim()) {
+      return {};
+    }
+    try {
+      return (load(yamlString) as Record<string, unknown>) ?? {};
+    } catch (err: unknown) {
+      ctx.issues.push({
+        code: 'invalid_format',
+        format: 'yaml',
+        input: yamlString,
+        message: err instanceof Error ? err.message : 'Invalid YAML',
+      });
+      return z.NEVER;
+    }
+  },
+  encode: value => dump(value),
+});
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
@@ -60,8 +74,6 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       logo: { dark: './icon_dark.png', light: './icon_light.png' },
     },
     command: 'goose',
-    // TODO: replace with official image once available — temporary testing image
-    baseImage: 'quay.io/bmahabir/openkaiden/openshell-goose:latest',
     acp: { args: ['acp'] },
     configurationFiles: [
       {
@@ -72,25 +84,54 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       },
     ],
     destinationSkillsFolder: '${HOME}/.agents/skills',
-    isSupportedModelType(): boolean {
-      return true;
+    isSupportedRuntime(runtime): boolean {
+      return runtime === 'podman';
+    },
+    isSupportedModelType(type: ModelType): boolean {
+      // Vertex AI setup is prepared below, but it is disabled until Kaiden injects it for Goose as Anthropic.
+      return type.name !== 'vertexai';
     },
     async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
+      const provider = context.model.llmMetadata?.name;
+
+      // Vertex AI + Goose: route through the openshell inference proxy as an
+      // Anthropic endpoint. We set GOOSE_PROVIDER=anthropic and ANTHROPIC_HOST
+      // here, but openshell overrides GOOSE_PROVIDER with gcp_vertex_ai because
+      // Kaiden creates a google-vertex-ai provider secret. Openshell injects
+      // its own env vars for that provider type and they win over --env flags.
+      // Workaround: pass `--provider anthropic` on the goose CLI to override
+      // the openshell-injected GOOSE_PROVIDER at runtime.
+      if (provider === 'vertexai') {
+        const envVars = [
+          { name: 'GOOSE_PROVIDER', value: 'anthropic' },
+          { name: 'ANTHROPIC_HOST', value: 'https://inference.local' },
+          { name: 'ANTHROPIC_API_KEY', value: 'unused' },
+        ];
+
+        context.workspace.environment ??= [];
+        for (const envVar of envVars) {
+          const index = context.workspace.environment.findIndex(e => e.name === envVar.name);
+          if (index >= 0) {
+            context.workspace.environment.splice(index, 1);
+          }
+          context.workspace.environment.push(envVar);
+        }
+      }
+
       const configFile = context.configurationFiles.find(f => f.path === GOOSE_CONFIG_PATH);
       if (!configFile) {
         return;
       }
 
-      const config = parseGooseConfig(await configFile.read());
+      const config = GooseConfigCodec.decode(await configFile.read());
       config.GOOSE_MODEL = context.model.model.label;
 
-      const provider = context.model.llmMetadata?.name;
       if (provider) {
-        config.GOOSE_PROVIDER = GOOSE_PROVIDER_MAPPING[provider] ?? provider;
+        config.GOOSE_PROVIDER = provider === 'vertexai' ? 'anthropic' : (GOOSE_PROVIDER_MAPPING[provider] ?? provider);
       }
 
       const endpoint = context.model.endpoint;
-      if (endpoint) {
+      if (endpoint && provider !== 'vertexai') {
         config.OPENAI_BASE_URL = endpoint;
       }
 
@@ -124,7 +165,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         config.extensions = extensions;
       }
 
-      await configFile.update(dump(config));
+      await configFile.update(GooseConfigCodec.encode(config));
     },
   });
   extensionContext.subscriptions.push(disposable);

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -38,8 +38,6 @@ const GooseExtensionEntrySchema = z.looseObject({
   timeout: z.number().optional(),
 });
 
-type GooseExtensionEntry = z.infer<typeof GooseExtensionEntrySchema>;
-
 const GooseConfigSchema = z.looseObject({
   extensions: z.record(z.string(), GooseExtensionEntrySchema).optional(),
 });
@@ -56,13 +54,17 @@ const GooseConfigCodec = z.codec(z.string(), GooseConfigSchema, {
         code: 'invalid_format',
         format: 'yaml',
         input: yamlString,
-        message: err instanceof Error ? err.message : 'Invalid YAML',
+        message: String(err),
       });
       return z.NEVER;
     }
   },
   encode: value => dump(value),
 });
+
+function nonEmpty(obj: Record<string, string> | undefined): Record<string, string> | undefined {
+  return obj && Object.keys(obj).length > 0 ? obj : undefined;
+}
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
@@ -73,6 +75,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       icon: { dark: './icon_dark.png', light: './icon_light.png' },
       logo: { dark: './icon_dark.png', light: './icon_light.png' },
     },
+    tags: ['Local'],
     command: 'goose',
     acp: { args: ['acp'] },
     configurationFiles: [
@@ -139,30 +142,28 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       const mcpCommands = context.workspace.mcp?.commands;
 
       if (mcpServers?.length || mcpCommands?.length) {
-        const extensions: Record<string, GooseExtensionEntry> = { ...config.extensions };
+        config.extensions ??= {};
 
         for (const server of mcpServers ?? []) {
-          extensions[server.name] = {
+          config.extensions[server.name] = {
             name: server.name,
             type: 'streamable_http',
             url: server.url,
             enabled: true,
-            ...(server.headers && Object.keys(server.headers).length > 0 ? { envs: server.headers } : {}),
+            envs: nonEmpty(server.headers),
           };
         }
 
         for (const cmd of mcpCommands ?? []) {
-          extensions[cmd.name] = {
+          config.extensions[cmd.name] = {
             name: cmd.name,
             type: 'stdio',
             cmd: cmd.command,
             args: cmd.args ?? [],
             enabled: true,
-            ...(cmd.env && Object.keys(cmd.env).length > 0 ? { envs: cmd.env } : {}),
+            envs: nonEmpty(cmd.env),
           };
         }
-
-        config.extensions = extensions;
       }
 
       await configFile.update(GooseConfigCodec.encode(config));

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -54,7 +54,7 @@ const GooseConfigCodec = z.codec(z.string(), GooseConfigSchema, {
         code: 'invalid_format',
         format: 'yaml',
         input: yamlString,
-        message: String(err),
+        message: err instanceof Error ? err.message : String(err),
       });
       return z.NEVER;
     }
@@ -64,6 +64,18 @@ const GooseConfigCodec = z.codec(z.string(), GooseConfigSchema, {
 
 function nonEmpty(obj: Record<string, string> | undefined): Record<string, string> | undefined {
   return obj && Object.keys(obj).length > 0 ? obj : undefined;
+}
+
+function setEnvironmentVariable(
+  environment: NonNullable<AgentWorkspaceContext['workspace']['environment']>,
+  name: string,
+  value: string,
+): void {
+  const index = environment.findIndex(entry => entry.name === name);
+  if (index >= 0) {
+    environment.splice(index, 1);
+  }
+  environment.push({ name, value });
 }
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
@@ -87,9 +99,6 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       },
     ],
     destinationSkillsFolder: '${HOME}/.agents/skills',
-    isSupportedRuntime(runtime): boolean {
-      return runtime === 'podman';
-    },
     isSupportedModelType(type: ModelType): boolean {
       // Vertex AI setup is prepared below, but it is disabled until Kaiden injects it for Goose as Anthropic.
       return type.name !== 'vertexai';
@@ -113,11 +122,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
         context.workspace.environment ??= [];
         for (const envVar of envVars) {
-          const index = context.workspace.environment.findIndex(e => e.name === envVar.name);
-          if (index >= 0) {
-            context.workspace.environment.splice(index, 1);
-          }
-          context.workspace.environment.push(envVar);
+          setEnvironmentVariable(context.workspace.environment, envVar.name, envVar.value);
         }
       }
 

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -16,8 +16,39 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@openkaiden/api';
+import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
+import { dump, load } from 'js-yaml';
+
+export const GOOSE_CONFIG_PATH = '.config/goose/config.yaml';
+
+const GOOSE_PROVIDER_MAPPING: Record<string, string> = {
+  gemini: 'google',
+  vertexai: 'gcp-vertex',
+};
+
+interface GooseExtensionEntry {
+  name: string;
+  type: string;
+  enabled: boolean;
+  cmd?: string;
+  args?: string[];
+  envs?: Record<string, string>;
+  url?: string;
+  timeout?: number;
+}
+
+interface GooseConfig {
+  [key: string]: unknown;
+  extensions?: Record<string, GooseExtensionEntry>;
+}
+
+function parseGooseConfig(content: string): GooseConfig {
+  if (!content.trim()) {
+    return {};
+  }
+  return (load(content) as GooseConfig) ?? {};
+}
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
@@ -29,14 +60,71 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       logo: { dark: './icon_dark.png', light: './icon_light.png' },
     },
     command: 'goose',
+    // TODO: replace with official image once available — temporary testing image
+    baseImage: 'quay.io/bmahabir/openkaiden/openshell-goose:latest',
     acp: { args: ['acp'] },
-    configurationFiles: [],
+    configurationFiles: [
+      {
+        path: GOOSE_CONFIG_PATH,
+        async read(): Promise<string> {
+          return '';
+        },
+      },
+    ],
     destinationSkillsFolder: '${HOME}/.agents/skills',
     isSupportedModelType(): boolean {
       return true;
     },
-    async preWorkspaceStart(): Promise<void> {
-      throw new Error('not implemented');
+    async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
+      const configFile = context.configurationFiles.find(f => f.path === GOOSE_CONFIG_PATH);
+      if (!configFile) {
+        return;
+      }
+
+      const config = parseGooseConfig(await configFile.read());
+      config.GOOSE_MODEL = context.model.model.label;
+
+      const provider = context.model.llmMetadata?.name;
+      if (provider) {
+        config.GOOSE_PROVIDER = GOOSE_PROVIDER_MAPPING[provider] ?? provider;
+      }
+
+      const endpoint = context.model.endpoint;
+      if (endpoint) {
+        config.OPENAI_BASE_URL = endpoint;
+      }
+
+      const mcpServers = context.workspace.mcp?.servers;
+      const mcpCommands = context.workspace.mcp?.commands;
+
+      if (mcpServers?.length || mcpCommands?.length) {
+        const extensions: Record<string, GooseExtensionEntry> = { ...config.extensions };
+
+        for (const server of mcpServers ?? []) {
+          extensions[server.name] = {
+            name: server.name,
+            type: 'streamable_http',
+            url: server.url,
+            enabled: true,
+            ...(server.headers && Object.keys(server.headers).length > 0 ? { envs: server.headers } : {}),
+          };
+        }
+
+        for (const cmd of mcpCommands ?? []) {
+          extensions[cmd.name] = {
+            name: cmd.name,
+            type: 'stdio',
+            cmd: cmd.command,
+            args: cmd.args ?? [],
+            enabled: true,
+            ...(cmd.env && Object.keys(cmd.env).length > 0 ? { envs: cmd.env } : {}),
+          };
+        }
+
+        config.extensions = extensions;
+      }
+
+      await configFile.update(dump(config));
     },
   });
   extensionContext.subscriptions.push(disposable);

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -34,7 +34,8 @@ const GooseExtensionEntrySchema = z.looseObject({
   cmd: z.string().optional(),
   args: z.array(z.string()).optional(),
   envs: z.record(z.string(), z.string()).optional(),
-  url: z.string().optional(),
+  uri: z.string().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
   timeout: z.number().optional(),
 });
 
@@ -66,18 +67,6 @@ function nonEmpty(obj: Record<string, string> | undefined): Record<string, strin
   return obj && Object.keys(obj).length > 0 ? obj : undefined;
 }
 
-function setEnvironmentVariable(
-  environment: NonNullable<AgentWorkspaceContext['workspace']['environment']>,
-  name: string,
-  value: string,
-): void {
-  const index = environment.findIndex(entry => entry.name === name);
-  if (index >= 0) {
-    environment.splice(index, 1);
-  }
-  environment.push({ name, value });
-}
-
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
     id: 'goose',
@@ -100,31 +89,10 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     ],
     destinationSkillsFolder: '${HOME}/.agents/skills',
     isSupportedModelType(type: ModelType): boolean {
-      // Vertex AI setup is prepared below, but it is disabled until Kaiden injects it for Goose as Anthropic.
       return type.name !== 'vertexai';
     },
     async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
       const provider = context.model.llmMetadata?.name;
-
-      // Vertex AI + Goose: route through the openshell inference proxy as an
-      // Anthropic endpoint. We set GOOSE_PROVIDER=anthropic and ANTHROPIC_HOST
-      // here, but openshell overrides GOOSE_PROVIDER with gcp_vertex_ai because
-      // Kaiden creates a google-vertex-ai provider secret. Openshell injects
-      // its own env vars for that provider type and they win over --env flags.
-      // Workaround: pass `--provider anthropic` on the goose CLI to override
-      // the openshell-injected GOOSE_PROVIDER at runtime.
-      if (provider === 'vertexai') {
-        const envVars = [
-          { name: 'GOOSE_PROVIDER', value: 'anthropic' },
-          { name: 'ANTHROPIC_HOST', value: 'https://inference.local' },
-          { name: 'ANTHROPIC_API_KEY', value: 'unused' },
-        ];
-
-        context.workspace.environment ??= [];
-        for (const envVar of envVars) {
-          setEnvironmentVariable(context.workspace.environment, envVar.name, envVar.value);
-        }
-      }
 
       const configFile = context.configurationFiles.find(f => f.path === GOOSE_CONFIG_PATH);
       if (!configFile) {
@@ -135,11 +103,11 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       config.GOOSE_MODEL = context.model.model.label;
 
       if (provider) {
-        config.GOOSE_PROVIDER = provider === 'vertexai' ? 'anthropic' : (GOOSE_PROVIDER_MAPPING[provider] ?? provider);
+        config.GOOSE_PROVIDER = GOOSE_PROVIDER_MAPPING[provider] ?? provider;
       }
 
       const endpoint = context.model.endpoint;
-      if (endpoint && provider !== 'vertexai') {
+      if (endpoint) {
         config.OPENAI_BASE_URL = endpoint;
       }
 
@@ -153,9 +121,9 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
           config.extensions[server.name] = {
             name: server.name,
             type: 'streamable_http',
-            url: server.url,
+            uri: server.url,
             enabled: true,
-            envs: nonEmpty(server.headers),
+            headers: nonEmpty(server.headers),
           };
         }
 

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -72,6 +72,8 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     id: 'goose',
     name: 'Goose',
     description: 'Open-source autonomous coding agent by Block.',
+    baseImage:
+      'ghcr.io/openkaiden/openshell-image-goose@sha256:e23918ed2ee0e7e13dc5dc52d753ac187ff5508fc0fdd4b5fd1f2e43e147584f',
     icon: {
       icon: { dark: './icon_dark.png', light: './icon_light.png' },
       logo: { dark: './icon_dark.png', light: './icon_light.png' },
@@ -101,6 +103,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
       const config = GooseConfigCodec.decode(await configFile.read());
       config.GOOSE_MODEL = context.model.model.label;
+      config.GOOSE_TELEMETRY_ENABLED = false;
 
       if (provider) {
         config.GOOSE_PROVIDER = GOOSE_PROVIDER_MAPPING[provider] ?? provider;

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -101,7 +101,8 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         return;
       }
 
-      const config = GooseConfigCodec.decode(await configFile.read());
+      const decodedConfig = GooseConfigCodec.safeDecode(await configFile.read());
+      const config = decodedConfig.success ? decodedConfig.data : {};
       config.GOOSE_MODEL = context.model.model.label;
       config.GOOSE_TELEMETRY_ENABLED = false;
 

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -67,6 +67,10 @@ function nonEmpty(obj: Record<string, string> | undefined): Record<string, strin
   return obj && Object.keys(obj).length > 0 ? obj : undefined;
 }
 
+function toOllamaHost(endpoint: string): string {
+  return endpoint.replace(/\/v1\/?$/, '');
+}
+
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
     id: 'goose',
@@ -112,7 +116,12 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
       const endpoint = context.model.endpoint;
       if (endpoint) {
-        config.OPENAI_BASE_URL = endpoint;
+        if (provider === 'ollama') {
+          config.OLLAMA_HOST = toOllamaHost(endpoint);
+          delete config.OPENAI_BASE_URL;
+        } else {
+          config.OPENAI_BASE_URL = endpoint;
+        }
       }
 
       const mcpServers = context.workspace.mcp?.servers;

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -24,7 +24,7 @@ import { z } from 'zod';
 export const GOOSE_CONFIG_PATH = '.config/goose/config.yaml';
 
 const GOOSE_PROVIDER_MAPPING: Record<string, string> = {
-  gemini: 'google',
+  gemini: 'openai',
 };
 
 const GooseExtensionEntrySchema = z.looseObject({

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -415,6 +415,7 @@ export class ExtensionLoader implements IAsyncDisposable {
         'kaiden.codex',
         'kaiden.copilot',
         'kaiden.openclaw',
+        'kaiden.goose',
         'kaiden.gemini',
         'kaiden.cursor',
         'kaiden.mistral',

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -415,7 +415,6 @@ export class ExtensionLoader implements IAsyncDisposable {
         'kaiden.codex',
         'kaiden.copilot',
         'kaiden.openclaw',
-        'kaiden.goose',
         'kaiden.gemini',
         'kaiden.cursor',
         'kaiden.mistral',

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -414,6 +414,7 @@ export class ExtensionLoader implements IAsyncDisposable {
         'kaiden.openai',
         'kaiden.codex',
         'kaiden.openclaw',
+        'kaiden.goose',
         'kaiden.gemini',
         'kaiden.cursor',
         'kaiden.mistral',

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -414,7 +414,6 @@ export class ExtensionLoader implements IAsyncDisposable {
         'kaiden.openai',
         'kaiden.codex',
         'kaiden.openclaw',
-        'kaiden.goose',
         'kaiden.gemini',
         'kaiden.cursor',
         'kaiden.mistral',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,7 +605,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/extension-api
       js-yaml:
-        specifier: ^4.1.1
+        specifier: ^4.3.0
         version: 4.3.0
       zod:
         specifier: ^4.3.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,6 +607,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.3.0
+      zod:
+        specifier: ^4.3.5
+        version: 4.4.3
     devDependencies:
       adm-zip:
         specifier: ^0.5.16

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -604,6 +604,9 @@ importers:
       '@openkaiden/api':
         specifier: workspace:*
         version: link:../../packages/extension-api
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.3.0
     devDependencies:
       adm-zip:
         specifier: ^0.5.16
@@ -8800,7 +8803,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -9070,7 +9073,7 @@ snapshots:
       form-data: 4.0.5
       hpagent: 1.2.0
       isomorphic-ws: 5.0.0(ws@8.19.0)
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       jsonpath-plus: 10.3.0
       node-fetch: 2.7.0(encoding@0.1.13)
       openid-client: 6.5.0
@@ -10483,7 +10486,7 @@ snapshots:
       hosted-git-info: 4.1.0
       is-ci: 3.0.1
       isbinaryfile: 5.0.4
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.0.3
@@ -10912,7 +10915,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-ci: 3.0.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       sanitize-filename: 1.6.3
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -11266,7 +11269,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -11452,7 +11455,7 @@ snapshots:
       builder-util-runtime: 9.3.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -11644,7 +11647,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.5.1
       fs-extra: 10.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0


### PR DESCRIPTION
## Summary
- Replaces the `configurationFiles` and `preWorkspaceStart` stubs with a real implementation that writes `GOOSE_MODEL` into `.goose/config.yaml` from the workspace context, preserving existing configuration fields.

Fixes #2174
Fixes #1731

## Test plan

_Before testing youll need to  set the baseImage property locally in extensions/goose/src/extension.ts: 
`baseImage: 'quay.io/bmahabir/openkaiden/openshell-goose:latest',`_

I built an openshell image on x86 and arm using openshell-image-builder and is public please use that image to test.
     
**Now create a sandbox using goose with a skill and specifically the playwright mcp server!**

Besides testing just the goose command with a model assert mcp and skills are there too

Goose does not have an mcp list feature so enter configure and scroll down to see playwright mcp listed and ready to go

```
sandbox@sandbox-Videos:~$ goose configure

This will update your existing config files
  if you prefer, you can edit them directly at /sandbox/.config/goose

T   goose-configure 
|
o  What would you like to configure?
|  Toggle Extensions 
|
*  enable extensions: (use "space" to toggle and "enter" to submit)
|   
|  [+] Extension Manager (<)
|  [+] ai.openkaiden.registry/playwright 
|  [+] analyze 
|  [+] apps 
|  [ ] chatrecall 
|  [ ] code_execution 
|  [+] developer 
|  [ ] orchestrator 
|  [+] skills 
|  [ ] summarize 
|  [+] summon 
|  [+] todo 
|  [+] tom 
—  
```

For skills u can list them

```
sandbox@sandbox-Videos:~$ goose skills list
Name              | Description                                        | Description tokens | Content tokens | Location                                 
goose-doc-guide   | Reference goose documentation to create, config... | 56                 | 712            | builtin://skills/goose-doc-guide         
summarize-changes | Summarizes the uncommitted changes in your git ... | 17                 | 90             | /sandbox/.agents/skills/summarize-changes
sandbox@sandbox-Videos:~$ 
```