### PR TITLE
ci: work around podman/crun OCI runtime-spec mismatch on ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/e2e-test-job.yaml
+++ b/.github/workflows/e2e-test-job.yaml
@@ -133,7 +133,9 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           CRUN_VERSION=1.28
+          CRUN_SHA256=2aa6b7024a9c9f153895c0d11ae233d3758f54844011c3a039e3e89048d01d42
           curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+          echo "${CRUN_SHA256}  /tmp/crun" | sha256sum -c -
           chmod +x /tmp/crun
           sudo mv /tmp/crun /usr/bin/crun
           crun --version

--- a/.github/workflows/e2e-test-job.yaml
+++ b/.github/workflows/e2e-test-job.yaml
@@ -123,6 +123,21 @@ jobs:
         timeout-minutes: 3
         run: npx playwright install chromium
 
+      # TEMPORARY: the ubuntu-24.04 runner image bumped Podman to >=5.6.2, which emits
+      # OCI runtime-spec v1.2.0/1.2.1. crun <1.14.3 has a version-check bug that rejects
+      # that spec ("crun: unknown version specified"), breaking every container-backed
+      # provider (Docling, Milvus, ...). Fixed upstream in crun 1.14.3.
+      # https://github.com/containers/podman/issues/27272
+      # Remove once the runner image ships a compatible crun.
+      - name: Upgrade crun (workaround for podman/crun OCI runtime-spec mismatch)
+        if: runner.os == 'Linux'
+        run: |
+          CRUN_VERSION=1.28
+          curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+          chmod +x /tmp/crun
+          sudo mv /tmp/crun /usr/bin/crun
+          crun --version
+
       - name: Enable Podman socket
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
## Summary

Every e2e job on `ubuntu-24.04` that creates a Podman-backed provider (Docling,
Milvus) is currently failing with:

```
Error: (HTTP code 500) server error - crun: unknown version specified: OCI runtime error
```

This blocks `knowledge-env-smoke.spec.ts` (KDB-02, KDB-07, and anything
downstream) on every PR and nightly run right now, regardless of the PR's
actual changes.

## Root Cause

The `ubuntu-24.04` GitHub-hosted runner image was updated recently, bumping
Podman from 4.9.3 to 5.8.4 while leaving crun at 1.14.1. Podman ≥5.6.2 emits
OCI runtime-spec v1.2.0/1.2.1 by default, and crun <1.14.3 has a known
version-check bug that rejects that spec string — fixed upstream in crun
1.14.3 ([containers/podman#27272](https://github.com/containers/podman/issues/27272)).

This PR pins crun to 1.28 on Linux e2e runners as a temporary workaround,
removable once the runner image ships a compatible crun.