### PR TITLE
feat(copilot): enable GitHub Copilot CLI agent with BYOK and MCP support

### DIFF
--- a/extensions/copilot/src/extension.spec.ts
+++ b/extensions/copilot/src/extension.spec.ts
@@ -22,11 +22,12 @@ import type {
   AgentWorkspaceContext,
   Disposable,
   ExtensionContext,
+  LLMMetadata,
 } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { activate, COPILOT_SETTINGS_PATH } from './extension';
+import { activate, buildCopilotCommand, COPILOT_MCP_CONFIG_PATH, COPILOT_SETTINGS_PATH } from './extension';
 
 const AGENT_DISPOSABLE_MOCK: Disposable = { dispose: vi.fn() };
 
@@ -46,13 +47,36 @@ function getRegisteredAgent(): Agent {
   return vi.mocked(agents.registerAgent).mock.calls[0]![0];
 }
 
-function createContext(configFiles: AgentConfigurationFile[], modelLabel = 'gpt-4o'): AgentWorkspaceContext {
+interface McpServer {
+  name: string;
+  url: string;
+  headers?: Record<string, string>;
+}
+
+interface McpCommand {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+function createContext(
+  configFiles: AgentConfigurationFile[],
+  options?: {
+    modelLabel?: string;
+    llmMetadata?: LLMMetadata;
+    endpoint?: string;
+    mcp?: { servers?: McpServer[]; commands?: McpCommand[] };
+  },
+): AgentWorkspaceContext {
   return {
     model: {
-      model: { label: modelLabel },
+      llmMetadata: options?.llmMetadata,
+      model: { label: options?.modelLabel ?? 'gpt-4o' },
+      endpoint: options?.endpoint,
     },
     configurationFiles: configFiles,
-    workspace: {},
+    workspace: { mcp: options?.mcp },
   };
 }
 
@@ -66,6 +90,41 @@ function createConfigFile(content = '{}'): AgentConfigurationFile & { updateMock
   return Object.assign(file, { updateMock });
 }
 
+function createMcpConfigFile(
+  content = '{"mcpServers":{}}',
+): AgentConfigurationFile & { updateMock: ReturnType<typeof vi.fn> } {
+  const updateMock = vi.fn();
+  const file: AgentConfigurationFile = {
+    path: COPILOT_MCP_CONFIG_PATH,
+    read: vi.fn().mockResolvedValue(content),
+    update: updateMock,
+  };
+  return Object.assign(file, { updateMock });
+}
+
+describe('buildCopilotCommand', () => {
+  test('returns shell command that bridges vault API key env vars to COPILOT_PROVIDER_API_KEY', () => {
+    const cmd = buildCopilotCommand();
+
+    expect(cmd).toContain('COPILOT_PROVIDER_API_KEY=');
+    expect(cmd).toContain('OPENAI_API_KEY');
+    expect(cmd).toContain('ANTHROPIC_API_KEY');
+    expect(cmd).toMatch(/copilot$/);
+  });
+
+  test('only bridges API key when COPILOT_PROVIDER_BASE_URL is set (BYOK mode)', () => {
+    const cmd = buildCopilotCommand();
+
+    expect(cmd).toContain('$COPILOT_PROVIDER_BASE_URL');
+  });
+
+  test('preserves existing COPILOT_PROVIDER_API_KEY when set', () => {
+    const cmd = buildCopilotCommand();
+
+    expect(cmd).toContain('${COPILOT_PROVIDER_API_KEY:-');
+  });
+});
+
 describe('activate', () => {
   test('registers copilot agent', async () => {
     await activate(extensionContextMock);
@@ -76,6 +135,7 @@ describe('activate', () => {
         name: 'GitHub Copilot',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { light: './icon_light.png', dark: './icon_dark.png' } }),
+        command: buildCopilotCommand(),
         destinationSkillsFolder: '${HOME}/.copilot/skills',
         isSupportedModelType: expect.any(Function),
       }),
@@ -93,20 +153,32 @@ describe('activate', () => {
 
     const agent = getRegisteredAgent();
     expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(true);
+    expect(agent.isSupportedModelType!({ name: 'anthropic' })).toBe(true);
+    expect(agent.isSupportedModelType!({ name: 'ollama' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'gemini' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'vertexai' })).toBe(false);
   });
 
-  test('registers agent with settings.json configuration file', async () => {
+  test('registers agent with settings.json and mcp-config.json configuration files', async () => {
     await activate(extensionContextMock);
 
     const agent = getRegisteredAgent();
-    expect(agent.configurationFiles).toHaveLength(1);
+    expect(agent.configurationFiles).toHaveLength(2);
     expect(agent.configurationFiles[0]!.path).toBe(COPILOT_SETTINGS_PATH);
+    expect(agent.configurationFiles[1]!.path).toBe(COPILOT_MCP_CONFIG_PATH);
+  });
+
+  test('default mcp-config.json includes mcpServers field', async () => {
+    await activate(extensionContextMock);
+
+    const agent = getRegisteredAgent();
+    const mcpConfigFile = agent.configurationFiles[1]!;
+    const content = JSON.parse(await mcpConfigFile.read());
+    expect(content).toEqual({ mcpServers: {} });
   });
 
   describe('preWorkspaceStart', () => {
-    test('writes model configuration into settings.json', async () => {
+    test('writes model into top-level model field in settings.json', async () => {
       await activate(extensionContextMock);
       const agent = getRegisteredAgent();
 
@@ -115,50 +187,20 @@ describe('activate', () => {
 
       expect(configFile.updateMock).toHaveBeenCalledOnce();
       const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
-      expect(written).toEqual({
-        chat: { model: 'gpt-4o' },
-      });
+      expect(written).toEqual({ model: 'gpt-4o' });
     });
 
     test('preserves existing configuration fields', async () => {
       await activate(extensionContextMock);
       const agent = getRegisteredAgent();
 
-      const existingConfig = JSON.stringify({ chat: { model: 'old-model', temperature: 0.7 }, other: true });
+      const existingConfig = JSON.stringify({ model: 'old-model', effortLevel: 'high', other: true });
       const configFile = createConfigFile(existingConfig);
-      await agent.preWorkspaceStart(createContext([configFile], 'claude-sonnet'));
+      await agent.preWorkspaceStart(createContext([configFile], { modelLabel: 'claude-sonnet' }));
 
       const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
-      expect(written.chat.model).toBe('claude-sonnet');
-      expect(written.chat.temperature).toBe(0.7);
-      expect(written.other).toBe(true);
-    });
-
-    test('sets model on chat object that has no model field', async () => {
-      await activate(extensionContextMock);
-      const agent = getRegisteredAgent();
-
-      const existingConfig = JSON.stringify({ chat: { temperature: 0.7 }, other: true });
-      const configFile = createConfigFile(existingConfig);
-      await agent.preWorkspaceStart(createContext([configFile], 'claude-sonnet'));
-
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
-      expect(written.chat.model).toBe('claude-sonnet');
-      expect(written.chat.temperature).toBe(0.7);
-      expect(written.other).toBe(true);
-    });
-
-    test('accepts chat object without model field', async () => {
-      await activate(extensionContextMock);
-      const agent = getRegisteredAgent();
-
-      const existingConfig = JSON.stringify({ chat: { temperature: 0.7 }, other: true });
-      const configFile = createConfigFile(existingConfig);
-      await agent.preWorkspaceStart(createContext([configFile], 'claude-sonnet'));
-
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
-      expect(written.chat.model).toBe('claude-sonnet');
-      expect(written.chat.temperature).toBe(0.7);
+      expect(written.model).toBe('claude-sonnet');
+      expect(written.effortLevel).toBe('high');
       expect(written.other).toBe(true);
     });
 
@@ -176,19 +218,6 @@ describe('activate', () => {
       await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
 
-    test.each([
-      JSON.stringify({ chat: 'bad-shape' }),
-      JSON.stringify({ chat: null }),
-      JSON.stringify({ chat: [1, 2] }),
-      JSON.stringify({ chat: 123 }),
-    ])('rejects malformed chat field: %s', async (payload: string) => {
-      await activate(extensionContextMock);
-      const agent = getRegisteredAgent();
-
-      const configFile = createConfigFile(payload);
-      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
-    });
-
     test('rejects invalid JSON', async () => {
       await activate(extensionContextMock);
       const agent = getRegisteredAgent();
@@ -197,7 +226,7 @@ describe('activate', () => {
       await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
 
-    test('does nothing when config file is not in context', async () => {
+    test('does not write config when config file is not in context', async () => {
       await activate(extensionContextMock);
       const agent = getRegisteredAgent();
 
@@ -211,6 +240,375 @@ describe('activate', () => {
       await agent.preWorkspaceStart(createContext([otherFile]));
 
       expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    describe('BYOK provider environment variables', () => {
+      test('sets COPILOT_PROVIDER_BASE_URL, COPILOT_MODEL, and COPILOT_PROVIDER_TYPE for OpenAI', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const ctx = createContext([configFile], {
+          modelLabel: 'gpt-4o',
+          llmMetadata: { name: 'openai' },
+          endpoint: 'https://api.openai.com/v1',
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        expect(ctx.workspace.environment).toEqual(
+          expect.arrayContaining([
+            { name: 'COPILOT_PROVIDER_TYPE', value: 'openai' },
+            { name: 'COPILOT_PROVIDER_BASE_URL', value: 'https://api.openai.com/v1' },
+            { name: 'COPILOT_MODEL', value: 'gpt-4o' },
+          ]),
+        );
+      });
+
+      test('sets COPILOT_PROVIDER_TYPE to openai for Ollama and clears API key', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const ctx = createContext([configFile], {
+          modelLabel: 'qwen3',
+          llmMetadata: { name: 'ollama' },
+          endpoint: 'http://host.openshell.internal:11434',
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        expect(ctx.workspace.environment).toEqual(
+          expect.arrayContaining([
+            { name: 'COPILOT_PROVIDER_TYPE', value: 'openai' },
+            { name: 'COPILOT_PROVIDER_BASE_URL', value: 'http://host.openshell.internal:11434' },
+            { name: 'COPILOT_MODEL', value: 'qwen3' },
+            { name: 'COPILOT_PROVIDER_API_KEY', value: '' },
+          ]),
+        );
+      });
+
+      test('sets COPILOT_PROVIDER_TYPE to anthropic for Anthropic providers with explicit endpoint', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const ctx = createContext([configFile], {
+          modelLabel: 'claude-sonnet-4',
+          llmMetadata: { name: 'anthropic' },
+          endpoint: 'https://custom-anthropic.example.com',
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        expect(ctx.workspace.environment).toEqual(
+          expect.arrayContaining([
+            { name: 'COPILOT_PROVIDER_TYPE', value: 'anthropic' },
+            { name: 'COPILOT_PROVIDER_BASE_URL', value: 'https://custom-anthropic.example.com' },
+            { name: 'COPILOT_MODEL', value: 'claude-sonnet-4' },
+          ]),
+        );
+      });
+
+      test('uses default base URL for Anthropic when endpoint is not set', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const ctx = createContext([configFile], {
+          modelLabel: 'claude-sonnet-4',
+          llmMetadata: { name: 'anthropic' },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        expect(ctx.workspace.environment).toEqual(
+          expect.arrayContaining([
+            { name: 'COPILOT_PROVIDER_TYPE', value: 'anthropic' },
+            { name: 'COPILOT_PROVIDER_BASE_URL', value: 'https://api.anthropic.com/v1' },
+            { name: 'COPILOT_MODEL', value: 'claude-sonnet-4' },
+          ]),
+        );
+      });
+
+      test('does not set BYOK env vars when provider name is absent', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const ctx = createContext([configFile], {
+          modelLabel: 'gpt-4o',
+          endpoint: 'https://api.openai.com/v1',
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        expect(ctx.workspace.environment).toBeUndefined();
+      });
+
+      test('does not set BYOK env vars when endpoint is absent and provider has no default', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const ctx = createContext([configFile], {
+          modelLabel: 'gpt-4o',
+          llmMetadata: { name: 'openai' },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        expect(ctx.workspace.environment).toBeUndefined();
+      });
+
+      test('does not set COPILOT_PROVIDER_TYPE for unknown provider', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const ctx = createContext([configFile], {
+          modelLabel: 'gemini-2.5-pro',
+          llmMetadata: { name: 'gemini' },
+          endpoint: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        const envNames = ctx.workspace.environment?.map(e => e.name) ?? [];
+        expect(envNames).toContain('COPILOT_PROVIDER_BASE_URL');
+        expect(envNames).toContain('COPILOT_MODEL');
+        expect(envNames).not.toContain('COPILOT_PROVIDER_TYPE');
+      });
+
+      test('does not set COPILOT_PROVIDER_API_KEY for non-Ollama providers', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const ctx = createContext([configFile], {
+          modelLabel: 'gpt-4o',
+          llmMetadata: { name: 'openai' },
+          endpoint: 'https://api.openai.com/v1',
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        const envNames = ctx.workspace.environment?.map(e => e.name) ?? [];
+        expect(envNames).not.toContain('COPILOT_PROVIDER_API_KEY');
+      });
+
+      test('replaces existing env vars instead of duplicating', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const ctx = createContext([configFile], {
+          modelLabel: 'gpt-4o',
+          llmMetadata: { name: 'openai' },
+          endpoint: 'https://api.openai.com/v1',
+        });
+        ctx.workspace.environment = [{ name: 'COPILOT_MODEL', value: 'old-model' }];
+
+        await agent.preWorkspaceStart(ctx);
+
+        const copilotModelEntries = ctx.workspace.environment!.filter(e => e.name === 'COPILOT_MODEL');
+        expect(copilotModelEntries).toHaveLength(1);
+        expect(copilotModelEntries[0]!.value).toBe('gpt-4o');
+      });
+    });
+
+    describe('MCP configuration', () => {
+      test('writes remote MCP servers into mcp-config.json', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile();
+        const ctx = createContext([configFile, mcpFile], {
+          mcp: {
+            servers: [{ name: 'my-server', url: 'https://mcp.example.com/sse' }],
+          },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        expect(mcpFile.updateMock).toHaveBeenCalledOnce();
+        const written = JSON.parse(mcpFile.updateMock.mock.calls[0]![0] as string);
+        expect(written.mcpServers).toEqual({
+          'my-server': { type: 'http', url: 'https://mcp.example.com/sse' },
+        });
+      });
+
+      test('writes remote MCP servers with headers', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile();
+        const ctx = createContext([configFile, mcpFile], {
+          mcp: {
+            servers: [
+              {
+                name: 'auth-server',
+                url: 'https://mcp.example.com',
+                headers: { Authorization: 'Bearer token123' },
+              },
+            ],
+          },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        const written = JSON.parse(mcpFile.updateMock.mock.calls[0]![0] as string);
+        expect(written.mcpServers['auth-server']).toEqual({
+          type: 'http',
+          url: 'https://mcp.example.com',
+          headers: { Authorization: 'Bearer token123' },
+        });
+      });
+
+      test('omits headers when empty', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile();
+        const ctx = createContext([configFile, mcpFile], {
+          mcp: {
+            servers: [{ name: 'no-headers', url: 'https://mcp.example.com', headers: {} }],
+          },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        const written = JSON.parse(mcpFile.updateMock.mock.calls[0]![0] as string);
+        expect(written.mcpServers['no-headers']).toEqual({
+          type: 'http',
+          url: 'https://mcp.example.com',
+        });
+      });
+
+      test('writes stdio MCP commands into mcp-config.json', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile();
+        const ctx = createContext([configFile, mcpFile], {
+          mcp: {
+            commands: [{ name: 'playwright', command: 'npx', args: ['@playwright/mcp@latest'] }],
+          },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        expect(mcpFile.updateMock).toHaveBeenCalledOnce();
+        const written = JSON.parse(mcpFile.updateMock.mock.calls[0]![0] as string);
+        expect(written.mcpServers).toEqual({
+          playwright: { type: 'local', command: 'npx', args: ['@playwright/mcp@latest'] },
+        });
+      });
+
+      test('writes stdio MCP commands with env', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile();
+        const ctx = createContext([configFile, mcpFile], {
+          mcp: {
+            commands: [
+              { name: 'github', command: 'github-mcp-server', args: ['stdio'], env: { GITHUB_TOKEN: 'ghp_xxx' } },
+            ],
+          },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        const written = JSON.parse(mcpFile.updateMock.mock.calls[0]![0] as string);
+        expect(written.mcpServers['github']).toEqual({
+          type: 'local',
+          command: 'github-mcp-server',
+          args: ['stdio'],
+          env: { GITHUB_TOKEN: 'ghp_xxx' },
+        });
+      });
+
+      test('omits env when empty', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile();
+        const ctx = createContext([configFile, mcpFile], {
+          mcp: {
+            commands: [{ name: 'tool', command: 'my-tool', env: {} }],
+          },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        const written = JSON.parse(mcpFile.updateMock.mock.calls[0]![0] as string);
+        expect(written.mcpServers['tool']).toEqual({
+          type: 'local',
+          command: 'my-tool',
+          args: [],
+        });
+      });
+
+      test('combines remote servers and stdio commands', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile();
+        const ctx = createContext([configFile, mcpFile], {
+          mcp: {
+            servers: [{ name: 'remote', url: 'https://mcp.example.com' }],
+            commands: [{ name: 'local', command: 'my-tool', args: ['--flag'] }],
+          },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        const written = JSON.parse(mcpFile.updateMock.mock.calls[0]![0] as string);
+        expect(written.mcpServers).toEqual({
+          remote: { type: 'http', url: 'https://mcp.example.com' },
+          local: { type: 'local', command: 'my-tool', args: ['--flag'] },
+        });
+      });
+
+      test('preserves existing MCP server entries', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const existingMcpConfig = JSON.stringify({
+          mcpServers: { existing: { type: 'http', url: 'https://old.example.com' } },
+        });
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile(existingMcpConfig);
+        const ctx = createContext([configFile, mcpFile], {
+          mcp: {
+            servers: [{ name: 'new-server', url: 'https://new.example.com' }],
+          },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        const written = JSON.parse(mcpFile.updateMock.mock.calls[0]![0] as string);
+        expect(written.mcpServers['existing']).toEqual({ type: 'http', url: 'https://old.example.com' });
+        expect(written.mcpServers['new-server']).toEqual({ type: 'http', url: 'https://new.example.com' });
+      });
+
+      test('does not write mcp-config.json when no MCP servers or commands', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile();
+        const ctx = createContext([configFile, mcpFile]);
+        await agent.preWorkspaceStart(ctx);
+
+        expect(mcpFile.updateMock).not.toHaveBeenCalled();
+      });
+
+      test('does not write mcp-config.json when MCP arrays are empty', async () => {
+        await activate(extensionContextMock);
+        const agent = getRegisteredAgent();
+
+        const configFile = createConfigFile();
+        const mcpFile = createMcpConfigFile();
+        const ctx = createContext([configFile, mcpFile], {
+          mcp: { servers: [], commands: [] },
+        });
+        await agent.preWorkspaceStart(ctx);
+
+        expect(mcpFile.updateMock).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/extensions/copilot/src/extension.spec.ts
+++ b/extensions/copilot/src/extension.spec.ts
@@ -321,7 +321,7 @@ describe('activate', () => {
         expect(ctx.workspace.environment).toEqual(
           expect.arrayContaining([
             { name: 'COPILOT_PROVIDER_TYPE', value: 'anthropic' },
-            { name: 'COPILOT_PROVIDER_BASE_URL', value: 'https://api.anthropic.com/v1' },
+            { name: 'COPILOT_PROVIDER_BASE_URL', value: 'https://api.anthropic.com' },
             { name: 'COPILOT_MODEL', value: 'claude-sonnet-4' },
           ]),
         );

--- a/extensions/copilot/src/extension.ts
+++ b/extensions/copilot/src/extension.ts
@@ -77,7 +77,7 @@ const VAULT_API_KEY_ENV_VAR: Record<string, string> = {
 // Default base URLs for providers that omit `endpoint` from their connection
 // info when using the standard API endpoint (e.g. Anthropic cloud).
 const DEFAULT_PROVIDER_BASE_URL: Record<string, string> = {
-  anthropic: 'https://api.anthropic.com/v1',
+  anthropic: 'https://api.anthropic.com',
 };
 
 function setEnvVar(context: AgentWorkspaceContext, name: string, value: string): void {

--- a/extensions/copilot/src/extension.ts
+++ b/extensions/copilot/src/extension.ts
@@ -20,28 +20,85 @@ import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 import { z } from 'zod';
 
-const CopilotSettingsSchema = z.looseObject({
-  chat: z.looseObject({ model: z.string().optional() }).optional(),
-});
+function jsonCodec<T extends z.ZodType>(schema: T): z.ZodCodec<z.ZodString, T> {
+  return z.codec(z.string(), schema, {
+    decode: (jsonString, ctx) => {
+      try {
+        return JSON.parse(jsonString);
+      } catch (err: unknown) {
+        ctx.issues.push({
+          code: 'invalid_format',
+          format: 'json',
+          input: jsonString,
+          message: err instanceof Error ? err.message : 'Invalid JSON',
+        });
+        return z.NEVER;
+      }
+    },
+    encode: value => JSON.stringify(value, undefined, 2),
+  });
+}
 
-const CopilotSettingsCodec = z.codec(z.string(), CopilotSettingsSchema, {
-  decode: (jsonString, ctx) => {
-    try {
-      return JSON.parse(jsonString);
-    } catch (err: unknown) {
-      ctx.issues.push({
-        code: 'invalid_format',
-        format: 'json',
-        input: jsonString,
-        message: err instanceof Error ? err.message : 'Invalid JSON',
-      });
-      return z.NEVER;
-    }
-  },
-  encode: value => JSON.stringify(value, undefined, 2),
-});
+const CopilotSettingsCodec = jsonCodec(
+  z.looseObject({
+    model: z.string().optional(),
+  }),
+);
+
+const CopilotMcpConfigCodec = jsonCodec(
+  z.looseObject({
+    mcpServers: z.record(z.string(), z.unknown()).optional(),
+  }),
+);
 
 export const COPILOT_SETTINGS_PATH = '.copilot/settings.json';
+export const COPILOT_MCP_CONFIG_PATH = '.copilot/mcp-config.json';
+
+// Maps Kaiden llmMetadata.name values to Copilot CLI COPILOT_PROVIDER_TYPE.
+// https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models
+const COPILOT_PROVIDER_TYPE: Record<string, string> = {
+  openai: 'openai',
+  ollama: 'openai',
+  anthropic: 'anthropic',
+};
+
+// Providers that do NOT require an API key (local-only, no auth).
+const NO_API_KEY_PROVIDERS = new Set(['ollama']);
+
+// Maps Kaiden provider names to the env var that the OpenShell vault injects
+// for that provider's API key.  Used to bridge the vault-injected name to the
+// COPILOT_PROVIDER_API_KEY that the Copilot CLI expects.
+const VAULT_API_KEY_ENV_VAR: Record<string, string> = {
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  gemini: 'OPENAI_API_KEY',
+};
+
+// Default base URLs for providers that omit `endpoint` from their connection
+// info when using the standard API endpoint (e.g. Anthropic cloud).
+const DEFAULT_PROVIDER_BASE_URL: Record<string, string> = {
+  anthropic: 'https://api.anthropic.com/v1',
+};
+
+function setEnvVar(context: AgentWorkspaceContext, name: string, value: string): void {
+  context.workspace.environment ??= [];
+  const index = context.workspace.environment.findIndex(e => e.name === name);
+  if (index >= 0) {
+    context.workspace.environment.splice(index, 1);
+  }
+  context.workspace.environment.push({ name, value });
+}
+
+// Builds the shell command that bridges vault-injected API key env vars to
+// COPILOT_PROVIDER_API_KEY before launching the Copilot CLI.  The bridge only
+// activates when COPILOT_PROVIDER_BASE_URL is set (BYOK mode); without it
+// Copilot uses GitHub auth and rejects a stray COPILOT_PROVIDER_API_KEY.
+export function buildCopilotCommand(): string {
+  const fallbacks = [...new Set(Object.values(VAULT_API_KEY_ENV_VAR))];
+  const inner = fallbacks.reduceRight((acc, v) => `\${${v}:-${acc}}`, '');
+  const bridge = `export COPILOT_PROVIDER_API_KEY="\${COPILOT_PROVIDER_API_KEY:-${inner}}"`;
+  return `[ -n "$COPILOT_PROVIDER_BASE_URL" ] && ${bridge}; copilot`;
+}
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
@@ -60,7 +117,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         light: './icon_light.png',
       },
     },
-    command: 'copilot',
+    command: buildCopilotCommand(),
     acp: { args: ['--acp'] },
     tags: [],
     destinationSkillsFolder: '${HOME}/.copilot/skills',
@@ -71,20 +128,78 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
           return '{}';
         },
       },
+      {
+        path: COPILOT_MCP_CONFIG_PATH,
+        async read(): Promise<string> {
+          return '{"mcpServers":{}}';
+        },
+      },
     ],
     isSupportedModelType(type): boolean {
       return type.name !== 'vertexai';
     },
     async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
+      const providerName = context.model.llmMetadata?.name;
+      const modelLabel = context.model.model.label;
+      const endpoint = context.model.endpoint;
+
+      // Write model into settings.json (lowest precedence, acts as fallback).
       const configFile = context.configurationFiles.find(f => f.path === COPILOT_SETTINGS_PATH);
-      if (!configFile) {
-        return;
+      if (configFile) {
+        const config = CopilotSettingsCodec.decode(await configFile.read());
+        config.model = modelLabel;
+        await configFile.update(CopilotSettingsCodec.encode(config));
       }
 
-      const config = CopilotSettingsCodec.decode(await configFile.read());
-      config.chat = { ...config.chat, model: context.model.model.label };
+      // For non-GitHub providers, configure BYOK environment variables so the
+      // Copilot CLI talks to the correct inference endpoint.
+      // https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models
+      const baseUrl = endpoint ?? (providerName ? DEFAULT_PROVIDER_BASE_URL[providerName] : undefined);
+      if (providerName && baseUrl) {
+        const copilotType = COPILOT_PROVIDER_TYPE[providerName];
+        if (copilotType) {
+          setEnvVar(context, 'COPILOT_PROVIDER_TYPE', copilotType);
+        }
 
-      await configFile.update(CopilotSettingsCodec.encode(config));
+        setEnvVar(context, 'COPILOT_PROVIDER_BASE_URL', baseUrl);
+        setEnvVar(context, 'COPILOT_MODEL', modelLabel);
+
+        if (NO_API_KEY_PROVIDERS.has(providerName)) {
+          setEnvVar(context, 'COPILOT_PROVIDER_API_KEY', '');
+        }
+      }
+
+      // Write MCP server configuration into mcp-config.json.
+      // https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+      const mcpServers = context.workspace.mcp?.servers;
+      const mcpCommands = context.workspace.mcp?.commands;
+
+      if (mcpServers?.length || mcpCommands?.length) {
+        const mcpConfigFile = context.configurationFiles.find(f => f.path === COPILOT_MCP_CONFIG_PATH);
+        if (mcpConfigFile) {
+          const mcpConfig = CopilotMcpConfigCodec.decode(await mcpConfigFile.read());
+          const servers: Record<string, unknown> = mcpConfig.mcpServers ?? {};
+
+          for (const srv of mcpServers ?? []) {
+            const entry: Record<string, unknown> = { type: 'http', url: srv.url };
+            if (srv.headers && Object.keys(srv.headers).length > 0) {
+              entry['headers'] = srv.headers;
+            }
+            servers[srv.name] = entry;
+          }
+
+          for (const cmd of mcpCommands ?? []) {
+            const entry: Record<string, unknown> = { type: 'local', command: cmd.command, args: cmd.args ?? [] };
+            if (cmd.env && Object.keys(cmd.env).length > 0) {
+              entry['env'] = cmd.env;
+            }
+            servers[cmd.name] = entry;
+          }
+
+          mcpConfig.mcpServers = servers;
+          await mcpConfigFile.update(CopilotMcpConfigCodec.encode(mcpConfig));
+        }
+      }
     },
   });
   extensionContext.subscriptions.push(disposable);

--- a/extensions/copilot/src/extension.ts
+++ b/extensions/copilot/src/extension.ts
@@ -94,7 +94,7 @@ function setEnvVar(context: AgentWorkspaceContext, name: string, value: string):
 // activates when COPILOT_PROVIDER_BASE_URL is set (BYOK mode); without it
 // Copilot uses GitHub auth and rejects a stray COPILOT_PROVIDER_API_KEY.
 export function buildCopilotCommand(): string {
-  const fallbacks = [...new Set(Object.values(VAULT_API_KEY_ENV_VAR))];
+  const fallbacks = Array.from(new Set(Object.values(VAULT_API_KEY_ENV_VAR)));
   const inner = fallbacks.reduceRight((acc, v) => `\${${v}:-${acc}}`, '');
   const bridge = `export COPILOT_PROVIDER_API_KEY="\${COPILOT_PROVIDER_API_KEY:-${inner}}"`;
   return `[ -n "$COPILOT_PROVIDER_BASE_URL" ] && ${bridge}; copilot`;

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -413,7 +413,6 @@ export class ExtensionLoader implements IAsyncDisposable {
       .get<string[]>(ExtensionLoaderSettings.Disabled, [
         'kaiden.openai',
         'kaiden.codex',
-        'kaiden.copilot',
         'kaiden.openclaw',
         'kaiden.goose',
         'kaiden.gemini',


### PR DESCRIPTION
## Summary

Enables the GitHub Copilot CLI agent extension (#2542) with full BYOK (Bring Your Own Key) provider support, MCP server configuration, and API key bridging.

### Changes

- **Enable by default**: Remove `kaiden.copilot` from the disabled extensions list so the agent appears in the workspace creation wizard.
- **BYOK provider env vars**: Set `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_TYPE`, and `COPILOT_MODEL` in `preWorkspaceStart` based on the selected provider. Includes a default base URL fallback for Anthropic, whose connection info omits `endpoint` when using the standard API.
- **MCP configuration**: Write workspace MCP servers/commands into `.copilot/mcp-config.json` using Copilot CLI's expected format (`type: "http"` for remote servers, `type: "local"` for stdio commands). The default file includes `{"mcpServers":{}}` since Copilot CLI requires the field to be present.
- **API key bridge**: Bridge vault-injected API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) to `COPILOT_PROVIDER_API_KEY` via inline shell expansion in the agent command.

### The `COPILOT_PROVIDER_API_KEY` problem

The Copilot CLI expects API keys in `COPILOT_PROVIDER_API_KEY`, but the OpenShell vault injects credentials using the provider's own env var name (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`). The extension's `preWorkspaceStart` hook cannot access the raw API key value — it only receives model metadata, endpoint, and configuration files.

#### Options explored

| Approach | Outcome |
|----------|---------|
| **OpenShell credential aliasing** — inject a stored credential under a different env var name | Not supported. Analyzed the OpenShell Rust codebase (`openshell-providers`, `openshell-server/grpc/provider.rs`, `openshell-supervisor-process`) and confirmed credential keys are used as env var names 1:1 with no remapping layer. Profile `env_vars` lists are for discovery/validation only, not injection expansion. |
| **Second OpenShell provider** — create a duplicate provider with `--credential COPILOT_PROVIDER_API_KEY` | Would require a core change in `AgentWorkspaceManager` since the extension doesn't have access to the raw API key at `preWorkspaceStart` time. Tightly coupled and wrong abstraction level. |
| **`--env` with placeholder reference** — pass `--env COPILOT_PROVIDER_API_KEY=openshell:resolve:env:OPENAI_API_KEY` | Placeholders only resolve in the OpenShell network proxy for outbound HTTP credential rewrite, not when apps read env vars directly. |
| **Shell wrapper script** — write a `.copilot/env-wrapper.sh` that bridges the vars | Implemented and reverted — added unnecessary complexity and an extra config file. |

#### Solution implemented

The agent `command` is written to a PTY (real shell) where the vault-injected env vars are already present. The command bridges them at execution time using POSIX shell parameter expansion:

```bash
[ -n "$COPILOT_PROVIDER_BASE_URL" ] && export COPILOT_PROVIDER_API_KEY="${COPILOT_PROVIDER_API_KEY:-${OPENAI_API_KEY:-${ANTHROPIC_API_KEY:-}}}"; copilot
```

## Test plan

- [ ] Create workspace with Copilot agent + Ollama local model → works without API key
- [ ] Create workspace with Copilot agent + OpenAI-compatible model → BYOK env vars set, API key bridged
- [ ] Create workspace with Copilot agent + Anthropic model (no explicit endpoint) → falls back to default base URL
- [ ] Create workspace with Copilot agent + MCP servers configured → `mcp-config.json` written correctly
- [ ] Default `mcp-config.json` includes `mcpServers` field (Copilot CLI requires it)
- [ ] Copilot agent visible in workspace creation wizard (no longer disabled by default)
- [ ] Unit tests pass (36 tests)

## Manual test plan

**Prerequisites:** Have at least one local model running (e.g. Ollama with `qwen2.5`), one OpenAI-compatible provider configured with an API key, one Anthropic provider configured with an API key, at least one MCP server configured, and at least one skill available.

### Test 1 — Local model (Ollama)

1. Open Kaiden and go to workspace creation
2. Select **Copilot** as the agent
3. Select a local model (e.g. Ollama `qwen2.5`)
4. Add at least one skill and one MCP server
5. Create the workspace
6. Click on the new workspace to open its detail page
7. Click the **Terminal** tab — Copilot should start automatically
8. Type a prompt and verify the agent responds correctly
9. Verify the skill is available (e.g. ask Copilot to list its skills or use one)
10. Verify the MCP server is available (e.g. ask Copilot to use a tool from the MCP server)

**Expected:** Local model is used for inference. Skills and MCP tools are accessible.

### Test 2 — OpenAI-compatible model

1. Open Kaiden and go to workspace creation
2. Select **Copilot** as the agent
3. Select an OpenAI-compatible model (e.g. `gpt-4o`)
4. Add at least one skill and one MCP server
5. Create the workspace
6. Click on the new workspace to open its detail page
7. Click the **Terminal** tab — Copilot should start automatically
8. Type a prompt and verify the agent responds correctly
9. Verify the skill is available
10. Verify the MCP server is available

**Expected:** No manual API key configuration needed — the key from your provider settings is bridged automatically. Skills and MCP tools are accessible.

### Test 3 — Anthropic model

1. Open Kaiden and go to workspace creation
2. Select **Copilot** as the agent
3. Select an Anthropic model (e.g. `claude-sonnet-4-20250514`)
4. Add at least one skill and one MCP server
5. Create the workspace
6. Click on the new workspace to open its detail page
7. Click the **Terminal** tab — Copilot should start automatically
8. Type a prompt and verify the agent responds correctly
9. Verify the skill is available
10. Verify the MCP server is available

**Expected:** No manual API key configuration needed. Copilot uses the Anthropic API with the correct base URL. Skills and MCP tools are accessible.

Closes #2542