### PR TITLE
feat: allow user to specify a custom container image for workspaces

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -101,6 +101,7 @@ export function getSandboxNameValidationError(name: string): string | undefined 
 export interface AgentWorkspaceCreateOptions {
   sourcePath?: string;
   agent: string;
+  image?: string;
   model: string;
   gateway: string;
   name?: string;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -529,6 +529,36 @@ describe('create – OpenShell mode', () => {
     );
   });
 
+  test('uses user-specified image over agent baseImage when provided', async () => {
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({
+      ...mockAgent,
+      baseImage: 'registry.example.com/agent-base:v1',
+    });
+
+    await manager.create({ ...defaultOptions, image: 'custom-registry.io/my-image:latest' });
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'custom-registry.io/my-image:latest',
+      }),
+    );
+  });
+
+  test('falls back to agent baseImage when image option is undefined', async () => {
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({
+      ...mockAgent,
+      baseImage: 'registry.example.com/agent-base:v1',
+    });
+
+    await manager.create({ ...defaultOptions, image: undefined });
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'registry.example.com/agent-base:v1',
+      }),
+    );
+  });
+
   test('calls agent.preWorkspaceStart with correct context', async () => {
     const preWorkspaceStart = vi.fn();
     vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({ ...mockAgent, preWorkspaceStart });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -259,7 +259,7 @@ export class AgentWorkspaceManager implements Disposable {
     await this.openshellCli.createSandbox({
       name: sandboxName,
       gateway: options.gateway,
-      from: agent.baseImage,
+      from: options.image ?? agent.baseImage,
       providers: options.secrets,
       env: env && Object.keys(env).length > 0 ? env : undefined,
       labels: {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -134,6 +134,8 @@ function clearProject(): void {
   wizard.draft.selectedNetwork = 'registries';
   wizard.draft.customMounts = [{ host: '', target: '', ro: false }];
   wizard.draft.hostsByMode = { registries: ['registry.npmjs.org', 'pypi.python.org'], blocked: [''] };
+  const agentInfo = $agentInfos.find(a => a.id === wizard.draft.selectedAgent);
+  wizard.draft.customImage = agentInfo?.baseImage ?? '';
 }
 
 function handleProjectSelect(project: WorkspaceProjectInfo | undefined): void {
@@ -206,6 +208,9 @@ onMount(async () => {
         wizard.draft.selectedModel = firstModel;
       }
     }
+
+    const agentInfo = $agentInfos.find(a => a.id === wizard.draft.selectedAgent);
+    wizard.draft.customImage = agentInfo?.baseImage ?? '';
 
     wizard.draft.initialized = true;
   }
@@ -487,6 +492,7 @@ function startAsIs(): void {
     .createAgentWorkspace({
       sourcePath: draftSnapshot.sourcePath.trim() || undefined,
       agent: draftSnapshot.selectedAgent,
+      image: draftSnapshot.customImage.trim() || undefined,
       model: getModelId(draftSnapshot.selectedModel!),
       gateway: draftSnapshot.selectedGateway,
       name: getEffectiveWorkspaceNameFromSnapshot(draftSnapshot),
@@ -546,6 +552,7 @@ function startWorkspace(): void {
     .createAgentWorkspace({
       sourcePath: draftSnapshot.sourcePath.trim() || undefined,
       agent: draftSnapshot.selectedAgent,
+      image: draftSnapshot.customImage.trim() || undefined,
       model: getModelId(draftSnapshot.selectedModel!),
       gateway: draftSnapshot.selectedGateway,
       name: getEffectiveWorkspaceNameFromSnapshot(draftSnapshot),
@@ -622,7 +629,7 @@ function startWorkspace(): void {
                 onProjectSelect={handleProjectSelect}
                 errors={validationErrors} />
             {:else if currentStepId === 'agent-model'}
-              <AgentWorkspaceCreateStepAgentModel bind:selectedAgent={wizard.draft.selectedAgent} bind:selectedModel={wizard.draft.selectedModel} />
+              <AgentWorkspaceCreateStepAgentModel bind:selectedAgent={wizard.draft.selectedAgent} bind:selectedModel={wizard.draft.selectedModel} bind:customImage={wizard.draft.customImage} bind:customImageFieldOpen={wizard.draft.customImageFieldOpen} />
             {:else if currentStepId === 'tools-secrets'}
               <AgentWorkspaceCreateStepToolsSecrets
                 {skillItems}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { untrack } from 'svelte';
 
@@ -15,9 +16,16 @@ import { catalogModels } from '/@/stores/models';
 interface Props {
   selectedAgent?: string;
   selectedModel?: ModelInfo;
+  customImage?: string;
+  customImageFieldOpen?: boolean;
 }
 
-let { selectedAgent = $bindable(''), selectedModel = $bindable() }: Props = $props();
+let {
+  selectedAgent = $bindable(''),
+  selectedModel = $bindable(),
+  customImage = $bindable(''),
+  customImageFieldOpen = $bindable(false),
+}: Props = $props();
 
 let filteredAgents = $derived(
   $agentInfos.toSorted((a, b) => {
@@ -57,6 +65,11 @@ function handleModelSelect(model: CatalogModelInfo): void {
 function selectAgent(value: string): void {
   if (selectedAgent === value) return;
   selectedAgent = value;
+  customImage = filteredAgents.find(a => a.id === value)?.baseImage ?? '';
+}
+
+function toggleCustomImageField(): void {
+  customImageFieldOpen = !customImageFieldOpen;
 }
 
 $effect(() => {
@@ -119,6 +132,35 @@ $effect(() => {
         </button>
       {/each}
     </div>
+  </div>
+
+  <!-- Container image override -->
+  <div class="rounded-xl border border-[var(--pd-content-card-border)]/85 bg-[var(--pd-content-card-bg)]/35 overflow-hidden">
+    <button
+      class="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-[var(--pd-modal-text)] hover:bg-[var(--pd-content-card-inset-bg)]/50 transition-colors cursor-pointer"
+      onclick={toggleCustomImageField}>
+      <span>
+        Container image <span class="text-xs font-normal opacity-50">(optional)</span>
+      </span>
+      <span
+        class="transition-transform duration-150 {customImageFieldOpen ? 'rotate-180' : ''}"
+        aria-hidden="true">
+        <Icon icon={faChevronDown} size="xs" />
+      </span>
+    </button>
+    {#if customImageFieldOpen}
+      <div class="px-4 pb-4">
+        <label for="workspace-custom-image" class="block text-xs text-[var(--pd-content-card-text)] opacity-60 mb-1.5">
+          Override the base container image for the workspace.
+        </label>
+        <Input
+          id="workspace-custom-image"
+          bind:value={customImage}
+          placeholder={selectedAgentInfo?.baseImage ?? 'Default agent image'}
+          class="w-full font-mono text-sm"
+        />
+      </div>
+    {/if}
   </div>
 
   <!-- Model catalog -->

--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
@@ -49,6 +49,8 @@ interface WorkspaceCreateDraft {
   selectedMcpIds: string[];
   selectedSecretIds: string[];
   selectedKnowledgeIds: string[];
+  customImage: string;
+  customImageFieldOpen: boolean;
   initialized: boolean;
 }
 
@@ -78,6 +80,8 @@ function createInitialDraft(): WorkspaceCreateDraft {
     selectedMcpIds: [],
     selectedSecretIds: [],
     selectedKnowledgeIds: [],
+    customImage: '',
+    customImageFieldOpen: false,
     initialized: false,
   };
 }


### PR DESCRIPTION
## Summary
- Add a collapsible "Container image" field to the Agent & Model step of the workspace creation wizard — users can now override the agent's default base image when creating a workspace
- The field defaults to the selected agent's `baseImage` and updates automatically when the user switches agents
- On the backend, `options.image` takes precedence over `agent.baseImage` when calling `openshellCli.createSandbox()`

<img width="1162" height="812" alt="image" src="https://github.com/user-attachments/assets/57313886-81b0-4c5f-837c-1bea0d379c92" />


Fixes #2555

## Testing

I used `ghcr.io/openkaiden/kaiden-fullsend-image` image as a custom image in the step (this is the image used to run fullsend)

then running `podman ps` command, I can see that my workspace container is using this container image
