### PR TITLE
fix(settings): feedback reminder tab in preferences

### DIFF
--- a/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
@@ -131,12 +131,12 @@ describe('init', () => {
     expect(registerConfigurationsMock).toHaveBeenCalledTimes(1);
     expect(registerConfigurationsMock).toHaveBeenCalledWith([
       {
-        id: 'preferences',
-        title: 'Feedback dialog',
+        id: 'preferences.feedback',
+        title: 'Feedback reminder',
         type: 'object',
         properties: {
           'feedback.dialog': {
-            description: 'Show feedback dialog for experimental features',
+            description: 'Show periodic feedback reminder for experimental features',
             type: 'boolean',
             default: true,
           },

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -77,12 +77,12 @@ export class ExperimentalFeatureFeedbackHandler {
 
   async init(): Promise<void> {
     const feedbackConfiguration: IConfigurationNode = {
-      id: 'preferences',
-      title: 'Feedback dialog',
+      id: 'preferences.feedback',
+      title: 'Feedback reminder',
       type: 'object',
       properties: {
         ['feedback.dialog']: {
-          description: 'Show feedback dialog for experimental features',
+          description: 'Show periodic feedback reminder for experimental features',
           type: 'boolean',
           default: true,
         },


### PR DESCRIPTION
## Summary
- Scope the feedback reminder configuration under `preferences.feedback` (instead of `preferences`) so its settings tree-item opens its own tab instead of all Preferences
- Rename the setting to "Feedback reminder" with a clearer description ("Show periodic feedback reminder for experimental features")
- Cherry-picked from upstream podman-desktop fixes for the same issue

## Test plan
- [x] `experimental-feature-feedback-handler.spec.ts` unit tests pass (20/20)
- [x] Manually verify clicking the feedback reminder item in Settings > Preferences opens only its own tab

<img width="1593" height="692" alt="Screenshot 2026-08-05 at 10 38 38 AM" src="https://github.com/user-attachments/assets/829c0f7d-cb57-44bb-8420-48eaeab605d9" />

fixes #1631