### PR TITLE
fix(build): kill all spawned vite processes when pnpm watch exits

### DIFF
--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -20,7 +20,7 @@
 
 import { createServer, build, createLogger } from 'vite';
 import electronPath from 'electron';
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { generateAsync } from 'dts-for-context-bridge';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -28,6 +28,89 @@ import { readdirSync, existsSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Spawned child processes tracked so we can tear them all down on exit.
+ * @type {Set<import('node:child_process').ChildProcess>}
+ */
+const childrenProcesses = new Set();
+
+/**
+ * Track a child process so it can be killed together with the watch script.
+ * @param {import('node:child_process').ChildProcess} child
+ */
+function trackChildProcess(child) {
+  childrenProcesses.add(child);
+  child.once('exit', () => childrenProcesses.delete(child));
+}
+
+/**
+ * Kill a single child process and its descendants using platform-specific
+ * process-tree termination.
+ * @param {import('node:child_process').ChildProcess} child
+ * @param {NodeJS.Signals} signal
+ */
+function killChild(child, signal) {
+  if (child.pid === undefined) {
+    return;
+  }
+  try {
+    if (process.platform === 'win32') {
+      spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+    } else {
+      process.kill(-child.pid, signal);
+    }
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // Process already exited.
+    }
+  }
+}
+
+/**
+ * Kill every tracked child process by sending the signal to its whole
+ * process group (which also kills its own descendants, e.g. pnpm → vite).
+ * @param {NodeJS.Signals} signal
+ */
+function killChildren(signal) {
+  for (const child of childrenProcesses) {
+    killChild(child, signal);
+  }
+  childrenProcesses.clear();
+}
+
+/**
+ * Kill everything spawned by this script and exit. The default terminal
+ * behavior only kills the direct `pnpm watch` process, leaving spawned
+ * package watchers (and their vite processes) orphaned.
+ * @param {NodeJS.Signals | number} signal
+ */
+function cleanupAndExit(signal) {
+  killChildren('SIGTERM');
+  if (typeof signal === 'string' && signal.startsWith('SIG')) {
+    // Re-raise so the parent shell sees the real exit reason.
+    process.removeListener(signal, cleanupAndExit);
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(typeof signal === 'number' ? signal : 0);
+  }
+}
+
+/**
+ * Preserve whether a child exited with a status code or a signal.
+ * @param {number | null} code
+ * @param {NodeJS.Signals | null} signal
+ */
+function cleanupOnChildExit(code, signal) {
+  cleanupAndExit(signal ?? code ?? 0);
+}
+
+// Ensure termination propagates to all child processes.
+process.on('SIGINT', cleanupAndExit);
+process.on('SIGTERM', cleanupAndExit);
+process.on('SIGQUIT', cleanupAndExit);
 
 /** @type 'production' | 'development'' */
 const mode = (process.env.MODE = process.env.MODE || 'development');
@@ -91,8 +174,8 @@ const setupMainPackageWatcher = ({ config: { server, extensions } }) => {
     configFile: 'packages/main/vite.config.js',
     writeBundle() {
       if (spawnProcess !== null) {
-        spawnProcess.off('exit', process.exit);
-        spawnProcess.kill('SIGINT');
+        spawnProcess.off('exit', cleanupOnChildExit);
+        killChild(spawnProcess, 'SIGINT');
         spawnProcess = null;
       }
 
@@ -103,6 +186,7 @@ const setupMainPackageWatcher = ({ config: { server, extensions } }) => {
       });
       spawnProcess = spawn(String(electronPath), ['--remote-debugging-port=9223', '.', ...extensionArgs], {
         env: { ...process.env, ELECTRON_IS_DEV: 1 },
+        detached: process.platform !== 'win32',
       });
 
       spawnProcess.stdout.on('data', d => d.toString().trim() && logger.warn(d.toString(), { timestamp: true }));
@@ -114,8 +198,11 @@ const setupMainPackageWatcher = ({ config: { server, extensions } }) => {
         logger.error(data, { timestamp: true });
       });
 
-      // Stops the watch script when the application has been quit
-      spawnProcess.on('exit', process.exit);
+      spawnProcess.on('exit', cleanupOnChildExit);
+
+      // Register cleanup first so the process group remains tracked while
+      // cleanupAndExit terminates any surviving descendants.
+      trackChildProcess(spawnProcess);
     },
   });
 };
@@ -166,11 +253,14 @@ const setupPreloadWebviewPackageWatcher = ({ ws }) =>
  * @param {{ws: import('vite').WebSocketServer}} WebSocketServer
  */
 const setupExtensionApiWatcher = name => {
-  let spawnProcess;
   const folderName = resolve(name);
 
   console.log('dirname is', folderName);
-  spawnProcess = spawn('pnpm', ['watch'], { cwd: folderName, shell: process.platform === 'win32' });
+  const spawnProcess = spawn('pnpm', ['watch'], {
+    cwd: folderName,
+    shell: process.platform === 'win32',
+    detached: process.platform !== 'win32',
+  });
 
   spawnProcess.stdout.on('data', d => d.toString().trim() && console.warn(d.toString(), { timestamp: true }));
   spawnProcess.stderr.on('data', d => {
@@ -179,8 +269,12 @@ const setupExtensionApiWatcher = name => {
     console.error(data, { timestamp: true });
   });
 
-  // Stops the watch script when the application has been quit
-  spawnProcess.on('exit', process.exit);
+  spawnProcess.on('exit', cleanupOnChildExit);
+
+  // Register cleanup first so the process group remains tracked while
+  // cleanupAndExit terminates any surviving descendants.
+  trackChildProcess(spawnProcess);
+  spawnProcess.unref();
 };
 
 (async () => {


### PR DESCRIPTION
- Track all child processes and install SIGINT/SIGTERM/SIGQUIT handlers
  to propagate termination to every spawned process tree
- Spawn children with detached: true (non-Windows) so process-group
  kill via negative pid cleans up entire subtrees (pnpm → vite)
- Re-raise the original signal instead of process.exit(0) so the
  parent shell sees the correct exit status
- Use taskkill /T on Windows for proper process-tree teardown

I was experiencing frequent OOM issues because of dangling vite processes, accumulating after each `pnpm watch`. Now all those are cleaned up on exit.