### PR TITLE
ci: skip workspace smoke e2e playwright tests on macos/windows gha runners

### DIFF
--- a/tests/playwright/src/specs/guided-setup-smoke.spec.ts
+++ b/tests/playwright/src/specs/guided-setup-smoke.spec.ts
@@ -208,7 +208,7 @@ test.describe('Guided setup smoke', { tag: '@smoke' }, () => {
 
     test.describe('Onboarding - guided setup persistence (Claude)', () => {
       test.skip(
-        process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
+        !!process.env.CI && process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
         'Requires an OpenShell gateway with the Podman driver, which is not available on macOS/Windows GitHub Actions runners',
       );
 

--- a/tests/playwright/src/specs/guided-setup-smoke.spec.ts
+++ b/tests/playwright/src/specs/guided-setup-smoke.spec.ts
@@ -208,7 +208,7 @@ test.describe('Guided setup smoke', { tag: '@smoke' }, () => {
 
     test.describe('Onboarding - guided setup persistence (Claude)', () => {
       test.skip(
-        !!process.env.CI && process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
+        !!process.env.GITHUB_ACTIONS && process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
         'Requires an OpenShell gateway with the Podman driver, which is not available on macOS/Windows GitHub Actions runners',
       );
 

--- a/tests/playwright/src/specs/guided-setup-smoke.spec.ts
+++ b/tests/playwright/src/specs/guided-setup-smoke.spec.ts
@@ -207,6 +207,11 @@ test.describe('Guided setup smoke', { tag: '@smoke' }, () => {
     });
 
     test.describe('Onboarding - guided setup persistence (Claude)', () => {
+      test.skip(
+        process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
+        'Requires an OpenShell gateway with the Podman driver, which is not available on macOS/Windows GitHub Actions runners',
+      );
+
       const session = bindGuidedSetupSession();
 
       test('[OGS-PERSIST-03] Guided setup persistence: Claude model appears in workspace wizard', async () => {

--- a/tests/playwright/src/specs/workspaces-smoke.spec.ts
+++ b/tests/playwright/src/specs/workspaces-smoke.spec.ts
@@ -42,6 +42,11 @@ const TEST_SKILL = {
   name: 'playwright-testing',
 };
 
+test.skip(
+  process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
+  'Workspaces tests require an OpenShell gateway (e.g. Podman), which is not available on macOS/Windows GitHub Actions runners',
+);
+
 const completeAgentModelStep: AgentModelSetup = async (createPage: AgentWorkspaceCreatePage): Promise<void> => {
   const connection = resolveAgentModelConnection();
   test.skip(!connection, agentModelSetupSkipMessage());

--- a/tests/playwright/src/specs/workspaces-smoke.spec.ts
+++ b/tests/playwright/src/specs/workspaces-smoke.spec.ts
@@ -43,7 +43,7 @@ const TEST_SKILL = {
 };
 
 test.skip(
-  !!process.env.CI && process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
+  !!process.env.GITHUB_ACTIONS && process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
   'Workspaces smoke requires an OpenShell gateway with the Podman driver, which is not available on macOS/Windows GitHub Actions runners',
 );
 

--- a/tests/playwright/src/specs/workspaces-smoke.spec.ts
+++ b/tests/playwright/src/specs/workspaces-smoke.spec.ts
@@ -44,7 +44,7 @@ const TEST_SKILL = {
 
 test.skip(
   process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
-  'Workspaces tests require an OpenShell gateway (e.g. Podman), which is not available on macOS/Windows GitHub Actions runners',
+  'Workspaces smoke requires an OpenShell gateway with the Podman driver, which is not available on macOS/Windows GitHub Actions runners',
 );
 
 const completeAgentModelStep: AgentModelSetup = async (createPage: AgentWorkspaceCreatePage): Promise<void> => {

--- a/tests/playwright/src/specs/workspaces-smoke.spec.ts
+++ b/tests/playwright/src/specs/workspaces-smoke.spec.ts
@@ -43,7 +43,7 @@ const TEST_SKILL = {
 };
 
 test.skip(
-  process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
+  !!process.env.CI && process.platform !== 'linux' && !process.env.PODMAN_ENABLED,
   'Workspaces smoke requires an OpenShell gateway with the Podman driver, which is not available on macOS/Windows GitHub Actions runners',
 );
 


### PR DESCRIPTION
Requires an OpenShell gateway with the Podman driver, which is not available on macOS/Windows GitHub Actions runners.

Closes https://github.com/openkaiden/kaiden/issues/2563