### PR TITLE
test(e2e): fix workspace names for 19-char OpenShell limit

### DIFF
--- a/.agents/skills/playwright-testing/workspace-provider-e2e.md
+++ b/.agents/skills/playwright-testing/workspace-provider-e2e.md
@@ -177,6 +177,8 @@ tests/playwright/src/specs/provider-specs/workspaces/
 
 `workspace-filesystem-network-smoke.spec.ts` defines scenarios × agents (OpenCode + Claude Code). Skipped scenarios emit 1 skip-marker test instead of 5 steps — use `--list | tail -1` for the current count.
 
+Inference resources (e.g. OpenAI, Claude) are created **once per agent** in `registerSandboxMatrixTests` (`beforeAll` / `afterAll` on the agent describe). Scenario lifecycle hooks pass `manageResource: false` so they do not recreate/delete the connection between scenarios.
+
 Scenarios use a single `SANDBOX_SCENARIOS` array grouped by comments (core matrix, extended combos, edge cases, known skips).
 
 ### UI-aligned tags
@@ -288,13 +290,13 @@ The `Workspace-Provider` project is defined in `tests/playwright/playwright.conf
 
 1. Add a `SandboxScenario` entry in `workspace-filesystem-network-smoke.spec.ts`:
    - `id`: uppercase tag-aligned ID (e.g. `FS-HOME-NET-DENY`); describe title is derived in `helpers/workspace-sandbox-matrix.ts`
-   - `workspaceSlug`: optional short slug when `id` is too long for OpenShell (see below)
+   - `workspaceSlug`: required readable kebab slug (e.g. `none-dev`, `cust-multi`); final name is `{agentPrefix}-{slug}` and must be ≤ 19 chars (OpenShell limit)
    - `fileAccess`, `network`, and optional `customMounts` / `denyHosts` / `additionalHosts`
    - Reuse mount presets from `helpers/workspace-sandbox-matrix.ts` (`CUSTOM_RW_MOUNT`, etc.) when applicable
 2. Tags are auto-derived from `fileAccess` / `network` — modifier tags apply when mounts/hosts need them.
 3. Use `host: ''` in `customMounts` to get a temp dir from the lifecycle helper; use `$SOURCES/...` hosts for sandbox-safe paths.
 4. Set `skipReason` if the combo is known broken on OpenShell until upstream fixes land.
-5. Workspace names are `{agent}-{slug}-e2e` (≤ 46 chars so `openshell-sandbox-…` stays within Podman's 64-char hostname limit). Use `workspaceSlug` when `id` is too long — registration asserts the constraint.
+5. Workspace names are `{agentPrefix}-{workspaceSlug}` and must be ≤ 19 characters (OpenShell limit). `buildWorkspaceName` enforces this for matrix tests; hardcode short names in lifecycle smoke specs.
 6. Run the single scenario: `--grep "FS-HOME-NET-DENY"`.
 
 ## Custom Mount Conventions

--- a/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-lifecycle-helper.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-lifecycle-helper.ts
@@ -67,6 +67,8 @@ export interface WorkspaceLifecycleConfig {
   };
   /** When set, configures filesystem/network wizard steps and skips stat-card assertions. */
   sandbox?: WorkspaceSandboxOptions;
+  /** When false, caller owns create/delete (sandbox matrix agent scope). Default true. */
+  manageResource?: boolean;
 }
 
 const SANDBOX_STEP_TITLES: Record<string, string> = {
@@ -114,10 +116,12 @@ export function registerWorkspaceLifecycleTests(
     ? { terminal: '03', prompt: '04', remove: '05' }
     : { statAfterCreate: '03', terminal: '04', prompt: '05', remove: '06', statAfterRemove: '07' };
 
+  const manageResource = config.manageResource !== false;
+
   test.beforeAll(async ({ workerNavigationBar }) => {
     await workerNavigationBar.ensureExtensionsRunning();
 
-    if (config.requiredResource) {
+    if (manageResource && config.requiredResource) {
       const provider = PROVIDERS[config.requiredResource];
       if (!('autoDetected' in provider && provider.autoDetected)) {
         const settingsPage = await workerNavigationBar.navigateToSettingsPage();
@@ -154,7 +158,7 @@ export function registerWorkspaceLifecycleTests(
     if (workingDir) {
       rmSync(workingDir, { recursive: true, force: true });
     }
-    if (config.requiredResource) {
+    if (manageResource && config.requiredResource) {
       const provider = PROVIDERS[config.requiredResource];
       if (!('autoDetected' in provider && provider.autoDetected)) {
         try {

--- a/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-sandbox-matrix.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-sandbox-matrix.ts
@@ -24,6 +24,7 @@ import {
   type FileAccessLevel,
   NETWORK_ACCESS_LEVEL,
   type NetworkAccessLevel,
+  PROVIDERS,
   type ResourceId,
   TIMEOUTS,
   type WorkspaceCustomMount,
@@ -43,10 +44,8 @@ function skipTestTitle(scenarioId: string, skipReason: string): string {
   return `[SKIP] ${scenarioId} — ${skipReason}`;
 }
 
-/** OpenShell prefixes container names with this; crun rejects hostnames longer than 64 bytes. */
-export const OPENSHELL_CONTAINER_NAME_PREFIX = 'openshell-sandbox-';
-export const OPENSHELL_MAX_HOSTNAME_LENGTH = 64;
-export const WORKSPACE_NAME_SUFFIX = '-e2e';
+/** Must match packages/api SANDBOX_NAME_MAX_LENGTH (OpenShell DNS-1123 limit). */
+export const SANDBOX_NAME_MAX_LENGTH = 19;
 
 export const CUSTOM_RW_MOUNT: WorkspaceCustomMount[] = [{ host: '', target: CUSTOM_MOUNT_TARGET, readOnly: false }];
 export const CUSTOM_RO_MOUNT: WorkspaceCustomMount[] = [{ host: '', target: CUSTOM_MOUNT_TARGET, readOnly: true }];
@@ -74,10 +73,11 @@ export interface SandboxScenario {
   /** Test ID segment after WKS-{AGENT}-, aligned with @fs-* / @net-* tags. */
   id: string;
   /**
-   * Short kebab-case segment for the OpenShell sandbox name when `id` is too long.
-   * Defaults to `id.toLowerCase()`. Must keep `openshell-sandbox-{prefix}-{slug}-e2e` ≤ 64 chars.
+   * Short kebab-case segment for the OpenShell sandbox name.
+   * Final name is `{prefix}-{slug}` (≤ 19 chars). Prefer readable slugs
+   * like `none-dev`, `cust-multi`, `deny-host` over single-letter codes.
    */
-  workspaceSlug?: string;
+  workspaceSlug: string;
   fileAccess: FileAccessLevel;
   network: NetworkAccessLevel;
   customMounts?: WorkspaceCustomMount[];
@@ -188,22 +188,14 @@ export function buildScenarioTags(scenario: SandboxScenario): string[] {
 }
 
 export function buildWorkspaceName(workspacePrefix: string, slug: string): string {
-  return `${workspacePrefix}-${slug}${WORKSPACE_NAME_SUFFIX}`;
-}
-
-export function openshellContainerName(workspaceName: string): string {
-  return `${OPENSHELL_CONTAINER_NAME_PREFIX}${workspaceName}`;
-}
-
-export function assertOpenshellContainerNameFits(workspaceName: string, context: string): void {
-  const containerName = openshellContainerName(workspaceName);
-  if (containerName.length > OPENSHELL_MAX_HOSTNAME_LENGTH) {
+  const workspaceName = `${workspacePrefix}-${slug}`;
+  if (workspaceName.length > SANDBOX_NAME_MAX_LENGTH) {
     throw new Error(
-      `Workspace name "${workspaceName}" produces OpenShell container name "${containerName}" ` +
-        `(${containerName.length} chars), exceeding the ${OPENSHELL_MAX_HOSTNAME_LENGTH}-char ` +
-        `Podman/crun hostname limit (${context})`,
+      `Workspace name "${workspaceName}" is ${workspaceName.length} chars; ` +
+        `must be ≤ ${SANDBOX_NAME_MAX_LENGTH} (OpenShell sandbox name limit)`,
     );
   }
+  return workspaceName;
 }
 
 export function registerSandboxMatrixTests(
@@ -214,10 +206,37 @@ export function registerSandboxMatrixTests(
 ): void {
   for (const agent of agents) {
     test.describe(agent.describeAgent, () => {
+      const provider = PROVIDERS[agent.requiredResource];
+      const managesResource = !('autoDetected' in provider && provider.autoDetected);
+
+      test.beforeAll(async ({ workerNavigationBar }) => {
+        await workerNavigationBar.ensureExtensionsRunning();
+
+        if (managesResource) {
+          const credentials = process.env[provider.envVarName];
+          if (!credentials) {
+            return;
+          }
+          const settingsPage = await workerNavigationBar.navigateToSettingsPage();
+          await settingsPage.createResource(agent.requiredResource, credentials);
+          await workerNavigationBar.navigateToWorkspacesPage();
+        }
+      });
+
+      test.afterAll(async ({ workerNavigationBar }) => {
+        if (!managesResource || !process.env[provider.envVarName]) {
+          return;
+        }
+        try {
+          const settingsPage = await workerNavigationBar.navigateToSettingsPage();
+          await settingsPage.deleteResource(agent.requiredResource);
+        } catch (error) {
+          console.error(`Failed to delete ${agent.requiredResource} resource:`, error);
+        }
+      });
+
       for (const scenario of scenarios) {
-        const slug = scenario.workspaceSlug ?? scenario.id.toLowerCase();
-        const workspaceName = buildWorkspaceName(agent.workspacePrefix, slug);
-        assertOpenshellContainerNameFits(workspaceName, `scenario ${scenario.id} / agent ${agent.workspacePrefix}`);
+        const workspaceName = buildWorkspaceName(agent.workspacePrefix, scenario.workspaceSlug);
         const description = scenarioDescription(scenario);
         const describeOptions = { tag: buildScenarioTags(scenario) };
 
@@ -235,6 +254,7 @@ export function registerSandboxMatrixTests(
             workspaceName,
             agent: agent.agent,
             requiredResource: agent.requiredResource,
+            manageResource: false,
             selectModel: agent.selectModel,
             terminalReadyPatterns: agent.terminalReadyPatterns,
             promptTimeout: TIMEOUTS.MODEL_RESPONSE,

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-claude-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-claude-smoke.spec.ts
@@ -25,7 +25,7 @@ test.describe
   .serial('Claude Code agent workspace with Anthropic model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-CLAUDE',
-      workspaceName: 'claude-e2e-smoke',
+      workspaceName: 'claude-default',
       agent: CODING_AGENT.CLAUDE,
       requiredResource: 'claude',
       selectModel: async createPage => {

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-filesystem-network-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-filesystem-network-smoke.spec.ts
@@ -66,47 +66,56 @@ const AGENT_SETUPS: SandboxAgentSetup[] = [
 
 const SANDBOX_SCENARIOS: SandboxScenario[] = [
   // --- Core matrix ---
+  // Names are `{agent}-{workspaceSlug}`; slug must keep total ≤ 19 chars.
   {
     id: 'FS-NONE-NET-DEVELOPER',
+    workspaceSlug: 'none-dev',
     fileAccess: FILE_ACCESS_LEVEL.NO_HOST_ACCESS,
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
   },
   {
     id: 'FS-HOME-NET-DEVELOPER',
+    workspaceSlug: 'home-dev',
     fileAccess: FILE_ACCESS_LEVEL.HOME_DIRECTORY,
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
   },
   {
     id: 'FS-CUSTOM-NET-DEVELOPER',
+    workspaceSlug: 'cust-dev',
     fileAccess: FILE_ACCESS_LEVEL.CUSTOM_PATHS,
     customMounts: CUSTOM_RW_MOUNT,
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
   },
   {
     id: 'FS-NONE-NET-DENY',
+    workspaceSlug: 'none-deny',
     fileAccess: FILE_ACCESS_LEVEL.NO_HOST_ACCESS,
     network: NETWORK_ACCESS_LEVEL.DENY_ALL,
   },
   // --- Extended filesystem × network ---
   {
     id: 'FS-FULL-NET-DEVELOPER',
+    workspaceSlug: 'full-dev',
     fileAccess: FILE_ACCESS_LEVEL.FULL_SYSTEM,
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
     skipReason: FULL_SYSTEM_SKIP_LABEL,
   },
   {
     id: 'FS-CUSTOM-NET-DENY',
+    workspaceSlug: 'cust-deny',
     fileAccess: FILE_ACCESS_LEVEL.CUSTOM_PATHS,
     customMounts: CUSTOM_RW_MOUNT,
     network: NETWORK_ACCESS_LEVEL.DENY_ALL,
   },
   {
     id: 'FS-HOME-NET-DENY',
+    workspaceSlug: 'home-deny',
     fileAccess: FILE_ACCESS_LEVEL.HOME_DIRECTORY,
     network: NETWORK_ACCESS_LEVEL.DENY_ALL,
   },
   {
     id: 'FS-CUSTOM-RO-NET-DEVELOPER',
+    workspaceSlug: 'cust-ro',
     fileAccess: FILE_ACCESS_LEVEL.CUSTOM_PATHS,
     customMounts: CUSTOM_RO_MOUNT,
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
@@ -114,13 +123,14 @@ const SANDBOX_SCENARIOS: SandboxScenario[] = [
   // --- Custom mount edge cases ---
   {
     id: 'FS-CUSTOM-DEFAULT-TARGET-NET-DEVELOPER',
-    workspaceSlug: 'fs-cust-def-tgt',
+    workspaceSlug: 'cust-def',
     fileAccess: FILE_ACCESS_LEVEL.CUSTOM_PATHS,
     customMounts: CUSTOM_DEFAULT_TARGET_MOUNT,
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
   },
   {
     id: 'FS-CUSTOM-MULTI-NET-DEVELOPER',
+    workspaceSlug: 'cust-multi',
     fileAccess: FILE_ACCESS_LEVEL.CUSTOM_PATHS,
     customMounts: CUSTOM_MULTI_MOUNTS,
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
@@ -128,13 +138,14 @@ const SANDBOX_SCENARIOS: SandboxScenario[] = [
   // --- Network host allowlist edge cases ---
   {
     id: 'FS-NONE-NET-DENY-CUSTOM-HOST',
+    workspaceSlug: 'deny-host',
     fileAccess: FILE_ACCESS_LEVEL.NO_HOST_ACCESS,
     network: NETWORK_ACCESS_LEVEL.DENY_ALL,
     denyHosts: [CUSTOM_ALLOWED_HOST],
   },
   {
     id: 'FS-NONE-NET-DEVELOPER-ADDITIONAL-HOST',
-    workspaceSlug: 'fs-none-dev-add-host',
+    workspaceSlug: 'dev-extra',
     fileAccess: FILE_ACCESS_LEVEL.NO_HOST_ACCESS,
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
     additionalHosts: [CUSTOM_ALLOWED_HOST],
@@ -142,6 +153,7 @@ const SANDBOX_SCENARIOS: SandboxScenario[] = [
   // --- Known skips on OpenShell ---
   {
     id: 'FS-FULL-NET-DENY',
+    workspaceSlug: 'full-deny',
     fileAccess: FILE_ACCESS_LEVEL.FULL_SYSTEM,
     network: NETWORK_ACCESS_LEVEL.DENY_ALL,
     skipReason: FULL_SYSTEM_SKIP_LABEL,

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-goose-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-goose-smoke.spec.ts
@@ -25,7 +25,7 @@ test.describe
   .serial('Goose agent workspace with OpenAI model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-OPENAI',
-      workspaceName: 'goose-openai-e2e-smoke',
+      workspaceName: 'goose-openai',
       agent: CODING_AGENT.GOOSE,
       requiredResource: 'openai',
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
@@ -41,7 +41,7 @@ test.describe
   .serial('Goose agent workspace with Mistral model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-MISTRAL',
-      workspaceName: 'goose-mistral-e2e-smoke',
+      workspaceName: 'goose-mistral',
       agent: CODING_AGENT.GOOSE,
       requiredResource: 'mistral',
       selectModel: async createPage => createPage.searchAndSelectDefault('mistral', 'Mistral'),
@@ -59,7 +59,7 @@ test.describe
 
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-OLLAMA',
-      workspaceName: 'goose-ollama-e2e-smoke',
+      workspaceName: 'goose-ollama',
       agent: CODING_AGENT.GOOSE,
       requiredResource: 'ollama',
       selectModel: async createPage => createPage.searchAndSelectByRuntime('ollama', 'Ollama'),
@@ -76,7 +76,7 @@ test.describe
   .serial('Goose agent workspace with RamaLama model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-RAMALAMA',
-      workspaceName: 'goose-ramalama-e2e-smoke',
+      workspaceName: 'goose-ramalama',
       agent: CODING_AGENT.GOOSE,
       requiredResource: 'ramalama',
       selectModel: async createPage => createPage.searchAndSelectByRuntime('ramalama', 'RamaLama'),

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-openclaw-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-openclaw-smoke.spec.ts
@@ -25,7 +25,7 @@ test.describe
   .serial('OpenClaw agent workspace with Ollama model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-OLLAMA',
-      workspaceName: 'openclaw-ollama-e2e-smoke',
+      workspaceName: 'openclaw-ollama',
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'ollama',
       selectModel: async createPage => createPage.searchAndSelectByRuntime('ollama', 'Ollama'),
@@ -43,7 +43,7 @@ test.describe
   .serial('OpenClaw agent workspace with OpenAI model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-OPENAI',
-      workspaceName: 'openclaw-openai-e2e-smoke',
+      workspaceName: 'openclaw-openai',
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'openai',
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
@@ -60,7 +60,7 @@ test.describe
   .serial('OpenClaw agent workspace with Anthropic model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-ANTHROPIC',
-      workspaceName: 'openclaw-anthropic-e2e-smoke',
+      workspaceName: 'openclaw-anthropic',
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'claude',
       selectModel: async createPage => createPage.searchAndSelectDefault('claude', 'Claude'),
@@ -77,7 +77,7 @@ test.describe
   .serial('OpenClaw agent workspace with Gemini model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-GEMINI',
-      workspaceName: 'openclaw-gemini-e2e-smoke',
+      workspaceName: 'openclaw-gemini',
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'gemini',
       selectModel: async createPage => createPage.searchAndSelectDefault('gemini', 'Gemini'),
@@ -94,7 +94,7 @@ test.describe
   .serial('OpenClaw agent workspace with Mistral model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-MISTRAL',
-      workspaceName: 'openclaw-mistral-e2e-smoke',
+      workspaceName: 'openclaw-mistral',
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'mistral',
       selectModel: async createPage => createPage.searchAndSelectDefault('mistral', 'Mistral'),

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-opencode-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-opencode-smoke.spec.ts
@@ -25,7 +25,7 @@ test.describe
   .serial('OpenCode agent workspace with OpenAI model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-OPENAI',
-      workspaceName: 'opencode-e2e-smoke',
+      workspaceName: 'opencode-openai',
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'openai',
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
@@ -42,7 +42,7 @@ test.describe
   .serial('OpenCode agent workspace with Gemini model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-GEMINI',
-      workspaceName: 'opencode-gemini-e2e-smoke',
+      workspaceName: 'opencode-gemini',
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'gemini',
       selectModel: async createPage => createPage.searchAndSelectDefault('gemini', 'Gemini'),
@@ -58,7 +58,7 @@ test.describe
   .serial('OpenCode agent workspace with Anthropic model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-ANTHROPIC',
-      workspaceName: 'opencode-anthropic-e2e-smoke',
+      workspaceName: 'opencode-anthropic',
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'claude',
       selectModel: async createPage => createPage.searchAndSelectDefault('claude', 'Claude'),
@@ -74,7 +74,7 @@ test.describe
   .serial('OpenCode agent workspace with Mistral model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-MISTRAL',
-      workspaceName: 'opencode-mistral-e2e-smoke',
+      workspaceName: 'opencode-mistral',
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'mistral',
       selectModel: async createPage => createPage.searchAndSelectDefault('mistral', 'Mistral'),
@@ -90,7 +90,7 @@ test.describe
   .serial('OpenCode agent workspace with Ollama model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-OLLAMA',
-      workspaceName: 'opencode-ollama-e2e-smoke',
+      workspaceName: 'opencode-ollama',
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'ollama',
       selectModel: async createPage => createPage.searchAndSelectByRuntime('ollama', 'Ollama'),


### PR DESCRIPTION
- Shorten workspace e2e names to ≤19 characters (OpenShell / DNS-1123 limit)
- Create inference resources once per agent in the sandbox matrix instead of per scenario
- Update workspace provider e2e docs for the new naming and resource setup
