### PR TITLE
fix(#2578): remove misleading Unrestricted network option from workspaces

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -1978,6 +1978,10 @@ describe('project filesystem mapping', () => {
       id: 'open-net',
       network: { mode: 'allow' },
     };
+    wizard.draft.hostsByMode = {
+      ...wizard.draft.hostsByMode,
+      registries: ['stale.example.com'],
+    };
     setProjects([openNetProject]);
     render(AgentWorkspaceCreate);
 
@@ -1985,6 +1989,7 @@ describe('project filesystem mapping', () => {
     await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
 
     expect(wizard.draft.selectedNetwork).toBe('registries');
+    expect(wizard.draft.hostsByMode['registries']).toEqual(['registry.npmjs.org', 'pypi.python.org']);
   });
 
   test('Expect deny network without hosts mapped to blocked mode', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -882,7 +882,7 @@ test('Expect networking step shows Network Policy heading', async () => {
   expect(screen.getByText('Outbound network for this workspace sandbox')).toBeInTheDocument();
 });
 
-test('Expect all four network options rendered with Agent mode disabled', async () => {
+test('Expect three network options rendered with Agent mode disabled and Unrestricted absent', async () => {
   render(AgentWorkspaceCreate);
 
   await navigateToNetworkingStep();
@@ -891,7 +891,8 @@ test('Expect all four network options rendered with Agent mode disabled', async 
   expect(screen.getByRole('radio', { name: 'Use Developer Preset' })).toBeInTheDocument();
   expect(screen.getByRole('radio', { name: 'Use Agent mode' })).toBeInTheDocument();
   expect(screen.getByRole('radio', { name: 'Use Agent mode' })).toBeDisabled();
-  expect(screen.getByRole('radio', { name: 'Use Unrestricted' })).toBeInTheDocument();
+  expect(screen.queryByRole('radio', { name: 'Use Unrestricted' })).not.toBeInTheDocument();
+  expect(screen.queryByRole('radio', { name: 'Use Allow all outbound' })).not.toBeInTheDocument();
 });
 
 test('Expect clicking disabled Agent mode does not change selection', async () => {
@@ -914,23 +915,14 @@ test('Expect Developer Preset selected by default on networking step', async () 
   expect(screen.getByRole('radio', { name: 'Use Deny All' })).not.toBeChecked();
 });
 
-test('Expect allowlists hint text displayed when Unrestricted selected on networking step', async () => {
-  render(AgentWorkspaceCreate);
-
-  await navigateToNetworkingStep();
-  await fireEvent.click(screen.getByRole('radio', { name: 'Use Unrestricted' }));
-
-  expect(screen.getByText(/Fine-grained host allowlists and static egress rules/)).toBeInTheDocument();
-});
-
-test('Expect selecting a different network option updates the radio', async () => {
+test('Expect selecting Deny All updates the radio', async () => {
   render(AgentWorkspaceCreate);
 
   await navigateToNetworkingStep();
 
-  await fireEvent.click(screen.getByRole('radio', { name: 'Use Unrestricted' }));
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Deny All' }));
 
-  expect(screen.getByRole('radio', { name: 'Use Unrestricted' })).toBeChecked();
+  expect(screen.getByRole('radio', { name: 'Use Deny All' })).toBeChecked();
   expect(screen.getByRole('radio', { name: 'Use Developer Preset' })).not.toBeChecked();
 });
 
@@ -1143,26 +1135,6 @@ test('Expect custom hosts pre-populated with registry hosts when Developer Prese
   expect((screen.getByLabelText('Custom host 1') as HTMLInputElement).value).toBe('registry.npmjs.org');
   expect((screen.getByLabelText('Custom host 2') as HTMLInputElement).value).toBe('pypi.python.org');
   expect(screen.getByRole('button', { name: 'Add Another Host' })).toBeInTheDocument();
-});
-
-test('Expect custom hosts input hidden when Agent mode is selected on networking step', async () => {
-  render(AgentWorkspaceCreate);
-
-  await navigateToNetworkingStep();
-  await fireEvent.click(screen.getByRole('radio', { name: 'Use Agent mode' }));
-
-  expect(screen.queryByLabelText('Custom host 1')).not.toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: 'Add Another Host' })).not.toBeInTheDocument();
-});
-
-test('Expect custom hosts input hidden when Unrestricted is selected on networking step', async () => {
-  render(AgentWorkspaceCreate);
-
-  await navigateToNetworkingStep();
-  await fireEvent.click(screen.getByRole('radio', { name: 'Use Unrestricted' }));
-
-  expect(screen.queryByLabelText('Custom host 1')).not.toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: 'Add Another Host' })).not.toBeInTheDocument();
 });
 
 test('Expect createAgentWorkspace called with registry hosts plus custom host for Developer Preset', async () => {
@@ -2000,7 +1972,7 @@ describe('when projects exist', () => {
 });
 
 describe('project filesystem mapping', () => {
-  test('Expect allow network maps to open', async () => {
+  test('Expect allow network maps to registries', async () => {
     const openNetProject: WorkspaceProjectInfo = {
       ...sampleProject,
       id: 'open-net',
@@ -2012,7 +1984,7 @@ describe('project filesystem mapping', () => {
     await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
     await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
 
-    expect(wizard.draft.selectedNetwork).toBe('open');
+    expect(wizard.draft.selectedNetwork).toBe('registries');
   });
 
   test('Expect deny network without hosts mapped to blocked mode', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -89,6 +89,10 @@ function applyNetworkFromProject(net: NetworkConfiguration | undefined): void {
   // mode: allow is no longer offered in the UI; fall back to the recommended preset.
   if (net.mode === 'allow') {
     wizard.draft.selectedNetwork = 'registries';
+    wizard.draft.hostsByMode = {
+      ...wizard.draft.hostsByMode,
+      registries: [...REGISTRY_PRESET],
+    };
     return;
   }
   const hosts = net.hosts ?? [];

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -43,8 +43,6 @@ import AgentWorkspaceCreateStepWorkspace from './AgentWorkspaceCreateStepWorkspa
 function mapNetworkSelection(value: string, hosts: string[]): NetworkConfiguration | undefined {
   const filtered = hosts.filter(h => h.trim() !== '');
   switch (value) {
-    case 'open':
-      return { mode: 'allow' };
     case 'registries':
     case 'blocked':
       return { mode: 'deny', hosts: filtered.length ? filtered : undefined };
@@ -88,8 +86,9 @@ function isRegistryPreset(hosts: string[]): boolean {
 
 function applyNetworkFromProject(net: NetworkConfiguration | undefined): void {
   if (!net) return;
+  // mode: allow is no longer offered in the UI; fall back to the recommended preset.
   if (net.mode === 'allow') {
-    wizard.draft.selectedNetwork = 'open';
+    wizard.draft.selectedNetwork = 'registries';
     return;
   }
   const hosts = net.hosts ?? [];

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
@@ -39,15 +39,17 @@ const networkOptions: NetworkAccessOption[] = [
     notes: 'Human in the loop',
     disabled: true,
   },
-  {
-    value: 'open',
-    name: 'Unrestricted',
-    description: 'Permit all outbound traffic. Best for trusted dev setups.',
-    access: 'All hosts',
-    notes: 'Trusted setups',
-    disabled: false,
-  },
 ];
+
+/** Shown only for existing workspaces with mode: allow — not selectable for new configs. */
+const legacyAllowAllOutboundOption: NetworkAccessOption = {
+  value: 'open',
+  name: 'Allow all outbound',
+  description: 'No outbound allowlist. The sandbox stays isolated from the host.',
+  access: 'All hosts',
+  notes: 'Legacy',
+  disabled: true,
+};
 
 interface Props {
   selectedNetwork: string;
@@ -67,6 +69,10 @@ let {
   onchange,
 }: Props = $props();
 
+let displayedNetworkOptions = $derived(
+  selectedNetwork === 'open' ? [...networkOptions, legacyAllowAllOutboundOption] : networkOptions,
+);
+
 let showCustomHosts = $derived(selectedNetwork === 'blocked' || selectedNetwork === 'registries');
 </script>
 
@@ -81,7 +87,7 @@ let showCustomHosts = $derived(selectedNetwork === 'blocked' || selectedNetwork 
 </div>
 
 <div class="rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] overflow-hidden">
-  {#each networkOptions as option, idx (option.value)}
+  {#each displayedNetworkOptions as option, idx (option.value)}
     {#if idx > 0}
       <div class="mx-3 border-t border-[var(--pd-content-card-border)] opacity-30"></div>
     {/if}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.svelte
@@ -78,7 +78,7 @@ const timeLabel = $derived(workspaceSummary && isActiveWorkspace(workspaceSummar
 const networkMode = $derived(configuration?.network?.mode ?? 'deny');
 const networkHosts = $derived(configuration?.network?.hosts ?? []);
 const networkLabel = $derived.by(() => {
-  if (networkMode === 'allow') return 'Unrestricted';
+  if (networkMode === 'allow') return 'Allow all outbound';
   if (networkHosts.length > 0) return 'Developer Preset';
   return 'Deny All';
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -934,15 +934,17 @@ test('Expect Network section defaults to Developer Preset when no network config
   expect(registriesRadio).toBeChecked();
 });
 
-test('Expect Network section shows Unrestricted selected for allow mode config', async () => {
+test('Expect Network section shows disabled Allow all outbound for allow mode config', async () => {
   const networkConfig: AgentWorkspaceConfiguration = { network: { mode: 'allow' } };
   render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: networkConfig });
 
   const networkNav = screen.getByRole('link', { name: 'Network' });
   await fireEvent.click(networkNav);
 
-  const openRadio = screen.getByRole('radio', { name: 'Use Unrestricted' });
+  const openRadio = screen.getByRole('radio', { name: 'Use Allow all outbound' });
   expect(openRadio).toBeChecked();
+  expect(openRadio).toBeDisabled();
+  expect(screen.queryByRole('radio', { name: 'Use Unrestricted' })).not.toBeInTheDocument();
 });
 
 test('Expect Network section shows Deny All selected for deny mode without hosts', async () => {
@@ -1029,8 +1031,9 @@ test('Expect discarding network changes resets to original mode', async () => {
   await fireEvent.click(screen.getByRole('radio', { name: 'Use Deny All' }));
   await fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
 
-  const openRadio = screen.getByRole('radio', { name: 'Use Unrestricted' });
+  const openRadio = screen.getByRole('radio', { name: 'Use Allow all outbound' });
   expect(openRadio).toBeChecked();
+  expect(openRadio).toBeDisabled();
   expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -139,8 +139,6 @@ function deriveNetworkHosts(network: NetworkConfiguration | undefined): string[]
 function mapNetworkSelection(value: string, hosts: string[]): NetworkConfiguration | undefined {
   const filtered = hosts.filter(h => h.trim() !== '');
   switch (value) {
-    case 'open':
-      return { mode: 'allow' };
     case 'registries':
     case 'blocked':
       return { mode: 'deny', hosts: filtered.length ? filtered : undefined };

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -274,7 +274,6 @@ export type FilesystemBadge = (typeof FILESYSTEM_BADGE)[keyof typeof FILESYSTEM_
 export const NETWORK_ACCESS_LEVEL = {
   DENY_ALL: 'Deny All',
   DEVELOPER_PRESET: 'Developer Preset',
-  UNRESTRICTED: 'Unrestricted',
 } as const;
 export const NETWORK_ACCESS_LEVELS = Object.values(NETWORK_ACCESS_LEVEL);
 export type NetworkAccessLevel = (typeof NETWORK_ACCESS_LEVEL)[keyof typeof NETWORK_ACCESS_LEVEL];

--- a/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-sandbox-matrix.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-sandbox-matrix.ts
@@ -38,7 +38,6 @@ export const CUSTOM_MOUNT_DEFAULT_HOST = '$SOURCES/e2e-default';
 export const CUSTOM_ALLOWED_HOST = 'api.example.com';
 
 export const FULL_SYSTEM_SKIP_LABEL = 'OpenShell tar fails on / mount';
-export const UNRESTRICTED_SKIP_LABEL = 'Unrestricted network disabled on OpenShell';
 
 function skipTestTitle(scenarioId: string, skipReason: string): string {
   return `[SKIP] ${scenarioId} — ${skipReason}`;
@@ -69,7 +68,6 @@ const FILESYSTEM_TAG: Record<FileAccessLevel, string> = {
 const NETWORK_TAG: Record<NetworkAccessLevel, string> = {
   [NETWORK_ACCESS_LEVEL.DENY_ALL]: '@net-deny',
   [NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET]: '@net-developer',
-  [NETWORK_ACCESS_LEVEL.UNRESTRICTED]: '@net-unrestricted',
 };
 
 export interface SandboxScenario {
@@ -138,8 +136,6 @@ function networkLabel(scenario: SandboxScenario): string {
       return scenario.additionalHosts?.length
         ? 'developer preset network and additional allowed host'
         : 'developer preset network';
-    case NETWORK_ACCESS_LEVEL.UNRESTRICTED:
-      return 'unrestricted network';
     default: {
       const _exhaustive: never = scenario.network;
       return _exhaustive;

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-filesystem-network-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-filesystem-network-smoke.spec.ts
@@ -30,7 +30,6 @@ import {
   registerSandboxMatrixTests,
   type SandboxAgentSetup,
   type SandboxScenario,
-  UNRESTRICTED_SKIP_LABEL,
 } from './helpers/workspace-sandbox-matrix';
 
 const AGENT_SETUPS: SandboxAgentSetup[] = [
@@ -146,25 +145,6 @@ const SANDBOX_SCENARIOS: SandboxScenario[] = [
     fileAccess: FILE_ACCESS_LEVEL.FULL_SYSTEM,
     network: NETWORK_ACCESS_LEVEL.DENY_ALL,
     skipReason: FULL_SYSTEM_SKIP_LABEL,
-  },
-  {
-    id: 'FS-NONE-NET-UNRESTRICTED',
-    fileAccess: FILE_ACCESS_LEVEL.NO_HOST_ACCESS,
-    network: NETWORK_ACCESS_LEVEL.UNRESTRICTED,
-    skipReason: UNRESTRICTED_SKIP_LABEL,
-  },
-  {
-    id: 'FS-HOME-NET-UNRESTRICTED',
-    fileAccess: FILE_ACCESS_LEVEL.HOME_DIRECTORY,
-    network: NETWORK_ACCESS_LEVEL.UNRESTRICTED,
-    skipReason: UNRESTRICTED_SKIP_LABEL,
-  },
-  {
-    id: 'FS-CUSTOM-NET-UNRESTRICTED',
-    fileAccess: FILE_ACCESS_LEVEL.CUSTOM_PATHS,
-    customMounts: CUSTOM_RW_MOUNT,
-    network: NETWORK_ACCESS_LEVEL.UNRESTRICTED,
-    skipReason: UNRESTRICTED_SKIP_LABEL,
   },
 ];
 


### PR DESCRIPTION
Drop Unrestricted from create/wizard UI. Keep a disabled legacy label for existing allow-mode configs; sandbox isolation was never removed.

Closes https://github.com/openkaiden/kaiden/issues/2578

<img width="968" height="757" alt="Screenshot 2026-07-29 at 12 22 02 PM" src="https://github.com/user-attachments/assets/ace881da-2b48-4a2b-aaf9-8a4f40ceb631" />
