### PR TITLE
fix(openshell): pin secret operations to gateways

### DIFF
--- a/packages/api/src/secret-info.ts
+++ b/packages/api/src/secret-info.ts
@@ -30,6 +30,11 @@ export type SecretName = components['schemas']['SecretName'];
  */
 export type SecretInfo = components['schemas']['SecretInfo'];
 
+/** Secret metadata together with the OpenShell gateway that owns it. */
+export interface GatewaySecretInfo extends SecretInfo {
+  gateway: string;
+}
+
 /**
  * Options for creating a new secret via `kdn secret create`.
  */
@@ -53,6 +58,6 @@ export interface SecretCreateOptions extends SecretInfo {
 export interface SecretCliBackend {
   createSecret(options: SecretCreateOptions, gateway?: string): Promise<SecretName>;
   listSecrets(gateway?: string): Promise<SecretInfo[]>;
-  removeSecret(name: string): Promise<SecretName>;
+  removeSecret(name: string, gateway?: string): Promise<SecretName>;
   listServices(): Promise<OpenshellProfile[]>;
 }

--- a/packages/api/src/secret-vault/secret-vault-info.ts
+++ b/packages/api/src/secret-vault/secret-vault-info.ts
@@ -19,6 +19,7 @@
 export interface SecretVaultInfo {
   id: string;
   name: string;
+  gateway?: string;
   type?: string;
   description?: string;
   hosts?: string[];

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -1368,6 +1368,19 @@ describe('deleteProvider', () => {
 
     await expect(openshellCli.deleteProvider('unknown')).rejects.toThrow('provider not found: unknown');
   });
+
+  test('deletes provider from the selected gateway', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.deleteProvider('my-openai', 'remote');
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['provider', 'delete', 'my-openai', '-g', 'remote'],
+      undefined,
+    );
+  });
 });
 
 describe('createProvider', () => {

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -468,8 +468,12 @@ export class OpenshellCli {
     return z.array(OpenshellProfileSchema).parse(data);
   }
 
-  async deleteProvider(name: string): Promise<void> {
-    await this.runCli(['provider', 'delete', name]);
+  async deleteProvider(name: string, gateway?: string): Promise<void> {
+    const args = ['provider', 'delete', name];
+    if (gateway) {
+      args.push('-g', gateway);
+    }
+    await this.runCli(args);
   }
 
   async createProvider(options: CreateProviderOptions, gateway?: string): Promise<void> {

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
@@ -152,7 +152,7 @@ describe('removeSecret', () => {
 
     const result = await adapter.removeSecret('my-openai');
 
-    expect(openshellCli.deleteProvider).toHaveBeenCalledWith('my-openai');
+    expect(openshellCli.deleteProvider).toHaveBeenCalledWith('my-openai', undefined);
     expect(result).toEqual({ name: 'my-openai' });
   });
 

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
@@ -62,8 +62,12 @@ export class OpenshellSecretAdapter implements SecretCliBackend {
     return await this.openshellCli.listProviders(gateway);
   }
 
-  async removeSecret(name: string): Promise<SecretName> {
-    await this.openshellCli.deleteProvider(name);
+  async removeSecret(name: string, gateway?: string): Promise<SecretName> {
+    if (gateway) {
+      await this.openshellCli.deleteProvider(name, gateway);
+    } else {
+      await this.openshellCli.deleteProvider(name);
+    }
     return { name };
   }
 

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
@@ -63,11 +63,7 @@ export class OpenshellSecretAdapter implements SecretCliBackend {
   }
 
   async removeSecret(name: string, gateway?: string): Promise<SecretName> {
-    if (gateway) {
-      await this.openshellCli.deleteProvider(name, gateway);
-    } else {
-      await this.openshellCli.deleteProvider(name);
-    }
+    await this.openshellCli.deleteProvider(name, gateway);
     return { name };
   }
 

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -24,6 +24,7 @@ import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import type { OpenshellGatewayStateManager } from '/@/plugin/openshell-cli/openshell-gateway-state-manager.js';
 import type { ProviderImpl } from '/@/plugin/provider-impl.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
@@ -83,6 +84,11 @@ const openshellGateway = {
   }),
 } as unknown as OpenshellGateway;
 
+const openshellGatewayStateManager = {
+  whenReady: vi.fn().mockResolvedValue(undefined),
+  listGateways: vi.fn().mockReturnValue([{ name: 'kaiden', endpoint: 'http://localhost' }]),
+} as unknown as OpenshellGatewayStateManager;
+
 const mockWatcher = {
   onDidChange: vi.fn(),
   onDidCreate: vi.fn(),
@@ -99,6 +105,10 @@ beforeEach(() => {
   unregisterInferenceCallback = undefined;
   vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
   vi.mocked(safeStorageRegistry.getExtensionStorage).mockReturnValue(extensionStorageMock);
+  vi.mocked(openshellGatewayStateManager.whenReady).mockResolvedValue(undefined);
+  vi.mocked(openshellGatewayStateManager.listGateways).mockReturnValue([
+    { name: 'kaiden', endpoint: 'http://localhost' },
+  ]);
   manager = new SecretManager(
     apiSender,
     ipcHandle,
@@ -107,6 +117,7 @@ beforeEach(() => {
     configurationRegistry,
     safeStorageRegistry,
     openshellGateway,
+    openshellGatewayStateManager,
   );
   manager.init();
 });
@@ -156,6 +167,10 @@ describe('openshellAdapter', () => {
     unregisterInferenceCallback = undefined;
     vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
     vi.mocked(safeStorageRegistry.getExtensionStorage).mockReturnValue(extensionStorageMock);
+    vi.mocked(openshellGatewayStateManager.whenReady).mockResolvedValue(undefined);
+    vi.mocked(openshellGatewayStateManager.listGateways).mockReturnValue([
+      { name: 'kaiden', endpoint: 'http://localhost' },
+    ]);
     manager = new SecretManager(
       apiSender,
       ipcHandle,
@@ -164,6 +179,7 @@ describe('openshellAdapter', () => {
       configurationRegistry,
       safeStorageRegistry,
       openshellGateway,
+      openshellGatewayStateManager,
     );
     manager.init();
   });
@@ -192,9 +208,51 @@ describe('openshellAdapter', () => {
 
     const result = await manager.list();
 
-    expect(openshellCli.listProviders).toHaveBeenCalled();
+    expect(openshellCli.listProviders).toHaveBeenCalledWith('kaiden');
     expect(result).toHaveLength(2);
     expect(result.map(s => s.name)).toEqual(['my-openai', 'my-anthropic']);
+  });
+
+  test('lists providers from every gateway and records their owning gateway', async () => {
+    vi.mocked(openshellGatewayStateManager.listGateways).mockReturnValue([
+      { name: 'local', endpoint: 'http://local' },
+      { name: 'remote', endpoint: 'http://remote' },
+    ]);
+    vi.mocked(openshellCli.listProviders).mockImplementation(async gateway => {
+      return gateway === 'local'
+        ? [{ name: 'shared-provider', type: 'openai' }]
+        : [{ name: 'shared-provider', type: 'anthropic' }];
+    });
+
+    await expect(manager.list()).resolves.toEqual([
+      { name: 'shared-provider', type: 'openai', gateway: 'local' },
+      { name: 'shared-provider', type: 'anthropic', gateway: 'remote' },
+    ]);
+    expect(openshellCli.listProviders).toHaveBeenNthCalledWith(1, 'local');
+    expect(openshellCli.listProviders).toHaveBeenNthCalledWith(2, 'remote');
+  });
+
+  test('lists providers only from the requested gateway', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([{ name: 'remote-provider', type: 'openai' }]);
+
+    await expect(manager.list('remote')).resolves.toEqual([
+      { name: 'remote-provider', type: 'openai', gateway: 'remote' },
+    ]);
+    expect(openshellGatewayStateManager.whenReady).not.toHaveBeenCalled();
+    expect(openshellCli.listProviders).toHaveBeenCalledWith('remote');
+  });
+
+  test('keeps providers from reachable gateways when another gateway fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(openshellGatewayStateManager.listGateways).mockReturnValue([
+      { name: 'offline', endpoint: 'http://offline' },
+      { name: 'online', endpoint: 'http://online' },
+    ]);
+    vi.mocked(openshellCli.listProviders)
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValueOnce([{ name: 'available-provider', type: 'openai' }]);
+
+    await expect(manager.list()).resolves.toEqual([{ name: 'available-provider', type: 'openai', gateway: 'online' }]);
   });
 
   test('delegates remove to openshellAdapter', async () => {
@@ -204,6 +262,14 @@ describe('openshellAdapter', () => {
 
     expect(openshellCli.deleteProvider).toHaveBeenCalledWith('my-openai');
     expect(result).toEqual({ name: 'my-openai' });
+  });
+
+  test('removes a provider from its owning gateway', async () => {
+    vi.mocked(openshellCli.deleteProvider).mockResolvedValue(undefined);
+
+    await manager.remove('my-openai', 'remote');
+
+    expect(openshellCli.deleteProvider).toHaveBeenCalledWith('my-openai', 'remote');
   });
 
   test('listServices delegates to openshellAdapter', async () => {
@@ -257,7 +323,7 @@ describe('inference connection lifecycle', () => {
     });
 
     await vi.waitFor(() => {
-      expect(openshellCli.deleteProvider).toHaveBeenCalledWith('kaiden.cursor-conn-123');
+      expect(openshellCli.deleteProvider).toHaveBeenCalledWith('kaiden.cursor-conn-123', 'kaiden');
     });
   });
 

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -260,7 +260,7 @@ describe('openshellAdapter', () => {
 
     const result = await manager.remove('my-openai');
 
-    expect(openshellCli.deleteProvider).toHaveBeenCalledWith('my-openai');
+    expect(openshellCli.deleteProvider).toHaveBeenCalledWith('my-openai', undefined);
     expect(result).toEqual({ name: 'my-openai' });
   });
 

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -96,7 +96,7 @@ export class SecretManager {
   }
 
   async remove(name: string, gateway?: string): Promise<SecretName> {
-    const result = gateway ? await this.cli.removeSecret(name, gateway) : await this.cli.removeSecret(name);
+    const result = await this.cli.removeSecret(name, gateway);
     this.apiSender.send('secret-manager-update');
     return result;
   }
@@ -113,16 +113,9 @@ export class SecretManager {
     const secrets = await this.list(gateway);
     const secret = secrets.find(s => s.name === expectedName);
     if (!secret) return undefined;
-    return {
-      name: secret.name,
-      type: secret.type,
-      description: secret.description,
-      envs: secret.envs,
-      hosts: secret.hosts,
-      path: secret.path,
-      header: secret.header,
-      headerTemplate: secret.headerTemplate,
-    };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, sonarjs/no-unused-vars -- gateway is intentionally omitted
+    const { gateway: _, ...secretInfo } = secret;
+    return secretInfo;
   }
 
   async ensureSecretForModel(modelId: string, gateway?: string): Promise<SecretInfo | undefined> {

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -21,13 +21,21 @@ import { inject, injectable } from 'inversify';
 
 import { IPCHandle } from '/@/plugin/api.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import { OpenshellGatewayStateManager } from '/@/plugin/openshell-cli/openshell-gateway-state-manager.js';
 import { ProviderImpl } from '/@/plugin/provider-impl.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import { IConfigurationPropertyRecordedSchema, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { OpenshellProfile } from '/@api/openshell-gateway-info.js';
-import type { SecretCliBackend, SecretCreateOptions, SecretInfo, SecretName, SecretValue } from '/@api/secret-info.js';
+import type {
+  GatewaySecretInfo,
+  SecretCliBackend,
+  SecretCreateOptions,
+  SecretInfo,
+  SecretName,
+  SecretValue,
+} from '/@api/secret-info.js';
 
 import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
 
@@ -52,6 +60,8 @@ export class SecretManager {
     private readonly safeStorageRegistry: SafeStorageRegistry,
     @inject(OpenshellGateway)
     private readonly openshellGateway: OpenshellGateway,
+    @inject(OpenshellGatewayStateManager)
+    private readonly openshellGatewayStateManager: OpenshellGatewayStateManager,
   ) {}
 
   private get cli(): SecretCliBackend {
@@ -64,12 +74,29 @@ export class SecretManager {
     return result;
   }
 
-  async list(gateway?: string): Promise<SecretInfo[]> {
-    return this.cli.listSecrets(gateway);
+  async list(gateway?: string): Promise<GatewaySecretInfo[]> {
+    if (gateway) {
+      const secrets = await this.cli.listSecrets(gateway);
+      return secrets.map(secret => ({ ...secret, gateway }));
+    }
+
+    await this.openshellGatewayStateManager.whenReady();
+    const results: GatewaySecretInfo[] = [];
+    for (const registeredGateway of this.openshellGatewayStateManager.listGateways()) {
+      try {
+        const secrets = await this.cli.listSecrets(registeredGateway.name);
+        results.push(...secrets.map(secret => ({ ...secret, gateway: registeredGateway.name })));
+      } catch (err: unknown) {
+        console.warn(
+          `[openshell] failed to list providers for gateway ${registeredGateway.name}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return results;
   }
 
-  async remove(name: string): Promise<SecretName> {
-    const result = await this.cli.removeSecret(name);
+  async remove(name: string, gateway?: string): Promise<SecretName> {
+    const result = gateway ? await this.cli.removeSecret(name, gateway) : await this.cli.removeSecret(name);
     this.apiSender.send('secret-manager-update');
     return result;
   }
@@ -84,7 +111,18 @@ export class SecretManager {
 
     const expectedName = `${info.providerId}-${info.connection.id}`;
     const secrets = await this.list(gateway);
-    return secrets.find(s => s.name === expectedName);
+    const secret = secrets.find(s => s.name === expectedName);
+    if (!secret) return undefined;
+    return {
+      name: secret.name,
+      type: secret.type,
+      description: secret.description,
+      envs: secret.envs,
+      hosts: secret.hosts,
+      path: secret.path,
+      header: secret.header,
+      headerTemplate: secret.headerTemplate,
+    };
   }
 
   async ensureSecretForModel(modelId: string, gateway?: string): Promise<SecretInfo | undefined> {
@@ -186,10 +224,10 @@ export class SecretManager {
   private async onInferenceConnectionUnregistered(event: UnregisterInferenceConnectionEvent): Promise<void> {
     const expectedName = `${event.providerId}-${event.connection.id}`;
     const secrets = await this.list();
-    const secret = secrets.find(s => s.name === expectedName);
-    if (secret) {
+    const matchingSecrets = secrets.filter(s => s.name === expectedName);
+    for (const secret of matchingSecrets) {
       try {
-        await this.remove(secret.name);
+        await this.remove(secret.name, secret.gateway);
       } catch (err: unknown) {
         console.warn(`Failed to delete openshell provider ${secret.name}:`, err);
       }
@@ -218,9 +256,12 @@ export class SecretManager {
       return this.list(gateway);
     });
 
-    this.ipcHandle('secret-manager:remove', async (_listener: unknown, name: string): Promise<SecretName> => {
-      return this.remove(name);
-    });
+    this.ipcHandle(
+      'secret-manager:remove',
+      async (_listener: unknown, name: string, gateway?: string): Promise<SecretName> => {
+        return this.remove(name, gateway);
+      },
+    );
 
     this.ipcHandle('secret-manager:list-services', async (): Promise<OpenshellProfile[]> => {
       return this.listServices();

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -151,7 +151,7 @@ import type { PullEvent } from '/@api/pull-event';
 import type { RagEnvironment } from '/@api/rag/rag-environment';
 import type { ExtensionBanner, RecommendedRegistry } from '/@api/recommendations/recommendations';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info';
-import type { SecretCreateOptions, SecretInfo, SecretName } from '/@api/secret-info';
+import type { GatewaySecretInfo, SecretCreateOptions, SecretName } from '/@api/secret-info';
 import type { SemanticRouterConfigInfo, SemanticRouterInfo } from '/@api/semantic-router-info';
 import type { SkillFileContent, SkillFolderInfo, SkillInfo, SkillResourceEntry } from '/@api/skill/skill-info';
 import type { StatusBarEntryDescriptor } from '/@api/status-bar';
@@ -532,12 +532,12 @@ export function initExposure(): void {
     return ipcInvoke('secret-manager:create', options);
   });
 
-  contextBridge.exposeInMainWorld('listSecrets', async (gateway?: string): Promise<SecretInfo[]> => {
+  contextBridge.exposeInMainWorld('listSecrets', async (gateway?: string): Promise<GatewaySecretInfo[]> => {
     return ipcInvoke('secret-manager:list', gateway);
   });
 
-  contextBridge.exposeInMainWorld('removeSecret', async (name: string): Promise<SecretName> => {
-    return ipcInvoke('secret-manager:remove', name);
+  contextBridge.exposeInMainWorld('removeSecret', async (name: string, gateway?: string): Promise<SecretName> => {
+    return ipcInvoke('secret-manager:remove', name, gateway);
   });
 
   contextBridge.exposeInMainWorld('listSecretServices', async (): Promise<OpenshellProfile[]> => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -572,11 +572,13 @@ test('Expect secrets listed from the selected gateway', async () => {
             name: 'github-token',
             type: 'github',
             description: 'Personal access token',
+            gateway: 'remote',
           },
           {
             name: 'anthropic-key',
             type: 'anthropic',
             description: 'API key',
+            gateway: 'remote',
           },
         ]
       : [
@@ -584,6 +586,7 @@ test('Expect secrets listed from the selected gateway', async () => {
             name: 'local-only-secret',
             type: 'generic',
             description: 'Only available on the local gateway',
+            gateway: 'local',
           },
         ],
   );
@@ -603,7 +606,7 @@ test('Expect secrets listed from the selected gateway', async () => {
 });
 
 test('Expect stale secret selections cleared and Continue disabled while gateway secrets load', async () => {
-  let resolveSecrets: (secrets: { name: string; type: string; description: string }[]) => void;
+  let resolveSecrets: (secrets: { name: string; type: string; description: string; gateway: string }[]) => void;
   vi.mocked(window.listSecrets).mockImplementation(
     () =>
       new Promise(resolve => {
@@ -619,7 +622,9 @@ test('Expect stale secret selections cleared and Continue disabled while gateway
   expect(wizard.draft.selectedSecretIds).toEqual([]);
   expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
 
-  resolveSecrets!([{ name: 'remote-secret', type: 'generic', description: 'Remote gateway secret' }]);
+  resolveSecrets!([
+    { name: 'remote-secret', type: 'generic', description: 'Remote gateway secret', gateway: 'remote' },
+  ]);
 
   await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled());
 });

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetails.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetails.spec.ts
@@ -48,12 +48,14 @@ const githubSecret: SecretVaultInfo = {
   path: '/v3',
   header: 'Authorization',
   headerTemplate: 'token {{secret}}',
+  gateway: 'kaiden',
 };
 
 const minimalSecret: SecretVaultInfo = {
   id: 'my-other-secret',
   name: 'Other secret',
   type: 'other',
+  gateway: 'remote',
 };
 
 beforeEach(() => {
@@ -109,7 +111,7 @@ test('should remove secret and navigate to list when user confirms removal', asy
   await fireEvent.click(removeButton);
 
   await waitFor(() => {
-    expect(window.removeSecret).toHaveBeenCalledWith('github-pat');
+    expect(window.removeSecret).toHaveBeenCalledWith('GitHub', 'kaiden');
   });
 
   expect(router.goto).toHaveBeenCalledWith('/secret-vault');

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetails.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetails.svelte
@@ -29,7 +29,10 @@ function handleRemove(): void {
   withConfirmation(
     async () => {
       try {
-        await window.removeSecret(id);
+        if (!secretInfo) {
+          return;
+        }
+        await window.removeSecret(secretInfo.name, secretInfo.gateway);
         router.goto('/secret-vault');
       } catch (error: unknown) {
         console.error('Failed to remove secret', error);

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetails.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetails.svelte
@@ -26,20 +26,17 @@ const secretInfo: SecretVaultInfo | undefined = $derived($secretVaultInfos.find(
 const secretIcon = $derived(getSecretIcon(secretInfo?.type));
 
 function handleRemove(): void {
-  withConfirmation(
-    async () => {
-      try {
-        if (!secretInfo) {
-          return;
-        }
-        await window.removeSecret(secretInfo.name, secretInfo.gateway);
-        router.goto('/secret-vault');
-      } catch (error: unknown) {
-        console.error('Failed to remove secret', error);
-      }
-    },
-    `remove secret ${secretInfo?.name ?? id}`,
-  );
+  if (!secretInfo) {
+    return;
+  }
+  withConfirmation(async () => {
+    try {
+      await window.removeSecret(secretInfo.name, secretInfo.gateway);
+      router.goto('/secret-vault');
+    } catch (error: unknown) {
+      console.error('Failed to remove secret', error);
+    }
+  }, `remove secret ${secretInfo.name}`);
 }
 </script>
 

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultActions.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultActions.spec.ts
@@ -30,6 +30,7 @@ const secret: SecretVaultInfo = {
   name: 'GitHub',
   type: 'github',
   description: 'Personal access token',
+  gateway: 'kaiden',
 };
 
 beforeEach(() => {
@@ -63,7 +64,7 @@ test('should remove secret when user confirms removal', async () => {
   await fireEvent.click(removeButton);
 
   await waitFor(() => {
-    expect(window.removeSecret).toHaveBeenCalledWith('github-pat');
+    expect(window.removeSecret).toHaveBeenCalledWith('GitHub', 'kaiden');
   });
 });
 

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultActions.svelte
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultActions.svelte
@@ -12,7 +12,10 @@ interface Props {
 let { object }: Props = $props();
 
 function handleRemove(): void {
-  withConfirmation(() => window.removeSecret(object.id).catch(console.error), `remove secret ${object.name}`);
+  withConfirmation(
+    () => window.removeSecret(object.name, object.gateway).catch(console.error),
+    `remove secret ${object.name}`,
+  );
 }
 </script>
 

--- a/packages/renderer/src/stores/secret-vault.ts
+++ b/packages/renderer/src/stores/secret-vault.ts
@@ -20,15 +20,16 @@ import type { Writable } from 'svelte/store';
 import { derived, writable } from 'svelte/store';
 
 import { findMatchInLeaves } from '/@/stores/search-util';
-import type { SecretInfo } from '/@api/secret-info';
+import type { GatewaySecretInfo } from '/@api/secret-info';
 import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
 
 import { EventStore } from './event-store';
 
-function secretInfoToVaultInfo(info: SecretInfo): SecretVaultInfo {
+function secretInfoToVaultInfo(info: GatewaySecretInfo): SecretVaultInfo {
   return {
-    id: info.name,
+    id: `${info.gateway}/${info.name}`,
     name: info.name,
+    gateway: info.gateway,
     type: info.type,
     description: info.description,
     hosts: info.hosts,

--- a/packages/renderer/src/stores/secret-vault.ts
+++ b/packages/renderer/src/stores/secret-vault.ts
@@ -27,16 +27,8 @@ import { EventStore } from './event-store';
 
 function secretInfoToVaultInfo(info: GatewaySecretInfo): SecretVaultInfo {
   return {
+    ...info,
     id: `${info.gateway}/${info.name}`,
-    name: info.name,
-    gateway: info.gateway,
-    type: info.type,
-    description: info.description,
-    hosts: info.hosts,
-    path: info.path,
-    header: info.header,
-    headerTemplate: info.headerTemplate,
-    envs: info.envs,
   };
 }
 


### PR DESCRIPTION
## Summary

OpenShell providers are scoped to gateways, but Kaiden previously treated provider names as globally unique. This caused secret-vault entries from different gateways to collide and could send deletion to the wrong gateway.

This change makes the owning gateway part of each secret's identity across the main process, preload bridge, renderer store, and Secret Vault UI. Kaiden now:

- lists providers from every registered OpenShell gateway while retaining gateway ownership
- keeps same-named providers from different gateways as distinct Secret Vault entries
- routes provider lookup and deletion to the gateway that owns the selected secret
- continues listing secrets from reachable gateways when another gateway is unavailable

Fixes #2525

## Try it locally

Use a fake credential so no real token is required. Replace `<gateway>` with a name from `openshell gateway list`.

```bash
openshell provider create \
  -g <gateway> \
  --name kaiden-gateway-smoke \
  --type github \
  --credential api_token=not-a-real-token

openshell provider list -g <gateway> --names
pnpm watch
```

In Kaiden:

1. Open **Secret Vault** and confirm `kaiden-gateway-smoke` is listed.
2. Open or remove that entry.
3. Confirm it was removed from the owning gateway:

```bash
openshell provider list -g <gateway> --names
```

If you have two gateways, create `kaiden-gateway-smoke` on both. Secret Vault should show two distinct entries, and removing either entry should leave the provider on the other gateway intact.

Clean up any remaining test provider with:

```bash
openshell provider delete kaiden-gateway-smoke -g <gateway>
```
