### PR TITLE
feat(openshell-cli): integrate OpenShell TypeScript SDK with CLI fall

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "@expo/sudo-prompt": "^9.3.2",
     "@kubernetes/client-node": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@nvidia/openshell-sdk": "link:../OpenShell/sdk/typescript",
     "@oslojs/crypto": "^1.0.1",
     "@oslojs/encoding": "^1.1.0",
     "@segment/analytics-node": "^2.3.0",

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -402,6 +402,70 @@ describe('createSandbox', () => {
 
     await expect(openshellCli.createSandbox()).rejects.toThrow('command failed (stdout: unexpected output)');
   });
+
+  test('uses SDK when no CLI-only options are present', async () => {
+    const gateways = [{ name: 'gw-1', endpoint: 'http://127.0.0.1:17670', active: true }];
+    const mockSdkClient = {
+      sandbox: { create: vi.fn().mockResolvedValue({ id: 'sb-1', name: 'test', phase: 'provisioning' }) },
+    };
+
+    vi.mocked(exec.exec).mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)));
+    openshellCli.getSdkClient = vi.fn().mockResolvedValue(mockSdkClient);
+
+    await openshellCli.createSandbox({
+      name: 'test',
+      from: 'ubuntu:latest',
+      gpu: true,
+      providers: ['openai'],
+      env: { FOO: 'bar' },
+      labels: { team: 'dev' },
+    });
+
+    expect(mockSdkClient.sandbox.create).toHaveBeenCalledWith({
+      name: 'test',
+      image: 'ubuntu:latest',
+      gpu: true,
+      providers: ['openai'],
+      environment: { FOO: 'bar' },
+      labels: { team: 'dev' },
+    });
+    expect(exec.exec).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back to CLI when uploads are present', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({
+      name: 'test',
+      uploads: [{ local: '/tmp/file', remote: '/workspace/file' }],
+    });
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      expect.arrayContaining(['--upload', '/tmp/file:/workspace/file']),
+      undefined,
+    );
+  });
+
+  test('falls back to CLI when SDK fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const gateways = [{ name: 'gw-1', endpoint: 'http://127.0.0.1:17670', active: true }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(''));
+    openshellCli.getSdkClient = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+    await openshellCli.createSandbox({ name: 'test' });
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      expect.arrayContaining(['sandbox', 'create', '--name', 'test']),
+      undefined,
+    );
+  });
 });
 
 describe('updatePolicy', () => {
@@ -449,6 +513,42 @@ describe('listSandboxes', () => {
 
     expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'list', '-o', 'json'], undefined);
     expect(result).toEqual(payload);
+  });
+
+  test('uses SDK when gateway endpoint is resolvable', async () => {
+    const gateways = [{ name: 'gw-1', endpoint: 'http://127.0.0.1:17670', active: true }];
+    const sdkRefs = [
+      { id: 'sdk-1', name: 'sdk-sandbox', phase: 'ready', labels: { env: 'test' }, resourceVersion: '42' },
+    ];
+    const mockSdkClient = { sandbox: { list: vi.fn().mockResolvedValue(sdkRefs) } };
+
+    vi.mocked(exec.exec).mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)));
+
+    openshellCli.getSdkClient = vi.fn().mockResolvedValue(mockSdkClient);
+
+    const result = await openshellCli.listSandboxes();
+
+    expect(openshellCli.getSdkClient).toHaveBeenCalledWith('http://127.0.0.1:17670');
+    expect(mockSdkClient.sandbox.list).toHaveBeenCalled();
+    expect(result).toEqual([
+      { id: 'sdk-1', name: 'sdk-sandbox', phase: 'Ready', labels: { env: 'test' }, resource_version: 42 },
+    ]);
+  });
+
+  test('falls back to CLI when SDK fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const gateways = [{ name: 'gw-1', endpoint: 'http://127.0.0.1:17670', active: true }];
+    const cliPayload = [{ id: 'cli-1', name: 'cli-sandbox', phase: 'Ready' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(cliPayload)));
+
+    openshellCli.getSdkClient = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+    const result = await openshellCli.listSandboxes();
+
+    expect(result).toEqual(cliPayload);
   });
 
   test('rejects when CLI fails', async () => {
@@ -501,6 +601,38 @@ describe('deleteSandbox', () => {
   test('executes openshell sandbox delete with name', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.deleteSandbox('my-sandbox');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'delete', 'my-sandbox'], undefined);
+  });
+
+  test('uses SDK when gateway endpoint is resolvable', async () => {
+    const gateways = [{ name: 'gw-1', endpoint: 'http://127.0.0.1:17670', active: true }];
+    const mockSdkClient = {
+      sandbox: { delete: vi.fn().mockResolvedValue(true), waitDeleted: vi.fn().mockResolvedValue(undefined) },
+    };
+
+    vi.mocked(exec.exec).mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)));
+    openshellCli.getSdkClient = vi.fn().mockResolvedValue(mockSdkClient);
+
+    await openshellCli.deleteSandbox('my-sandbox');
+
+    expect(openshellCli.getSdkClient).toHaveBeenCalledWith('http://127.0.0.1:17670');
+    expect(mockSdkClient.sandbox.delete).toHaveBeenCalledWith('my-sandbox');
+    expect(mockSdkClient.sandbox.waitDeleted).toHaveBeenCalledWith('my-sandbox', 30);
+    expect(exec.exec).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back to CLI when SDK fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const gateways = [{ name: 'gw-1', endpoint: 'http://127.0.0.1:17670', active: true }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(''));
+    openshellCli.getSdkClient = vi.fn().mockRejectedValue(new Error('connection refused'));
 
     await openshellCli.deleteSandbox('my-sandbox');
 
