### PR TITLE
fix(milvus): preserve class names through minification

### DIFF
--- a/extensions/milvus/vite.config.js
+++ b/extensions/milvus/vite.config.js
@@ -34,6 +34,15 @@ const config = {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
     },
   },
+  // @grpc/grpc-js (bundled here, like every other extension dependency, since the
+  // packaged app only ships extensions/**/dist and never node_modules) dynamically
+  // declares `class ServiceClientImpl` and relies on its Function.prototype.name
+  // matching that identifier at runtime. esbuild's production-only minification
+  // renames the class and breaks that check inside milvus2-sdk-node, so names must
+  // be preserved through minification instead.
+  esbuild: {
+    keepNames: true,
+  },
   build: {
     sourcemap: 'inline',
     target: 'esnext',


### PR DESCRIPTION
Fixes #2667

## Summary
- Production builds minify the milvus extension's bundled code, and esbuild renames a class (`ServiceClientImpl`, dynamically declared by `@grpc/grpc-js`) that `@zilliz/milvus2-sdk-node` checks by name (`Function.prototype.name`) at runtime
- That check always fails after minification, so every Milvus indexing attempt errors immediately in packaged builds, regardless of file type or LLM provider
- Adds `esbuild: { keepNames: true }` to `extensions/milvus/vite.config.js`, which makes esbuild emit a `__name()` call restoring the original class name after minification

## Test plan
- [x] Verified the built bundle contains the preserved class name (`static { __name(this, "ServiceClientImpl") }`) instead of a mangled one
- [x] `pnpm --filter milvus test` passes (34/34)