### PR TITLE
feat(config): support declarative env/file defaults in configuration properties

### DIFF
--- a/extensions/vertex-ai/package.json
+++ b/extensions/vertex-ai/package.json
@@ -22,18 +22,31 @@
         "vertex-ai.factory.projectId": {
           "type": "string",
           "scope": "InferenceProviderConnectionFactory",
-          "description": "Google Cloud project ID where Anthropic models are enabled (not the ADC quota_project_id)"
+          "description": "Google Cloud project ID where Anthropic models are enabled",
+          "default": [
+            "env:GOOGLE_VERTEX_PROJECT",
+            "env:ANTHROPIC_VERTEX_PROJECT_ID"
+          ]
         },
         "vertex-ai.factory.region": {
           "type": "string",
           "scope": "InferenceProviderConnectionFactory",
-          "description": "Google Cloud region (e.g. us-east5, europe-west1)"
+          "description": "Google Cloud region (e.g. us-east5, europe-west1)",
+          "default": [
+            "env:GOOGLE_VERTEX_LOCATION",
+            "env:CLOUD_ML_REGION"
+          ]
         },
         "vertex-ai.factory.credentialsFile": {
           "type": "string",
           "format": "file",
           "scope": "InferenceProviderConnectionFactory",
-          "description": "Path to gcloud credentials file (e.g. ~/.config/gcloud/application_default_credentials.json)"
+          "description": "Path to gcloud credentials file (e.g. ~/.config/gcloud/application_default_credentials.json)",
+          "default": [
+            "env:GOOGLE_APPLICATION_CREDENTIALS",
+            "file:~/.config/gcloud/application_default_credentials.json",
+            "file:$APPDATA/gcloud/application_default_credentials.json"
+          ]
         },
         "vertex-ai.connection._type": {
           "type": "string",

--- a/extensions/vertex-ai/package.json
+++ b/extensions/vertex-ai/package.json
@@ -22,7 +22,7 @@
         "vertex-ai.factory.projectId": {
           "type": "string",
           "scope": "InferenceProviderConnectionFactory",
-          "description": "Google Cloud project ID where Anthropic models are enabled",
+          "description": "Google Cloud project ID where Anthropic models are enabled (not the ADC quota_project_id)",
           "default": [
             "env:GOOGLE_VERTEX_PROJECT",
             "env:ANTHROPIC_VERTEX_PROJECT_ID"

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -18,9 +18,10 @@
 
 // Import to access mocked functionionalities such as using vi.mock (we don't want to actually call node:fs methods)
 import * as fs from 'node:fs';
+import { homedir } from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import {
@@ -41,7 +42,7 @@ vi.mock('node:fs', () => ({
   readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
   cpSync: vi.fn(),
-  accessSync: vi.fn(),
+  existsSync: vi.fn(),
   promises: {
     access: vi.fn(),
     mkdir: vi.fn(),
@@ -50,6 +51,14 @@ vi.mock('node:fs', () => ({
     copyFile: vi.fn(),
   },
 }));
+
+vi.mock(import('node:os'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    homedir: vi.fn(),
+  };
+});
 
 // mock DefaultConfiguration for the new managed defaults functionality
 vi.mock(import('./default-configuration.js'), () => ({
@@ -109,6 +118,8 @@ beforeEach(async () => {
   writeFileMock.mockResolvedValue(undefined);
   readFileMock.mockResolvedValue(JSON.stringify({}));
   cpSync.mockReturnValue(undefined);
+  vi.mocked(fs.existsSync).mockReturnValue(false);
+  vi.mocked(homedir).mockReturnValue('/home/testuser');
 
   // Setup DefaultConfiguration mock for the new functionality
   getContentMock.mockResolvedValue({});
@@ -338,129 +349,183 @@ test('addConfigurationEnum with a previous default value', async () => {
   expect(val).toEqual('myValue1');
 });
 
-describe('env-prefix default resolution', () => {
-  const ENV_KEYS = ['TEST_ENV_VAR_A', 'TEST_ENV_VAR_B', 'APPDATA'] as const;
-  const savedEnv: Record<string, string | undefined> = {};
+describe('declarative env:/file: defaults', () => {
+  const ENV_VAR = 'PD_TEST_CREDENTIALS_PATH';
+  const APPDATA_VAR = 'PD_TEST_APPDATA';
 
   beforeEach(() => {
-    for (const key of ENV_KEYS) {
-      savedEnv[key] = process.env[key];
-      delete process.env[key];
-    }
+    delete process.env[ENV_VAR];
+    delete process.env[APPDATA_VAR];
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(homedir).mockReturnValue('/home/testuser');
   });
 
-  afterEach(() => {
-    for (const key of ENV_KEYS) {
-      if (savedEnv[key] !== undefined) {
-        process.env[key] = savedEnv[key];
-      } else {
-        delete process.env[key];
-      }
-    }
-  });
-
-  function registerWithDefault(defaultValue: unknown): Record<string, IConfigurationPropertyRecordedSchema> {
+  function registerWithDefault(defaultValue: unknown): IConfigurationPropertyRecordedSchema | undefined {
     const node: IConfigurationNode = {
-      id: 'env.test',
-      title: 'Env Test',
+      id: 'my-extension',
+      title: 'My Extension',
       type: 'object',
       properties: {
-        ['env.test.field']: {
-          description: 'A test field',
+        'my-extension.credentialsFile': {
+          description: 'Path to credentials file',
           type: 'string',
-          scope: 'InferenceProviderConnectionFactory',
+          format: 'file',
           default: defaultValue,
         },
       },
     };
     configurationRegistry.registerConfigurations([node]);
-    return configurationRegistry.getConfigurationProperties();
+    return configurationRegistry.getConfigurationProperties()['my-extension.credentialsFile'];
   }
 
-  test('should resolve env: entry to environment variable value', () => {
-    process.env['TEST_ENV_VAR_A'] = 'resolved-value';
+  test('should resolve env: entry when environment variable is set', () => {
+    process.env[ENV_VAR] = '/custom/credentials.json';
 
-    const records = registerWithDefault(['env:TEST_ENV_VAR_A']);
+    const property = registerWithDefault([
+      `env:${ENV_VAR}`,
+      'file:~/.config/my-tool/credentials.json',
+      `file:$${APPDATA_VAR}/my-tool/credentials.json`,
+    ]);
 
-    expect(records['env.test.field']?.default).toBe('resolved-value');
+    expect(property?.default).toBe('/custom/credentials.json');
+    expect(configurationRegistry.getConfiguration('my-extension').get('credentialsFile')).toBe(
+      '/custom/credentials.json',
+    );
   });
 
-  test('should resolve first available env var from array', () => {
-    process.env['TEST_ENV_VAR_B'] = 'fallback-value';
+  test('should skip empty env: value and fall through to file:', () => {
+    process.env[ENV_VAR] = '';
+    const expectedPath = path.join('/home/testuser', '.config/my-tool/credentials.json');
+    vi.mocked(fs.existsSync).mockImplementation((p: Parameters<typeof fs.existsSync>[0]) => p === expectedPath);
 
-    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'env:TEST_ENV_VAR_B']);
+    const property = registerWithDefault([`env:${ENV_VAR}`, 'file:~/.config/my-tool/credentials.json']);
 
-    expect(records['env.test.field']?.default).toBe('fallback-value');
+    expect(property?.default).toBe(expectedPath);
   });
 
-  test('should prefer first entry in array when multiple match', () => {
-    process.env['TEST_ENV_VAR_A'] = 'primary';
-    process.env['TEST_ENV_VAR_B'] = 'secondary';
+  test('should resolve file: with ~ expansion when file exists', () => {
+    const expectedPath = path.join('/home/testuser', '.config/my-tool/credentials.json');
+    vi.mocked(fs.existsSync).mockImplementation((p: Parameters<typeof fs.existsSync>[0]) => p === expectedPath);
 
-    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'env:TEST_ENV_VAR_B']);
+    const property = registerWithDefault([
+      `env:${ENV_VAR}`,
+      'file:~/.config/my-tool/credentials.json',
+      `file:$${APPDATA_VAR}/my-tool/credentials.json`,
+    ]);
 
-    expect(records['env.test.field']?.default).toBe('primary');
+    expect(property?.default).toBe(expectedPath);
   });
 
-  test('should resolve to undefined when no env vars are set', () => {
-    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'env:TEST_ENV_VAR_B']);
+  test('should resolve file: with $VAR expansion when file exists', () => {
+    process.env[APPDATA_VAR] = 'C:\\Users\\test\\AppData\\Roaming';
+    const expectedPath = 'C:\\Users\\test\\AppData\\Roaming/my-tool/credentials.json';
+    vi.mocked(fs.existsSync).mockImplementation((p: Parameters<typeof fs.existsSync>[0]) => p === expectedPath);
 
-    expect(records['env.test.field']?.default).toBeUndefined();
+    const property = registerWithDefault([
+      `env:${ENV_VAR}`,
+      'file:~/.config/my-tool/credentials.json',
+      `file:$${APPDATA_VAR}/my-tool/credentials.json`,
+    ]);
+
+    expect(property?.default).toBe(expectedPath);
   });
 
-  test('should leave non-env defaults unchanged', () => {
-    const records = registerWithDefault('plain-value');
+  test('should skip file: entry when $VAR is unset instead of checking a truncated path', () => {
+    const existsSyncMock = vi.mocked(fs.existsSync);
+    existsSyncMock.mockImplementation((p: Parameters<typeof fs.existsSync>[0]) => p === '/my-tool/credentials.json');
 
-    expect(records['env.test.field']?.default).toBe('plain-value');
+    const property = registerWithDefault([`file:$${APPDATA_VAR}/my-tool/credentials.json`]);
+
+    expect(property?.default).toBeUndefined();
+    expect(existsSyncMock).not.toHaveBeenCalled();
   });
 
-  test('should leave non-string defaults unchanged', () => {
-    const records = registerWithDefault(42);
+  test('should leave default undefined when no entry resolves', () => {
+    const property = registerWithDefault([
+      `env:${ENV_VAR}`,
+      'file:~/.config/my-tool/credentials.json',
+      `file:$${APPDATA_VAR}/my-tool/credentials.json`,
+    ]);
 
-    expect(records['env.test.field']?.default).toBe(42);
+    expect(property?.default).toBeUndefined();
+    expect(configurationRegistry.getConfiguration('my-extension').get('credentialsFile')).toBeUndefined();
   });
 
-  test('should resolve file: entry with tilde when file exists', () => {
-    vi.mocked(fs.accessSync).mockReturnValue(undefined);
+  test('should not treat literal array defaults as declarative', () => {
+    const literalDefault = [
+      { label: 'foo', value: 1 },
+      { label: 'bar', value: 2 },
+    ];
+    const node: IConfigurationNode = {
+      id: 'custom',
+      title: 'Test Object Property',
+      properties: {
+        'test.literalArray': {
+          description: 'test property',
+          type: 'array',
+          default: literalDefault,
+        },
+      },
+    };
 
-    const records = registerWithDefault(['file:~/.config/gcloud/creds.json']);
+    configurationRegistry.registerConfigurations([node]);
+    const property = configurationRegistry.getConfigurationProperties()['test.literalArray'];
 
-    expect(records['env.test.field']?.default).toContain(path.join('.config', 'gcloud', 'creds.json'));
+    expect(property?.default).toEqual(literalDefault);
   });
 
-  test('should resolve file: entry with $VAR when env var and file exist', () => {
-    process.env['APPDATA'] = '/mock/appdata';
-    vi.mocked(fs.accessSync).mockReturnValue(undefined);
+  test('should not treat string array defaults without env:/file: prefixes as declarative', () => {
+    const literalDefault = ['alpha', 'beta'];
+    const node: IConfigurationNode = {
+      id: 'custom',
+      title: 'Test String Array',
+      properties: {
+        'test.stringArray': {
+          description: 'test property',
+          type: 'array',
+          default: literalDefault,
+        },
+      },
+    };
 
-    const records = registerWithDefault(['file:$APPDATA/gcloud/creds.json']);
+    configurationRegistry.registerConfigurations([node]);
+    const property = configurationRegistry.getConfigurationProperties()['test.stringArray'];
 
-    expect(records['env.test.field']?.default).toContain('appdata');
-    expect(records['env.test.field']?.default).toContain('gcloud');
+    expect(property?.default).toEqual(literalDefault);
   });
 
-  test('should skip file: entry with $VAR when env var is not set', () => {
-    const records = registerWithDefault(['file:$APPDATA/gcloud/creds.json']);
-
-    expect(records['env.test.field']?.default).toBeUndefined();
+  test('should leave scalar defaults unchanged', () => {
+    const property = registerWithDefault('/already/set/path.json');
+    expect(property?.default).toBe('/already/set/path.json');
   });
 
-  test('should skip file: entry when file does not exist', () => {
-    vi.mocked(fs.accessSync).mockImplementation(() => {
-      throw new Error('ENOENT');
-    });
+  test('should resolve single env: string default when variable is set', () => {
+    process.env[ENV_VAR] = '/from/env/creds.json';
 
-    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'file:/nonexistent/path.json']);
+    const property = registerWithDefault(`env:${ENV_VAR}`);
 
-    expect(records['env.test.field']?.default).toBeUndefined();
+    expect(property?.default).toBe('/from/env/creds.json');
   });
 
-  test('should prefer env var over file: fallback', () => {
-    process.env['TEST_ENV_VAR_A'] = '/custom/creds.json';
-    vi.mocked(fs.accessSync).mockReturnValue(undefined);
+  test('should resolve single env: string default to undefined when variable is unset', () => {
+    const property = registerWithDefault(`env:${ENV_VAR}`);
 
-    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'file:~/.config/gcloud/creds.json']);
+    expect(property?.default).toBeUndefined();
+  });
 
-    expect(records['env.test.field']?.default).toBe('/custom/creds.json');
+  test('should resolve single file: string default when file exists', () => {
+    const expectedPath = path.join('/home/testuser', '.config/my-tool/credentials.json');
+    vi.mocked(fs.existsSync).mockImplementation((p: Parameters<typeof fs.existsSync>[0]) => p === expectedPath);
+
+    const property = registerWithDefault('file:~/.config/my-tool/credentials.json');
+
+    expect(property?.default).toBe(expectedPath);
+  });
+
+  test('should resolve single file: string default to undefined when file does not exist', () => {
+    const property = registerWithDefault('file:~/.config/my-tool/credentials.json');
+
+    expect(property?.default).toBeUndefined();
   });
 });
 

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -19,14 +19,14 @@
 // Import to access mocked functionionalities such as using vi.mock (we don't want to actually call node:fs methods)
 import * as fs from 'node:fs';
 
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import {
   CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
   CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE,
 } from '/@api/configuration/constants.js';
-import type { IConfigurationNode } from '/@api/configuration/models.js';
+import type { IConfigurationNode, IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type { IDisposable } from '/@api/disposable.js';
 
 import { ConfigurationRegistry } from './configuration-registry.js';
@@ -40,6 +40,7 @@ vi.mock('node:fs', () => ({
   readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
   cpSync: vi.fn(),
+  accessSync: vi.fn(),
   promises: {
     access: vi.fn(),
     mkdir: vi.fn(),
@@ -334,6 +335,132 @@ test('addConfigurationEnum with a previous default value', async () => {
   // check default property is no longer 'myValue3' but it is defaulted to myValue1
   const val = configurationRegistry.getConfiguration('my.fake')?.get<string>('enum.property');
   expect(val).toEqual('myValue1');
+});
+
+describe('env-prefix default resolution', () => {
+  const ENV_KEYS = ['TEST_ENV_VAR_A', 'TEST_ENV_VAR_B', 'APPDATA'] as const;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  function registerWithDefault(defaultValue: unknown): Record<string, IConfigurationPropertyRecordedSchema> {
+    const node: IConfigurationNode = {
+      id: 'env.test',
+      title: 'Env Test',
+      type: 'object',
+      properties: {
+        ['env.test.field']: {
+          description: 'A test field',
+          type: 'string',
+          scope: 'InferenceProviderConnectionFactory',
+          default: defaultValue,
+        },
+      },
+    };
+    configurationRegistry.registerConfigurations([node]);
+    return configurationRegistry.getConfigurationProperties();
+  }
+
+  test('should resolve env: entry to environment variable value', () => {
+    process.env['TEST_ENV_VAR_A'] = 'resolved-value';
+
+    const records = registerWithDefault(['env:TEST_ENV_VAR_A']);
+
+    expect(records['env.test.field']?.default).toBe('resolved-value');
+  });
+
+  test('should resolve first available env var from array', () => {
+    process.env['TEST_ENV_VAR_B'] = 'fallback-value';
+
+    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'env:TEST_ENV_VAR_B']);
+
+    expect(records['env.test.field']?.default).toBe('fallback-value');
+  });
+
+  test('should prefer first entry in array when multiple match', () => {
+    process.env['TEST_ENV_VAR_A'] = 'primary';
+    process.env['TEST_ENV_VAR_B'] = 'secondary';
+
+    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'env:TEST_ENV_VAR_B']);
+
+    expect(records['env.test.field']?.default).toBe('primary');
+  });
+
+  test('should resolve to undefined when no env vars are set', () => {
+    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'env:TEST_ENV_VAR_B']);
+
+    expect(records['env.test.field']?.default).toBeUndefined();
+  });
+
+  test('should leave non-env defaults unchanged', () => {
+    const records = registerWithDefault('plain-value');
+
+    expect(records['env.test.field']?.default).toBe('plain-value');
+  });
+
+  test('should leave non-string defaults unchanged', () => {
+    const records = registerWithDefault(42);
+
+    expect(records['env.test.field']?.default).toBe(42);
+  });
+
+  test('should resolve file: entry with tilde when file exists', () => {
+    vi.mocked(fs.accessSync).mockReturnValue(undefined);
+
+    const records = registerWithDefault(['file:~/.config/gcloud/creds.json']);
+
+    expect(records['env.test.field']?.default).toContain('.config/gcloud/creds.json');
+  });
+
+  test('should resolve file: entry with $VAR when env var and file exist', () => {
+    process.env['APPDATA'] = '/mock/appdata';
+    vi.mocked(fs.accessSync).mockReturnValue(undefined);
+
+    const records = registerWithDefault(['file:$APPDATA/gcloud/creds.json']);
+
+    expect(records['env.test.field']?.default).toContain('appdata');
+    expect(records['env.test.field']?.default).toContain('gcloud');
+  });
+
+  test('should skip file: entry with $VAR when env var is not set', () => {
+    const records = registerWithDefault(['file:$APPDATA/gcloud/creds.json']);
+
+    expect(records['env.test.field']?.default).toBeUndefined();
+  });
+
+  test('should skip file: entry when file does not exist', () => {
+    vi.mocked(fs.accessSync).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'file:/nonexistent/path.json']);
+
+    expect(records['env.test.field']?.default).toBeUndefined();
+  });
+
+  test('should prefer env var over file: fallback', () => {
+    process.env['TEST_ENV_VAR_A'] = '/custom/creds.json';
+    vi.mocked(fs.accessSync).mockReturnValue(undefined);
+
+    const records = registerWithDefault(['env:TEST_ENV_VAR_A', 'file:~/.config/gcloud/creds.json']);
+
+    expect(records['env.test.field']?.default).toBe('/custom/creds.json');
+  });
 });
 
 test('check to be able to register a property with a group', async () => {

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -18,6 +18,7 @@
 
 // Import to access mocked functionionalities such as using vi.mock (we don't want to actually call node:fs methods)
 import * as fs from 'node:fs';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -424,7 +425,7 @@ describe('env-prefix default resolution', () => {
 
     const records = registerWithDefault(['file:~/.config/gcloud/creds.json']);
 
-    expect(records['env.test.field']?.default).toContain('.config/gcloud/creds.json');
+    expect(records['env.test.field']?.default).toContain(path.join('.config', 'gcloud', 'creds.json'));
   });
 
   test('should resolve file: entry with $VAR when env var and file exist', () => {

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -221,18 +221,20 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
           configProperty.extension = { id: configuration.extension?.id };
         }
 
+        // Resolve declarative defaults (env:/file: arrays) at registration time
+        configProperty.default = this.resolveDeclarativeDefault(configProperty.default);
+
         // register default if not yet set
         const configurationValue = this.configurationValues.get(CONFIGURATION_DEFAULT_SCOPE);
         if (configurationValue !== undefined) {
           if (
-            configProperty.default &&
+            configProperty.default !== undefined &&
             this.isDefaultScope(configProperty.scope) &&
             configurationValue[key] === undefined
           ) {
             configurationValue[key] = configProperty.default;
           }
         }
-        configProperty.default = this.resolveEnvDefault(configProperty.default);
         configProperty.scope ??= CONFIGURATION_DEFAULT_SCOPE;
         this.configurationProperties[key] = configProperty;
       }
@@ -245,68 +247,98 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
   }
 
   /**
-   * Resolves a declarative default value by trying each entry in order
-   * and returning the first match. Supports `env:VAR` (environment variable lookup)
-   * and `file:PATH` (file existence check) prefixes. Returns the original value
-   * if it is not a declarative default, or `undefined` if no entry resolves.
+   * Resolve declarative default values declared as `env:` / `file:` entries.
+   * Supports both a single string (`"default": "env:VAR"`) and an ordered
+   * array (`"default": ["env:VAR", "file:~/.path"]`).
+   * Returns the first matching value, or `undefined` if none resolve.
+   * Non-declarative defaults (literals, object arrays, etc.) are returned unchanged.
    */
-  private resolveEnvDefault(value: unknown): unknown {
-    const entries = this.parseDefaultEntries(value);
-    if (!entries) {
-      return value;
+  protected resolveDeclarativeDefault(defaultValue: unknown): unknown {
+    // Single string form: "default": "env:VAR" or "default": "file:~/.path"
+    if (typeof defaultValue === 'string' && (defaultValue.startsWith('env:') || defaultValue.startsWith('file:'))) {
+      return this.resolveDeclarativeDefaultEntry(defaultValue);
     }
-    for (const entry of entries) {
-      if (entry.startsWith('env:')) {
-        const resolved = process.env[entry.slice(4)];
-        if (resolved) {
-          return resolved;
-        }
-      } else if (entry.startsWith('file:')) {
-        const resolved = this.resolveFilePath(entry.slice(5));
-        if (resolved) {
-          return resolved;
-        }
+
+    if (!Array.isArray(defaultValue) || defaultValue.length === 0) {
+      return defaultValue;
+    }
+
+    // Only treat as declarative when every entry is an env: or file: string
+    if (
+      !defaultValue.every(
+        (entry): entry is string =>
+          typeof entry === 'string' && (entry.startsWith('env:') || entry.startsWith('file:')),
+      )
+    ) {
+      return defaultValue;
+    }
+
+    for (const entry of defaultValue) {
+      const resolved = this.resolveDeclarativeDefaultEntry(entry);
+      if (resolved !== undefined) {
+        return resolved;
       }
     }
     return undefined;
   }
 
-  /**
-   * Parses a declarative default into an ordered list of entries.
-   * Accepts a JSON array of strings (e.g. `["env:VAR", "file:PATH"]`).
-   * Returns `undefined` for plain (non-declarative) defaults.
-   */
-  private parseDefaultEntries(value: unknown): string[] | undefined {
-    if (Array.isArray(value) && value.every(v => typeof v === 'string')) {
-      return value as string[];
+  protected resolveDeclarativeDefaultEntry(entry: string): string | undefined {
+    if (entry.startsWith('env:')) {
+      const varName = entry.slice('env:'.length);
+      if (!varName) {
+        return undefined;
+      }
+      const value = process.env[varName];
+      if (value !== undefined && value !== '') {
+        return value;
+      }
+      return undefined;
     }
+
+    if (entry.startsWith('file:')) {
+      const pathSpec = entry.slice('file:'.length);
+      if (!pathSpec) {
+        return undefined;
+      }
+      const expanded = this.expandPath(pathSpec);
+      if (expanded && fs.existsSync(expanded)) {
+        return expanded;
+      }
+      return undefined;
+    }
+
     return undefined;
   }
 
   /**
-   * Expands a file path and returns it only if the file exists on disk.
-   * Supports `~` (user home directory) and `$VAR` (environment variable, e.g. `$APPDATA`)
-   * as path prefixes for cross-platform resolution.
+   * Expand `~` (home directory) and `$VAR` environment variables in a path string.
+   * Returns `undefined` if any referenced `$VAR` is unset or empty, so we never
+   * check a truncated path like `/gcloud/creds.json` when `$APPDATA` is missing.
    */
-  private resolveFilePath(filePath: string): string | undefined {
-    let expanded: string;
-    if (filePath.startsWith('~')) {
-      expanded = path.join(homedir(), filePath.slice(1));
-    } else if (filePath.startsWith('$')) {
-      const sepIdx = filePath.indexOf('/');
-      const varName = sepIdx > 0 ? filePath.slice(1, sepIdx) : filePath.slice(1);
-      const envValue = process.env[varName];
-      if (!envValue) return undefined;
-      expanded = sepIdx > 0 ? path.join(envValue, filePath.slice(sepIdx)) : envValue;
-    } else {
-      expanded = filePath;
+  protected expandPath(pathSpec: string): string | undefined {
+    let result = pathSpec;
+
+    if (result === '~') {
+      result = homedir();
+    } else if (result.startsWith('~/') || result.startsWith('~\\')) {
+      result = path.join(homedir(), result.slice(2));
     }
-    try {
-      fs.accessSync(expanded);
-      return expanded;
-    } catch {
+
+    let unsetVariable = false;
+    result = result.replace(/\$([A-Za-z_]\w*)/g, (_match, name: string) => {
+      const value = process.env[name];
+      if (value === undefined || value === '') {
+        unsetVariable = true;
+        return '';
+      }
+      return value;
+    });
+
+    if (unsetVariable) {
       return undefined;
     }
+
+    return result;
   }
 
   private isDefaultScope(scope?: ConfigurationScope | ConfigurationScope[]): boolean {

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -18,6 +18,7 @@
 
 import * as fs from 'node:fs';
 import { promises as fsPromises } from 'node:fs';
+import { homedir } from 'node:os';
 import * as path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 
@@ -231,6 +232,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
             configurationValue[key] = configProperty.default;
           }
         }
+        configProperty.default = this.resolveEnvDefault(configProperty.default);
         configProperty.scope ??= CONFIGURATION_DEFAULT_SCOPE;
         this.configurationProperties[key] = configProperty;
       }
@@ -240,6 +242,71 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
       this._onDidUpdateConfiguration.fire({ properties });
     }
     return properties;
+  }
+
+  /**
+   * Resolves a declarative default value by trying each entry in order
+   * and returning the first match. Supports `env:VAR` (environment variable lookup)
+   * and `file:PATH` (file existence check) prefixes. Returns the original value
+   * if it is not a declarative default, or `undefined` if no entry resolves.
+   */
+  private resolveEnvDefault(value: unknown): unknown {
+    const entries = this.parseDefaultEntries(value);
+    if (!entries) {
+      return value;
+    }
+    for (const entry of entries) {
+      if (entry.startsWith('env:')) {
+        const resolved = process.env[entry.slice(4)];
+        if (resolved) {
+          return resolved;
+        }
+      } else if (entry.startsWith('file:')) {
+        const resolved = this.resolveFilePath(entry.slice(5));
+        if (resolved) {
+          return resolved;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Parses a declarative default into an ordered list of entries.
+   * Accepts a JSON array of strings (e.g. `["env:VAR", "file:PATH"]`).
+   * Returns `undefined` for plain (non-declarative) defaults.
+   */
+  private parseDefaultEntries(value: unknown): string[] | undefined {
+    if (Array.isArray(value) && value.every(v => typeof v === 'string')) {
+      return value as string[];
+    }
+    return undefined;
+  }
+
+  /**
+   * Expands a file path and returns it only if the file exists on disk.
+   * Supports `~` (user home directory) and `$VAR` (environment variable, e.g. `$APPDATA`)
+   * as path prefixes for cross-platform resolution.
+   */
+  private resolveFilePath(filePath: string): string | undefined {
+    let expanded: string;
+    if (filePath.startsWith('~')) {
+      expanded = path.join(homedir(), filePath.slice(1));
+    } else if (filePath.startsWith('$')) {
+      const sepIdx = filePath.indexOf('/');
+      const varName = sepIdx > 0 ? filePath.slice(1, sepIdx) : filePath.slice(1);
+      const envValue = process.env[varName];
+      if (!envValue) return undefined;
+      expanded = sepIdx > 0 ? path.join(envValue, filePath.slice(sepIdx)) : envValue;
+    } else {
+      expanded = filePath;
+    }
+    try {
+      fs.accessSync(expanded);
+      return expanded;
+    } catch {
+      return undefined;
+    }
   }
 
   private isDefaultScope(scope?: ConfigurationScope | ConfigurationScope[]): boolean {


### PR DESCRIPTION
## Summary

Closes #2507

Introduces a declarative mechanism for extensions to resolve configuration defaults from environment variables and file paths at registration time, without requiring new extension API surface.

- **`ConfigurationRegistry`**: Added `resolveEnvDefault`, `parseDefaultEntries`, and `resolveFilePath` methods that process `default` values declared as a JSON array of prefixed entries (`env:VAR_NAME` for environment variables, `file:PATH` for file existence checks). The `file:` prefix supports `~` (home directory) and `$VAR` (environment variable expansion, e.g. `$APPDATA`) for cross-platform path resolution.
- **Vertex AI extension**: Updated `package.json` to use the new array syntax for `projectId` (from `GOOGLE_VERTEX_PROJECT` / `ANTHROPIC_VERTEX_PROJECT_ID`), `region` (from `GOOGLE_VERTEX_LOCATION` / `CLOUD_ML_REGION`), and `credentialsFile` (from `GOOGLE_APPLICATION_CREDENTIALS`, with fallbacks to the default ADC path on both Unix and Windows).

## Test plan

- [x] Unit tests for `ConfigurationRegistry` covering: single env var resolution, array fallback ordering, file existence with `~` expansion, file existence with `$VAR` expansion, missing env var / missing file returns `undefined`, env var preferred over file fallback, non-declarative defaults left unchanged.
- [ ] Manual: set `GOOGLE_VERTEX_PROJECT` env var, open Vertex AI connection form, verify project ID field is pre-filled.
- [ ] Manual: unset all env vars, verify ADC credentials path is pre-filled if `~/.config/gcloud/application_default_credentials.json` exists (Unix) or `%APPDATA%\gcloud\application_default_credentials.json` exists (Windows).
- [ ] Manual: unset all env vars and remove ADC file, verify credentials field is empty.