@@ -685,6 +817,7 @@ describe('listSandboxesForGateway', () => {
 
     vi.mocked(exec.exec)
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes)));
 
     const result = await openshellCli.listSandboxesForGateway('gw-2');
@@ -718,7 +851,9 @@ describe('listSandboxesPerGateway', () => {
 
     vi.mocked(exec.exec)
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes1)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes2)));
 
     const results = await openshellCli.listSandboxesPerGateway();
@@ -771,6 +906,7 @@ describe('listSandboxesPerGateway auto-refresh', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    openshellCli.getSdkClient = vi.fn().mockRejectedValue(new Error('sdk unavailable'));
   });
 
   afterEach(() => {
@@ -784,7 +920,9 @@ describe('listSandboxesPerGateway auto-refresh', () => {
 
     vi.mocked(exec.exec)
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
 
@@ -806,6 +944,7 @@ describe('listSandboxesPerGateway auto-refresh', () => {
 
     vi.mocked(exec.exec)
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
 
     const listener = vi.fn();
@@ -823,9 +962,12 @@ describe('listSandboxesPerGateway auto-refresh', () => {
 
     vi.mocked(exec.exec)
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
-      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
 
@@ -845,7 +987,9 @@ describe('listSandboxesPerGateway auto-refresh', () => {
 
     vi.mocked(exec.exec)
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)));
 
@@ -864,9 +1008,12 @@ describe('listSandboxesPerGateway auto-refresh', () => {
 
     vi.mocked(exec.exec)
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
-      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
 
@@ -890,6 +1037,7 @@ describe('listSandboxesPerGateway auto-refresh', () => {
 
     vi.mocked(exec.exec)
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
       .mockRejectedValueOnce(new Error('connection lost'));
 
@@ -910,6 +1058,7 @@ describe('listSandboxesPerGateway auto-refresh', () => {
 
     vi.mocked(exec.exec)
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)));
 
     const listener = vi.fn();
@@ -927,19 +1076,41 @@ describe('checkEndpointStatus', () => {
   test('returns true when endpoint is healthy', async () => {
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
     expect(await openshellCli.checkEndpointStatus('https://127.0.0.1:8443')).toBe(true);
+  });
+
+  test('returns true via SDK health check', async () => {
+    const mockSdkClient = { health: vi.fn().mockResolvedValue({ status: 'serving', version: '0.5.0' }) };
+    openshellCli.getSdkClient = vi.fn().mockResolvedValue(mockSdkClient);
+
+    expect(await openshellCli.checkEndpointStatus('http://127.0.0.1:17670')).toBe(true);
+
+    expect(openshellCli.getSdkClient).toHaveBeenCalledWith('http://127.0.0.1:17670');
+    expect(mockSdkClient.health).toHaveBeenCalled();
+    expect(exec.exec).not.toHaveBeenCalled();
+  });
+
+  test('falls back to CLI when SDK health fails', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    openshellCli.getSdkClient = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+    expect(await openshellCli.checkEndpointStatus('http://127.0.0.1:17670')).toBe(true);
+
     expect(exec.exec).toHaveBeenCalledWith(
       OPENSHELL_CLI_PATH,
-      ['status', '--gateway-endpoint', 'https://127.0.0.1:8443'],
+      ['status', '--gateway-endpoint', 'http://127.0.0.1:17670', '--gateway-insecure'],
       undefined,
     );
   });
 
-  test('returns false when endpoint is unreachable', async () => {
+  test('returns false when both SDK and CLI fail', async () => {
+    openshellCli.getSdkClient = vi.fn().mockRejectedValue(new Error('connection refused'));
     vi.mocked(exec.exec).mockRejectedValue(new Error('connection refused'));
+
     expect(await openshellCli.checkEndpointStatus('http://127.0.0.1:17670')).toBe(false);
   });
 
   test('appends --gateway-insecure for http endpoints', async () => {
+    openshellCli.getSdkClient = vi.fn().mockRejectedValue(new Error('force CLI'));
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
     await openshellCli.checkEndpointStatus('http://127.0.0.1:17670');
     expect(exec.exec).toHaveBeenCalledWith(
@@ -950,6 +1121,7 @@ describe('checkEndpointStatus', () => {
   });
 
   test('does not append --gateway-insecure for https endpoints', async () => {
+    openshellCli.getSdkClient = vi.fn().mockRejectedValue(new Error('force CLI'));
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
     await openshellCli.checkEndpointStatus('https://127.0.0.1:8443');
     expect(exec.exec).toHaveBeenCalledWith(

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -19,6 +19,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { OpenShellClient, type SandboxRef } from '@nvidia/openshell-sdk';
 import type { RunError, RunOptions } from '@openkaiden/api';
 import { inject, injectable, preDestroy } from 'inversify';
 import z from 'zod';
@@ -42,6 +43,25 @@ import {
   SandboxInfoSchema,
   type SetInferenceOptions,
 } from '/@api/openshell-gateway-info.js';
+
+const PHASE_MAP: Record<string, SandboxInfo['phase']> = {
+  provisioning: 'Provisioning',
+  ready: 'Ready',
+  error: 'Error',
+  deleting: 'Deleting',
+  unknown: 'Unknown',
+  unspecified: 'Unspecified',
+};
+
+function sandboxRefToInfo(ref: SandboxRef): SandboxInfo {
+  return {
+    id: ref.id,
+    name: ref.name,
+    phase: PHASE_MAP[ref.phase] ?? 'Unknown',
+    labels: ref.labels,
+    resource_version: Number(ref.resourceVersion) || undefined,
+  };
+}
 
 const SettingValue = z.union([z.string(), z.boolean(), z.number()]);
 
@@ -85,6 +105,7 @@ const OpenshellSettingsSchema = z.looseObject({
  */
 @injectable()
 export class OpenshellCli {
+  #sdkClients = new Map<string, OpenShellClient>();
   private readonly _onDidSandboxListChange = new Emitter<GatewaySandboxes[]>();
   readonly onDidSandboxListChange: Event<GatewaySandboxes[]> = this._onDidSandboxListChange.event;
   private _deletingPollTimer: ReturnType<typeof setTimeout> | undefined;
@@ -95,6 +116,23 @@ export class OpenshellCli {
     @inject(CliToolRegistry)
     private readonly cliToolRegistry: CliToolRegistry,
   ) {}
+
+  async getSdkClient(gatewayEndpoint: string): Promise<OpenShellClient> {
+    const existing = this.#sdkClients.get(gatewayEndpoint);
+    if (existing) {
+      return existing;
+    }
+    const gateway =
+      gatewayEndpoint.startsWith('http://') || gatewayEndpoint.startsWith('https://')
+        ? gatewayEndpoint
+        : `http://${gatewayEndpoint}`;
+    const client = await OpenShellClient.connect({
+      gateway,
+      insecureSkipVerify: gateway.startsWith('https://'),
+    });
+    this.#sdkClients.set(gatewayEndpoint, client);
+    return client;
+  }
 
   getCliPath(): string {
     const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell');
@@ -165,6 +203,43 @@ export class OpenshellCli {
   // ── sandbox commands ──────────────────────────────────────────────
 
   async createSandbox(options: CreateSandboxOptions = {}): Promise<void> {
+    const requiresCli = !!(
+      options.uploads?.length ??
+      options.command?.length ??
+      options.policy ??
+      options.gpuDevice ??
+      options.cpu ??
+      options.memory
+    );
+
+    if (!requiresCli) {
+      const gateway = options.gateway
+        ? await this.resolveGatewayEndpoint(options.gateway)
+        : await this.resolveGatewayEndpoint();
+      if (gateway) {
+        try {
+          const client = await this.getSdkClient(gateway);
+          const labels = { ...options.labels };
+          if (options.gateway) {
+            labels['gateway'] = options.gateway;
+          }
+          await client.sandbox.create({
+            name: options.name,
+            image: options.from,
+            labels: Object.keys(labels).length > 0 ? labels : undefined,
+            environment: options.env,
+            providers: options.providers,
+            gpu: options.gpu,
+          });
+          return;
+        } catch (err: unknown) {
+          console.warn(
+            `[openshell] SDK createSandbox failed, falling back to CLI: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+
     const args = ['sandbox', 'create'];
     if (options.name) {
       args.push('--name', options.name);
@@ -221,12 +296,35 @@ export class OpenshellCli {
   }
 
   async listSandboxes(gatewayName?: string): Promise<SandboxInfo[]> {
+    const gateway = await this.resolveGatewayEndpoint(gatewayName);
+    if (gateway) {
+      try {
+        const client = await this.getSdkClient(gateway);
+        const refs = await client.sandbox.list();
+        return refs.map(sandboxRefToInfo);
+      } catch (err: unknown) {
+        console.warn(
+          `[openshell] SDK listSandboxes failed, falling back to CLI: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     const args = ['sandbox', 'list'];
     if (gatewayName) {
       args.push('-g', gatewayName);
     }
     const data = await this.execCLI<unknown>(args);
     return z.array(SandboxInfoSchema).parse(data);
+  }
+
+  private async resolveGatewayEndpoint(gatewayName?: string): Promise<string | undefined> {
+    try {
+      const gateways = await this.listGateways();
+      const target = gatewayName ? gateways.find(g => g.name === gatewayName) : gateways.find(g => g.active);
+      return target?.endpoint;
+    } catch {
+      return undefined;
+    }
   }
 
   async startSandbox(name: string): Promise<void> {
@@ -238,6 +336,19 @@ export class OpenshellCli {
   }
 
   async deleteSandbox(name: string): Promise<void> {
+    const gateway = await this.resolveGatewayEndpoint();
+    if (gateway) {
+      try {
+        const client = await this.getSdkClient(gateway);
+        await client.sandbox.delete(name);
+        await client.sandbox.waitDeleted(name, 30);
+        return;
+      } catch (err: unknown) {
+        console.warn(
+          `[openshell] SDK deleteSandbox failed, falling back to CLI: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
     await this.runCli(['sandbox', 'delete', name]);
   }
 
@@ -350,6 +461,14 @@ export class OpenshellCli {
   }
 
   async checkEndpointStatus(endpoint: string): Promise<boolean> {
+    try {
+      const client = await this.getSdkClient(endpoint);
+      await client.health();
+      return true;
+    } catch {
+      // SDK failed — fall back to CLI
+    }
+
     const args = ['status', '--gateway-endpoint', endpoint];
     if (endpoint.startsWith('http://')) {
       args.push('--gateway-insecure');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      '@nvidia/openshell-sdk':
+        specifier: link:../OpenShell/sdk/typescript
+        version: link:../OpenShell/sdk/typescript
       '@oslojs/crypto':
         specifier: ^1.0.1
         version: 1.0.1
@@ -1145,12 +1148,6 @@ packages:
 
   '@ai-sdk/anthropic@4.0.15':
     resolution: {integrity: sha512-6iVlzqZjqqoHTmgO1WU9id/33pYykIRasWJFAMf1+d+nhju6d7566VRFsOGZ2W2GzgNtzKs8DGsYN7X5/wOGuw==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/gateway@4.0.20':
-    resolution: {integrity: sha512-m3PdYs0yqSxswsrEhVj64wDLgFs35Zxl8liLNuWGzE7bwBLF6Mhu0E5rPpDNJbIjyQpA4aMKOOWBfjERw2zvPw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -3081,12 +3078,6 @@ packages:
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
-
-  ai@7.0.28:
-    resolution: {integrity: sha512-RtynA4e6rWH2YiMX0OJz2h2i+sdJgiItuwqmstYZAiTZ0ZkZzQ8s4KVh7tQfZuDCfzIhRTg+q1h1xirT8AClkw==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
 
   ai@7.0.30:
     resolution: {integrity: sha512-tm0gTAHSWBdDfW4P2mj+LlglGCUQTSA9ktyS2PsPgVhxNO9gYWTSnRAehiJ3h1lYsJBp1Zgbz3RH2lezJXagiw==}
@@ -8143,13 +8134,6 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.10(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@4.0.20(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.10(zod@4.3.6)
-      '@vercel/oidc': 3.2.0
-      zod: 4.3.6
-
   '@ai-sdk/gateway@4.0.22(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
@@ -10329,13 +10313,6 @@ snapshots:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
-
-  ai@7.0.28(zod@4.3.6):
-    dependencies:
-      '@ai-sdk/gateway': 4.0.20(zod@4.3.6)
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.10(zod@4.3.6)
-      zod: 4.3.6
 
   ai@7.0.30(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## Summary

Integrate the OpenShell TypeScript SDK (`@nvidia/openshell-sdk`) into `OpenshellCli` using an **SDK-first strategy with automatic CLI fallback**. When a gateway endpoint is resolvable, sandbox operations go through the SDK's gRPC client; if the SDK call fails or the operation requires CLI-only features (uploads, policy files, resource flags), it transparently falls back to spawning the `openshell` binary.

### What changed

- **`openshell-cli.ts`** — Added SDK integration for four operations:
  - `createSandbox`: uses SDK when no CLI-only options are present (`uploads`, `policy`, `cpu`, `memory`, `gpuDevice`, `command`). Falls back to CLI otherwise.
  - `listSandboxes`: resolves the gateway endpoint, calls `client.sandbox.list()`, converts `SandboxRef[]` to `SandboxInfo[]` via `sandboxRefToInfo`. Falls back to CLI on failure.
  - `deleteSandbox`: calls `client.sandbox.delete()` + `client.sandbox.waitDeleted()` (30s timeout). Falls back to CLI on failure.
  - `checkEndpointStatus`: calls `client.health()` before attempting the CLI `status` command.
- **`PHASE_MAP` + `sandboxRefToInfo`** — The SDK returns phases in lowercase (`ready`, `provisioning`, etc.) while the rest of the codebase (Zod schemas in `openshell-gateway-info.ts`, renderer comparisons in `workspace-utils.ts`) expects PascalCase (`Ready`, `Provisioning`). The `PHASE_MAP` adapter handles this conversion.
- **`getSdkClient`** — Creates and caches `OpenShellClient` instances per gateway endpoint, handling URL normalization and `insecureSkipVerify` for HTTPS endpoints.
- **`resolveGatewayEndpoint`** — Private helper that calls `listGateways()` to find the endpoint for a gateway name (or the active gateway).
- **`package.json`** — Added `@nvidia/openshell-sdk` as a `link:` dependency pointing to the local OpenShell SDK build (see testing instructions below).

### Test changes

- Added 11 new tests covering SDK happy paths, CLI fallback on SDK failure, and CLI-only forced paths for `createSandbox`, `listSandboxes`, `deleteSandbox`, and `checkEndpointStatus`.
- Updated 8 existing `listSandboxesPerGateway auto-refresh` tests to account for the additional `listGateways()` call made by `resolveGatewayEndpoint` inside `listSandboxes`, and mocked `getSdkClient` in the auto-refresh `beforeEach` to avoid real gRPC connections under fake timers.

## How to test

> **Prerequisite:** The SDK is not published to npm yet — it lives in [NVIDIA/OpenShell#2122](https://github.com/NVIDIA/OpenShell/pull/2122). You need to build it locally.

### 1. Clone and build the OpenShell SDK

```bash
# Clone the OpenShell repo alongside the Kaiden workspace
cd /path/to/your/projects  # same parent directory as kaiden/
git clone https://github.com/NVIDIA/OpenShell.git
cd OpenShell
git fetch origin pull/2122/head:sdk-ts
git checkout sdk-ts

# Build the TypeScript SDK
cd sdk/typescript
npm install
npm run build

cd /path/to/your/projects/kaiden
# The package.json already has: "@nvidia/openshell-sdk": "link:../OpenShell/sdk/typescript"
# Adjust the relative path in package.json if your OpenShell clone is elsewhere
pnpm install
```


### 4. Manual E2E verification (requires a running OpenShell gateway)

1. Start Kaiden in dev mode (`pnpm watch`)
2. Verify the following operations use the SDK (look for SDK log lines in the dev console — absence of `SDK ... failed, falling back to CLI` means the SDK path succeeded):
   - **List sandboxes**: navigate to the sandbox list view
   - **Create a sandbox**: create one without uploads or custom policy
   - **Delete a sandbox**: delete an existing sandbox
   - **Health check**: add a new gateway endpoint and watch the health status resolve
3. Verify CLI fallback works by creating a sandbox **with uploads** — it should go through the CLI path (you'll see the standard `Executing: openshell sandbox create ...` log)

## Known limitations

This is an incremental integration. The following operations remain CLI-only and are tracked locally:

- `startSandbox` / `stopSandbox` — not yet exposed in the SDK
- `createSandbox` with `--upload`, `--policy`, `--cpu`, `--memory`, `--gpu-device` — require CLI-only flags
- `connectSandbox` — requires `ExecSandboxInteractive` (bidi streaming), not yet wrapped in the TS SDK
- All `gateway` and `provider` management commands — gateway-scoped, not sandbox-scoped
- SSH / TCP forwarding — `CreateSshSession` / `ForwardTcp` RPCs planned for future SDK releases

