### PR TITLE
fix: align CLI Tools card separators with Resources page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -164,7 +164,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
           {/if}
           <span
             id={cliTool.id}
-            class="my-auto ml-3 break-words font-semibold text-[var(--pd-invert-content-header-text)]"
+            class="my-auto ml-3 break-all font-semibold text-[var(--pd-invert-content-header-text)]"
             aria-label="cli-name">{cliTool.name}</span>
         </div>
         <div class="flex flex-row space-x-1 w-full">

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -146,20 +146,20 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
   <div class="divide-x divide-[var(--pd-content-divider)] flex flex-row">
     <div>
       <!-- left col - cli-tool icon/name + "create new" button -->
-      <div class="min-w-[170px] max-w-[200px] h-full flex flex-col justify-between">
+      <div class="w-[170px] h-full flex flex-col justify-between">
         <div class="flex flex-row">
           {#if cliTool?.images?.icon ?? cliTool?.extensionInfo.icon}
             {#if cliTool?.images?.icon}
               <ThemedIcon
                 icon={cliTool.images.icon}
                 alt="{cliTool.name} logo"
-                class="max-w-[40px] max-h-[40px] h-full" />
+                class="max-w-[40px] max-h-[40px] h-full shrink-0" />
             {:else if typeof cliTool.extensionInfo.icon === 'string'}
               <img
                 src={cliTool.extensionInfo.icon}
                 aria-label="cli-logo"
                 alt="{cliTool.name} logo"
-                class="max-w-[40px] max-h-[40px] h-full" />
+                class="max-w-[40px] max-h-[40px] h-full shrink-0" />
             {/if}
           {/if}
           <span


### PR DESCRIPTION
## Summary
- Apply the Podman Desktop Resources separator pattern to the CLI Tools page: replace `divide-x` with explicit `border-r` and even `pr-5` / `px-5 py-2` padding.
- Use a fixed `w-[170px]` left column so separators stay vertically aligned across cards with different tool name lengths.
- Drop float-based header layout in favor of a simple flex row for the display name / “Registered by” line.

<img width="1448" height="571" alt="Screenshot 2026-07-24 at 11 24 42 AM" src="https://github.com/user-attachments/assets/2f981a19-2ee1-4562-9445-9c9c7c4973a8" />


## Test plan
- [x] Open Settings → CLI Tools with multiple registered tools (different name lengths)
- [x] Confirm vertical separators are evenly padded and aligned across cards
- [x] Compare visually with Settings → Resources separator treatment
- [x] `pnpm exec vitest run packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts`


Made with [Cursor](https://cursor.com)