### PR TITLE
fix(rag): fix PDF and hyphenated-name knowledge indexing

### DIFF
--- a/extensions/docling/src/manager/connection-manager.spec.ts
+++ b/extensions/docling/src/manager/connection-manager.spec.ts
@@ -507,6 +507,43 @@ describe('ConnectionManager', () => {
       );
     });
 
+    test('should upload PDF with application/pdf content type', async () => {
+      let registeredConnection: ChunkProviderConnection;
+      vi.mocked(doclingProviderMock.registerChunkProviderConnection).mockImplementation(conn => {
+        registeredConnection = conn;
+        return { dispose: vi.fn() };
+      });
+
+      await connectionManager.registerConnection({
+        path: '/test/endpoint',
+        containerId: 'chunk-container-id',
+        name: 'chunk-test',
+        port: 7070,
+        running: true,
+      });
+
+      vi.mocked(Uri.file).mockReturnValue({ fsPath: '/path/to/document.pdf' } as unknown as Uri);
+      const docUri = Uri.file('/path/to/document.pdf');
+      // openAsBlob leaves type empty on Node — reproducing the PDF indexing bug
+      vi.mocked(openAsBlob).mockResolvedValue(new Blob(['%PDF-1.4']));
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          chunks: [{ text: 'chunk1' }],
+        }),
+      } as unknown as Response);
+
+      await registeredConnection!.chunk(docUri);
+
+      const [, options] = vi.mocked(global.fetch).mock.calls[0]!;
+      const body = (options as RequestInit).body as FormData;
+      const uploaded = body.get('files') as File;
+      expect(uploaded).toBeInstanceOf(Blob);
+      expect(uploaded.name).toBe('document.pdf');
+      expect(uploaded.type).toBe('application/pdf');
+    });
+
     test('should throw when connection is stopped', async () => {
       let registeredConnection: ChunkProviderConnection;
       vi.mocked(doclingProviderMock.registerChunkProviderConnection).mockImplementation(conn => {

--- a/extensions/docling/src/manager/connection-manager.ts
+++ b/extensions/docling/src/manager/connection-manager.ts
@@ -44,6 +44,26 @@ const DOCLING_PORT = 5001;
 const DOCLING_NAME_LABEL = 'ai.openkaiden.docling.name';
 const DOCLING_PORT_LABEL = 'ai.openkaiden.docling.port';
 
+/** MIME types keyed by lowercase file extension (without the leading dot). */
+const EXTENSION_MIME_TYPES: Record<string, string> = {
+  pdf: 'application/pdf',
+  txt: 'text/plain',
+  md: 'text/markdown',
+  markdown: 'text/markdown',
+  htm: 'text/html',
+  html: 'text/html',
+  shtm: 'text/html',
+  shtml: 'text/html',
+  xht: 'application/xhtml+xml',
+  xhtml: 'application/xhtml+xml',
+  hta: 'application/hta',
+};
+
+function getMimeTypeForFilename(filename: string): string {
+  const extension = filename.includes('.') ? filename.slice(filename.lastIndexOf('.') + 1).toLowerCase() : '';
+  return EXTENSION_MIME_TYPES[extension] ?? 'application/octet-stream';
+}
+
 type DoclingContainerInfo = {
   dockerode: Dockerode;
   containerId: string;
@@ -207,8 +227,14 @@ export class ConnectionManager {
     const docFileName = basename(docPath);
 
     const data = new FormData();
+    // openAsBlob() often leaves Blob.type empty on Node, which makes FormData send
+    // application/octet-stream. Docling needs a real MIME type (e.g. application/pdf)
+    // to index PDFs correctly — mirror what the official docling SDK does.
     const blob = await openAsBlob(docPath);
-    data.set('files', blob, docFileName);
+    const file = new File([blob], docFileName, {
+      type: blob.type || getMimeTypeForFilename(docFileName),
+    });
+    data.set('files', file);
     const response = await fetch(`http://localhost:${entry.containerInfo.port}/v1/chunk/hierarchical/file`, {
       method: 'POST',
       body: data,

--- a/extensions/milvus/src/api/milvus-connection.spec.ts
+++ b/extensions/milvus/src/api/milvus-connection.spec.ts
@@ -16,11 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { readFile } from 'node:fs/promises';
+
 import * as api from '@openkaiden/api';
+import { MilvusClient } from '@zilliz/milvus2-sdk-node';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { MilvusConnection } from './milvus-connection';
 
+vi.mock(import('node:fs/promises'));
 vi.mock(import('@zilliz/milvus2-sdk-node'));
 
 beforeEach(() => {
@@ -94,4 +98,41 @@ test('should set connection status to stopped when running is false', () => {
 test('should store serverId from registered server', () => {
   const connection = new MilvusConnection('/path', 'test-db', 'container-1', 19530, true);
   expect(connection.mcpServer.serverId).toBe('test-server-id');
+});
+
+test('should sanitize hyphenated names when indexing into milvus collections', async () => {
+  const hasCollection = vi.fn().mockResolvedValue({ value: true });
+  const insert = vi.fn().mockResolvedValue({});
+  const flush = vi.fn().mockResolvedValue({});
+
+  vi.mocked(MilvusClient).mockImplementation(function (this: {
+    hasCollection: typeof hasCollection;
+    insert: typeof insert;
+    flush: typeof flush;
+  }): void {
+    this.hasCollection = hasCollection;
+    this.insert = insert;
+    this.flush = flush;
+  } as unknown as new (
+    ...args: ConstructorParameters<typeof MilvusClient>
+  ) => InstanceType<typeof MilvusClient>);
+  vi.mocked(readFile).mockResolvedValue('chunk text');
+  vi.mocked(api.Uri.file).mockImplementation(
+    (path: string) =>
+      ({
+        fsPath: path,
+        toString: (): string => `file://${path}`,
+      }) as unknown as api.Uri,
+  );
+
+  const connection = new MilvusConnection('/path', 'test-2', 'container-1', 19530, true);
+  await connection.index(api.Uri.file('/doc.pdf'), [api.Uri.file('/chunk0.txt')]);
+
+  expect(hasCollection).toHaveBeenCalledWith({ collection_name: 'test_2' });
+  expect(insert).toHaveBeenCalledWith(
+    expect.objectContaining({
+      collection_name: 'test_2',
+    }),
+  );
+  expect(flush).toHaveBeenCalledWith({ collection_names: ['test_2'] });
 });

--- a/extensions/milvus/src/api/milvus-connection.ts
+++ b/extensions/milvus/src/api/milvus-connection.ts
@@ -22,6 +22,14 @@ import type { MCPServerDetail, ProviderConnectionLifecycle, ProviderConnectionSt
 import * as api from '@openkaiden/api';
 import { DataType, FunctionType, MilvusClient } from '@zilliz/milvus2-sdk-node';
 
+/**
+ * Milvus collection names may only contain letters, numbers, and underscores.
+ * Connection names are often hyphenated (container-safe), so convert for API use.
+ */
+export function sanitizeMilvusCollectionName(name: string): string {
+  return name.replace(/\W/g, '_');
+}
+
 export class MilvusConnection implements api.RagProviderConnection {
   private connectionStatus: api.ProviderConnectionStatus;
   mcpServer: api.MCPServer;
@@ -191,7 +199,7 @@ export class MilvusConnection implements api.RagProviderConnection {
 
   public async index(doc: api.Uri, chunks: api.Uri[]): Promise<void> {
     const client = this.getMilvusClient();
-    const collectionName = this.name;
+    const collectionName = sanitizeMilvusCollectionName(this.name);
 
     try {
       // Ensure collection exists
@@ -227,7 +235,7 @@ export class MilvusConnection implements api.RagProviderConnection {
 
   async deindex(doc: api.Uri): Promise<void> {
     const client = this.getMilvusClient();
-    const collectionName = this.name;
+    const collectionName = sanitizeMilvusCollectionName(this.name);
 
     try {
       // Check if collection exists

--- a/packages/renderer/src/lib/rag/RAGEnvironmentDetails.svelte
+++ b/packages/renderer/src/lib/rag/RAGEnvironmentDetails.svelte
@@ -39,6 +39,11 @@ async function handleAddFile(): Promise<void> {
       selectors: ['openFile'],
       filters: [
         {
+          // First filter is the dialog default — include all supported types so PDFs are visible
+          name: 'Supported documents',
+          extensions: ['pdf', 'txt', 'md', 'markdown', 'htm', 'html', 'shtm', 'shtml', 'xht', 'xhtml', 'hta'],
+        },
+        {
           name: 'Normal text file',
           extensions: ['txt'],
         },


### PR DESCRIPTION
Docling was uploading PDFs as application/octet-stream because openAsBlob left Blob.type empty, and Milvus rejected hyphenated connection names used as collection IDs. Set extension-based MIME types on upload, sanitize collection names to word characters, and default the file picker to all supported types including PDF.

https://github.com/user-attachments/assets/0378be03-eb39-4a07-a3c1-e96e07a7ba85

## Test plan

### PDF indexin
- [ ] Create a knowledge base with a Milvus vector store and Docling chunker
- [ ] Click "Click to upload" in the Sources tab
- [ ] Verify the file picker defaults to "Supported documents" showing PDF, TXT, MD, and HTML files
- [ ] Select a PDF file and confirm it appears in the Sources list with "pending" status
- [ ] Wait for the chunking/indexing task to complete — verify status changes to "indexed" (not "error")

Closes #2546