### PR TITLE
feat(renderer): allow vector store creation during knowledge base setup

### DIFF
--- a/packages/renderer/src/lib/rag/RAGEnvironmentCreateModal.svelte
+++ b/packages/renderer/src/lib/rag/RAGEnvironmentCreateModal.svelte
@@ -158,6 +158,39 @@ function selectFactoryProvider(internalId: string): void {
       <div role="group" aria-label="Vector Store" class="flex flex-col space-y-3">
         <span class="text-sm font-medium text-[var(--pd-modal-text)]">Vector Store</span>
 
+        {#if showCreateRagConnection || (ragConnectionOptions.length === 0 && ragFactoryProviders.length > 0)}
+          <div class="flex flex-col gap-3">
+            {#if ragFactoryProviders.length > 1}
+              <div class="flex flex-wrap gap-3" data-testid="rag-factory-picker">
+                {#each ragFactoryProviders as provider (provider.internalId)}
+                  {@const isActive = activeFactoryProvider?.internalId === provider.internalId}
+                  <Button
+                    type={isActive ? 'primary' : 'secondary'}
+                    aria-label="Select {provider.ragProviderConnectionCreationDisplayName ?? provider.name}"
+                    onclick={selectFactoryProvider.bind(undefined, provider.internalId)}>
+                    {provider.ragProviderConnectionCreationDisplayName ?? provider.name}
+                  </Button>
+                {/each}
+              </div>
+            {/if}
+
+            {#if activeFactoryProvider}
+              {#key `${activeFactoryProvider.internalId}-${creationAttempt}`}
+                <div class="rounded-lg border border-(--pd-content-card-border) bg-(--pd-content-card-bg) p-4" data-testid="inline-rag-creation-form">
+                  <PreferencesConnectionCreationRendering
+                    providerInfo={activeFactoryProvider}
+                    properties={$configurationProperties}
+                    propertyScope="RagProviderConnectionFactory"
+                    callback={window.createRagProviderConnection}
+                    disableEmptyScreen={true}
+                    hideCloseButton={true}
+                    bind:inProgress={creationInProgress} />
+                </div>
+              {/key}
+            {/if}
+          </div>
+        {/if}
+
         {#if ragConnectionOptions.length > 0}
           <div class="grid grid-cols-2 gap-4">
             {#if ragFactoryProviders.length > 0}
@@ -176,7 +209,7 @@ function selectFactoryProvider(internalId: string): void {
                   <div class="text-base font-medium text-(--pd-modal-text)">Create new</div>
                 </div>
                 <div class="text-xs text-(--pd-content-text) leading-relaxed">
-                  Set up a new vector store
+                  Set up a new connection
                 </div>
               </button>
             {/if}
@@ -213,39 +246,6 @@ function selectFactoryProvider(internalId: string): void {
             <p class="text-xs text-(--pd-content-card-text) opacity-60 max-w-sm">
               No vector store providers installed. Install a compatible extension to create knowledge environments.
             </p>
-          </div>
-        {/if}
-
-        {#if showCreateRagConnection || (ragConnectionOptions.length === 0 && ragFactoryProviders.length > 0)}
-          <div class="flex flex-col gap-3">
-            {#if ragFactoryProviders.length > 1}
-              <div class="flex flex-wrap gap-3" data-testid="rag-factory-picker">
-                {#each ragFactoryProviders as provider (provider.internalId)}
-                  {@const isActive = activeFactoryProvider?.internalId === provider.internalId}
-                  <Button
-                    type={isActive ? 'primary' : 'secondary'}
-                    aria-label="Select {provider.ragProviderConnectionCreationDisplayName ?? provider.name}"
-                    onclick={selectFactoryProvider.bind(undefined, provider.internalId)}>
-                    {provider.ragProviderConnectionCreationDisplayName ?? provider.name}
-                  </Button>
-                {/each}
-              </div>
-            {/if}
-
-            {#if activeFactoryProvider}
-              {#key `${activeFactoryProvider.internalId}-${creationAttempt}`}
-                <div class="rounded-lg border border-(--pd-content-card-border) bg-(--pd-content-card-bg) p-4" data-testid="inline-rag-creation-form">
-                  <PreferencesConnectionCreationRendering
-                    providerInfo={activeFactoryProvider}
-                    properties={$configurationProperties}
-                    propertyScope="RagProviderConnectionFactory"
-                    callback={window.createRagProviderConnection}
-                    disableEmptyScreen={true}
-                    hideCloseButton={true}
-                    bind:inProgress={creationInProgress} />
-                </div>
-              {/key}
-            {/if}
           </div>
         {/if}
       </div>

--- a/packages/renderer/src/lib/rag/RAGEnvironmentCreateModal.svelte
+++ b/packages/renderer/src/lib/rag/RAGEnvironmentCreateModal.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { Button, Input } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import Dialog from '/@/lib/dialogs/Dialog.svelte';
+import PreferencesConnectionCreationRendering from '/@/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte';
+import { configurationProperties } from '/@/stores/configurationProperties';
 import type { ProviderInfo } from '/@api/provider-info';
 
 interface Props {
@@ -19,6 +23,10 @@ let { providers, closeCallback, onCreate }: Props = $props();
 let environmentName = $state('');
 let selectedRagConnectionKey = $state('');
 let selectedChunkerConnectionKey = $state('');
+let showCreateRagConnection = $state(false);
+let selectedFactoryProviderId: string | undefined = $state(undefined);
+let creationInProgress = $state(false);
+let creationAttempt = $state(0);
 
 let ragConnectionOptions = $derived(
   providers.flatMap(provider =>
@@ -31,6 +39,14 @@ let ragConnectionOptions = $derived(
     })),
   ),
 );
+
+let ragFactoryProviders = $derived(providers.filter(p => p.ragProviderConnectionCreation === true));
+
+let activeFactoryProvider = $derived.by((): ProviderInfo | undefined => {
+  if (selectedFactoryProviderId) return ragFactoryProviders.find(p => p.internalId === selectedFactoryProviderId);
+  if (ragFactoryProviders.length === 1) return ragFactoryProviders[0];
+  return undefined;
+});
 
 let chunkConnectionOptions = $derived(
   providers.flatMap(provider =>
@@ -52,6 +68,22 @@ const selectedChunkOption = $derived(
 let isFormValid = $derived(
   environmentName.trim() !== '' && selectedRagOption !== undefined && selectedChunkOption !== undefined,
 );
+
+let previousRagOptionsCount = $state(0);
+
+$effect(() => {
+  const options = ragConnectionOptions;
+  const newlyCreated = options.length > previousRagOptionsCount && previousRagOptionsCount >= 0;
+  previousRagOptionsCount = options.length;
+
+  if (selectedRagConnectionKey && !options.find(o => o.key === selectedRagConnectionKey)) {
+    selectedRagConnectionKey = '';
+  }
+  if (newlyCreated && options.length > 0) {
+    selectedRagConnectionKey = options[options.length - 1]!.key;
+    showCreateRagConnection = false;
+  }
+});
 
 function handleCreate(): void {
   if (!isFormValid) return;
@@ -81,10 +113,21 @@ function onNameInput(
 
 function selectRagConnection(key: string): void {
   selectedRagConnectionKey = key;
+  showCreateRagConnection = false;
 }
 
 function selectChunkConnection(key: string): void {
   selectedChunkerConnectionKey = key;
+}
+
+function openCreateRagConnection(): void {
+  showCreateRagConnection = true;
+  selectedRagConnectionKey = '';
+  creationAttempt++;
+}
+
+function selectFactoryProvider(internalId: string): void {
+  selectedFactoryProviderId = internalId;
 }
 </script>
 
@@ -105,34 +148,103 @@ function selectChunkConnection(key: string): void {
 
       <!-- Vector Store Selection -->
       <div role="group" aria-label="Vector Store" class="flex flex-col space-y-3">
-        <label class="text-sm font-medium text-[var(--pd-modal-text)]">Vector Store</label>
-        <div class="grid grid-cols-2 gap-4">
-          {#each ragConnectionOptions as option (option.key)}
-            <button
-              type="button"
-              class="border-2 rounded-lg p-4 text-left transition-all cursor-pointer {selectedRagConnectionKey ===
-              option.key
-                ? 'border-[var(--pd-content-card-border-selected)] bg-[var(--pd-content-card-hover-inset-bg)]'
-                : 'border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] hover:border-[var(--pd-content-card-border-selected)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
-              onclick={selectRagConnection.bind(undefined, option.key)}>
-              <div class="flex items-center gap-3 mb-2">
-                <div
-                  class="w-8 h-8 rounded-md flex items-center justify-center text-[var(--pd-label-primary-text)] text-xs font-bold bg-[var(--pd-label-primary-bg)]">
-                  {option.displayName.charAt(0).toUpperCase()}
+        <span class="text-sm font-medium text-[var(--pd-modal-text)]">Vector Store</span>
+
+        {#if ragConnectionOptions.length > 0}
+          <div class="grid grid-cols-2 gap-4">
+            {#each ragConnectionOptions as option (option.key)}
+              <button
+                type="button"
+                class="border-2 rounded-lg p-4 text-left transition-all cursor-pointer {selectedRagConnectionKey ===
+                option.key
+                  ? 'border-[var(--pd-content-card-border-selected)] bg-[var(--pd-content-card-hover-inset-bg)]'
+                  : 'border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] hover:border-[var(--pd-content-card-border-selected)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+                onclick={selectRagConnection.bind(undefined, option.key)}>
+                <div class="flex items-center gap-3 mb-2">
+                  <div
+                    class="w-8 h-8 rounded-md flex items-center justify-center text-[var(--pd-label-primary-text)] text-xs font-bold bg-[var(--pd-label-primary-bg)]">
+                    {option.displayName.charAt(0).toUpperCase()}
+                  </div>
+                  <div class="text-base font-medium text-[var(--pd-modal-text)]">{option.displayName}</div>
                 </div>
-                <div class="text-base font-medium text-[var(--pd-modal-text)]">{option.displayName}</div>
+                <div class="text-xs text-[var(--pd-content-text)] leading-relaxed">
+                  {option.providerName}
+                </div>
+              </button>
+            {/each}
+
+            {#if ragFactoryProviders.length > 0}
+              <button
+                type="button"
+                aria-label="Create new vector store"
+                class="border-2 border-dashed rounded-lg p-4 text-left transition-all cursor-pointer {showCreateRagConnection
+                  ? 'border-(--pd-content-card-border-selected) bg-(--pd-content-card-hover-inset-bg)'
+                  : 'border-(--pd-content-card-border) bg-(--pd-content-card-bg) hover:border-(--pd-content-card-border-selected) hover:bg-(--pd-content-card-hover-inset-bg)'}"
+                onclick={openCreateRagConnection}>
+                <div class="flex items-center gap-3 mb-2">
+                  <div
+                    class="w-8 h-8 rounded-md flex items-center justify-center text-(--pd-label-primary-text) text-xs font-bold bg-(--pd-label-primary-bg)">
+                    <Icon icon={faPlus} size="1x" />
+                  </div>
+                  <div class="text-base font-medium text-(--pd-modal-text)">Create new</div>
+                </div>
+                <div class="text-xs text-(--pd-content-text) leading-relaxed">
+                  Set up a new vector store
+                </div>
+              </button>
+            {/if}
+          </div>
+        {:else if ragFactoryProviders.length > 0}
+          <div class="flex flex-col items-center text-center py-4">
+            <p class="text-xs text-(--pd-content-card-text) opacity-60 max-w-sm mb-4">
+              No vector stores available. Create one to continue.
+            </p>
+          </div>
+        {:else}
+          <div class="flex flex-col items-center text-center py-4">
+            <p class="text-xs text-(--pd-content-card-text) opacity-60 max-w-sm">
+              No vector store providers installed. Install a compatible extension to create knowledge environments.
+            </p>
+          </div>
+        {/if}
+
+        {#if showCreateRagConnection || (ragConnectionOptions.length === 0 && ragFactoryProviders.length > 0)}
+          <div class="flex flex-col gap-3">
+            {#if ragFactoryProviders.length > 1}
+              <div class="flex flex-wrap gap-3" data-testid="rag-factory-picker">
+                {#each ragFactoryProviders as provider (provider.internalId)}
+                  {@const isActive = activeFactoryProvider?.internalId === provider.internalId}
+                  <Button
+                    type={isActive ? 'primary' : 'secondary'}
+                    aria-label="Select {provider.ragProviderConnectionCreationDisplayName ?? provider.name}"
+                    onclick={selectFactoryProvider.bind(undefined, provider.internalId)}>
+                    {provider.ragProviderConnectionCreationDisplayName ?? provider.name}
+                  </Button>
+                {/each}
               </div>
-              <div class="text-xs text-[var(--pd-content-text)] leading-relaxed">
-                {option.providerName}
-              </div>
-            </button>
-          {/each}
-        </div>
+            {/if}
+
+            {#if activeFactoryProvider}
+              {#key `${activeFactoryProvider.internalId}-${creationAttempt}`}
+                <div class="rounded-lg border border-(--pd-content-card-border) bg-(--pd-content-card-bg) p-4" data-testid="inline-rag-creation-form">
+                  <PreferencesConnectionCreationRendering
+                    providerInfo={activeFactoryProvider}
+                    properties={$configurationProperties}
+                    propertyScope="RagProviderConnectionFactory"
+                    callback={window.createRagProviderConnection}
+                    disableEmptyScreen={true}
+                    hideCloseButton={true}
+                    bind:inProgress={creationInProgress} />
+                </div>
+              {/key}
+            {/if}
+          </div>
+        {/if}
       </div>
 
       <!-- Embedding Model Selection -->
       <div role="group" aria-label="Embedding Model" class="flex flex-col space-y-3">
-        <label class="text-sm font-medium text-[var(--pd-modal-text)]">Embedding Model</label>
+        <span class="text-sm font-medium text-[var(--pd-modal-text)]">Embedding Model</span>
         <div class="grid grid-cols-2 gap-4">
           {#each chunkConnectionOptions as option (option.key)}
             <button

--- a/packages/renderer/src/lib/rag/RAGEnvironmentCreateModal.svelte
+++ b/packages/renderer/src/lib/rag/RAGEnvironmentCreateModal.svelte
@@ -2,6 +2,7 @@
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { Button, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { untrack } from 'svelte';
 
 import Dialog from '/@/lib/dialogs/Dialog.svelte';
 import PreferencesConnectionCreationRendering from '/@/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte';
@@ -69,19 +70,25 @@ let isFormValid = $derived(
   environmentName.trim() !== '' && selectedRagOption !== undefined && selectedChunkOption !== undefined,
 );
 
-let previousRagOptionsCount = $state(0);
+let prevOptionsLength = $state(-1);
 
 $effect(() => {
   const options = ragConnectionOptions;
-  const newlyCreated = options.length > previousRagOptionsCount && previousRagOptionsCount >= 0;
-  previousRagOptionsCount = options.length;
+  const prevLength = untrack(() => prevOptionsLength);
+  const currentKey = untrack(() => selectedRagConnectionKey);
+  prevOptionsLength = options.length;
 
-  if (selectedRagConnectionKey && !options.find(o => o.key === selectedRagConnectionKey)) {
+  if (currentKey && !options.find(o => o.key === currentKey)) {
     selectedRagConnectionKey = '';
   }
-  if (newlyCreated && options.length > 0) {
-    selectedRagConnectionKey = options[options.length - 1]!.key;
-    showCreateRagConnection = false;
+
+  if (prevLength >= 0 && options.length > prevLength) {
+    const factoryId = untrack(() => activeFactoryProvider?.id);
+    const created = factoryId ? options.filter(o => o.providerId === factoryId).at(-1) : options.at(-1);
+    if (created) {
+      selectedRagConnectionKey = created.key;
+      showCreateRagConnection = false;
+    }
   }
 });
 
@@ -123,6 +130,7 @@ function selectChunkConnection(key: string): void {
 function openCreateRagConnection(): void {
   showCreateRagConnection = true;
   selectedRagConnectionKey = '';
+  creationInProgress = false;
   creationAttempt++;
 }
 
@@ -152,27 +160,6 @@ function selectFactoryProvider(internalId: string): void {
 
         {#if ragConnectionOptions.length > 0}
           <div class="grid grid-cols-2 gap-4">
-            {#each ragConnectionOptions as option (option.key)}
-              <button
-                type="button"
-                class="border-2 rounded-lg p-4 text-left transition-all cursor-pointer {selectedRagConnectionKey ===
-                option.key
-                  ? 'border-[var(--pd-content-card-border-selected)] bg-[var(--pd-content-card-hover-inset-bg)]'
-                  : 'border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] hover:border-[var(--pd-content-card-border-selected)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
-                onclick={selectRagConnection.bind(undefined, option.key)}>
-                <div class="flex items-center gap-3 mb-2">
-                  <div
-                    class="w-8 h-8 rounded-md flex items-center justify-center text-[var(--pd-label-primary-text)] text-xs font-bold bg-[var(--pd-label-primary-bg)]">
-                    {option.displayName.charAt(0).toUpperCase()}
-                  </div>
-                  <div class="text-base font-medium text-[var(--pd-modal-text)]">{option.displayName}</div>
-                </div>
-                <div class="text-xs text-[var(--pd-content-text)] leading-relaxed">
-                  {option.providerName}
-                </div>
-              </button>
-            {/each}
-
             {#if ragFactoryProviders.length > 0}
               <button
                 type="button"
@@ -193,6 +180,27 @@ function selectFactoryProvider(internalId: string): void {
                 </div>
               </button>
             {/if}
+
+            {#each ragConnectionOptions as option (option.key)}
+              <button
+                type="button"
+                class="border-2 rounded-lg p-4 text-left transition-all cursor-pointer {selectedRagConnectionKey ===
+                option.key
+                  ? 'border-[var(--pd-content-card-border-selected)] bg-[var(--pd-content-card-hover-inset-bg)]'
+                  : 'border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] hover:border-[var(--pd-content-card-border-selected)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+                onclick={selectRagConnection.bind(undefined, option.key)}>
+                <div class="flex items-center gap-3 mb-2">
+                  <div
+                    class="w-8 h-8 rounded-md flex items-center justify-center text-[var(--pd-label-primary-text)] text-xs font-bold bg-[var(--pd-label-primary-bg)]">
+                    {option.displayName.charAt(0).toUpperCase()}
+                  </div>
+                  <div class="text-base font-medium text-[var(--pd-modal-text)]">{option.displayName}</div>
+                </div>
+                <div class="text-xs text-[var(--pd-content-text)] leading-relaxed">
+                  {option.providerName}
+                </div>
+              </button>
+            {/each}
           </div>
         {:else if ragFactoryProviders.length > 0}
           <div class="flex flex-col items-center text-center py-4">

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -42,6 +42,7 @@ const windowEvents = [
   'provider-unregister-flow-connection',
   'provider-register-inference-connection',
   'provider-register-mcp-connection',
+  'provider-register-rag-connection',
   'provider-register-chunk-connection',
   'provider-unregister-chunk-connection',
   'extensions-started',


### PR DESCRIPTION
Users can now create a new vector store inline from the knowledge base creation modal instead of having to pre-create one in Settings. Also adds the missing provider-register-rag-connection event to the providers store so the UI refreshes after inline creation.


https://github.com/user-attachments/assets/fa748dd9-0a01-41c2-af70-e2b822571672


## Test Plan

### Scenario 1: No vector stores exist
1. Remove any existing Milvus vector stores from Settings → Resources
2. Go to Knowledge Bases → click "New Knowledge Base"
3. **Verify**: The modal shows "No vector stores available. Create one to continue." with an inline creation form below
4. Fill in a name for the Milvus connection and click "Create"
5. **Verify**: After creation completes, the new vector store appears as a selected tile and the creation form collapses

### Scenario 2: Vector store exists, create an additional one
1. With at least one vector store already configured, open the KB creation modal
2. **Verify**: Existing vector store tiles are shown alongside a dashed "Create new" card
3. Click the "Create new" card
4. **Verify**: The inline creation form appears below the tiles
5. Create a new vector store
6. **Verify**: The new tile appears and is auto-selected; the form collapses

### Scenario 3: Create new card works repeatedly
1. After creating a vector store inline, click the "Create new" card again
2. **Verify**: A fresh creation form appears (empty name field, active "Create" button, no spinner)

### Scenario 4: Selecting an existing tile dismisses the form
1. Click "Create new" to show the inline form
2. Click on an existing vector store tile
3. **Verify**: The inline form disappears and the clicked tile is selected

Closes #2547