### PR TITLE
fix(openshell): use non-expiring JWTs for local gateway

### DIFF
--- a/extensions/openshell-podman-gateway/src/manager/gateway-container-manager.spec.ts
+++ b/extensions/openshell-podman-gateway/src/manager/gateway-container-manager.spec.ts
@@ -589,6 +589,22 @@ describe('GatewayContainerManager', () => {
     );
   });
 
+  test('should generate gateway config with non-expiring JWTs (ttl_secs = 0)', async () => {
+    const { writeFile: writeFileMock } = await import('node:fs/promises');
+
+    Object.defineProperty(env, 'isWindows', { value: true, configurable: true });
+    setupCliMock('/usr/bin/openshell');
+    setupFollowProgress();
+    vi.mocked(processApi.exec).mockResolvedValue({ stdout: '', stderr: '', command: '' });
+
+    await gatewayContainerManager.init();
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      expect.stringContaining('gateway.toml'),
+      expect.stringContaining('ttl_secs = 0'),
+    );
+  });
+
   test('should mount gateway directory to /kaiden in gateway container', async () => {
     Object.defineProperty(env, 'isWindows', { value: true, configurable: true });
     setupCliMock('/usr/bin/openshell');

--- a/extensions/openshell-podman-gateway/src/manager/gateway-container-manager.ts
+++ b/extensions/openshell-podman-gateway/src/manager/gateway-container-manager.ts
@@ -47,7 +47,7 @@ allow_unauthenticated_users = true
 signing_key_path = "/kaiden/jwt/signing.pem"
 public_key_path = "/kaiden/jwt/public.pem"
 kid_path = "/kaiden/jwt/kid"
-ttl_secs = 3600
+ttl_secs = 0
 `;
 
 const WINDOWS_PATH_REGEXP = /^([A-Za-z]):[/\\](.*)$/;

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -558,6 +558,17 @@ describe('start', () => {
     expect(writeFile).toHaveBeenCalledWith(GATEWAY_CONFIG_PATH, expect.stringContaining('kid_path'), 'utf-8');
   });
 
+  test('generates gateway config with non-expiring JWTs (ttl_secs = 0)', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+
+    await gateway.start();
+
+    expect(writeFile).toHaveBeenCalledWith(GATEWAY_CONFIG_PATH, expect.stringContaining('ttl_secs = 0'), 'utf-8');
+  });
+
   test('starts gateway without --config when cert generation fails', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.toml.template
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.toml.template
@@ -25,4 +25,4 @@ allow_unauthenticated_users = true
 signing_key_path = "{{{gatewayDir}}}/jwt/signing.pem"
 public_key_path = "{{{gatewayDir}}}/jwt/public.pem"
 kid_path = "{{{gatewayDir}}}/jwt/kid"
-ttl_secs = 3600
+ttl_secs = 0


### PR DESCRIPTION
Set gateway_jwt.ttl_secs = 0 (non-expiring) instead of 3600 in both
the native gateway config template and the podman-containerized gateway
config. A 1-hour TTL caused sandboxes to permanently lose their
supervisor connection after any gateway restart exceeding the token's
remaining lifetime, with no recovery path.

fixes #2654