### PR TITLE
feat(rag): derive knowledge base file picker filters from chunker cap…

### DIFF
--- a/extensions/docling/src/manager/connection-manager.spec.ts
+++ b/extensions/docling/src/manager/connection-manager.spec.ts
@@ -225,6 +225,7 @@ describe('ConnectionManager', () => {
         expect.objectContaining({
           id: 'docling-my-chunker',
           name: 'my-chunker',
+          supportedExtensions: expect.arrayContaining(['pdf', 'txt', 'md']),
           chunk: expect.any(Function),
           status: expect.any(Function),
           lifecycle: expect.objectContaining({

--- a/extensions/docling/src/manager/connection-manager.ts
+++ b/extensions/docling/src/manager/connection-manager.ts
@@ -45,7 +45,7 @@ const DOCLING_NAME_LABEL = 'ai.openkaiden.docling.name';
 const DOCLING_PORT_LABEL = 'ai.openkaiden.docling.port';
 
 /** MIME types keyed by lowercase file extension (without the leading dot). */
-const EXTENSION_MIME_TYPES: Record<string, string> = {
+export const EXTENSION_MIME_TYPES: Record<string, string> = {
   pdf: 'application/pdf',
   txt: 'text/plain',
   md: 'text/markdown',
@@ -73,6 +73,8 @@ const CANONICAL_EXTENSIONS: Record<string, string> = {
   shtml: 'html',
   xht: 'xhtml',
 };
+
+const DOCLING_SUPPORTED_EXTENSIONS = Object.keys(EXTENSION_MIME_TYPES);
 
 /** Returns the lowercase extension for a filename, or '' if it has none (including leading-dot-only names like '.markdown'). */
 function getExtension(filename: string): string {
@@ -185,6 +187,7 @@ export class ConnectionManager {
     const connection: ChunkProviderConnection = {
       id: `docling-${info.name}`,
       name: info.name,
+      supportedExtensions: DOCLING_SUPPORTED_EXTENSIONS,
       chunk: (doc: Uri): Promise<Chunk[]> => this.convertDocumentForConnection(entry, doc),
       status: (): ProviderConnectionStatus => entry.connectionStatus,
       lifecycle: {

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -77,6 +77,8 @@ export interface ProviderChunkProviderConnectionInfo {
   status: ProviderConnectionStatus;
   lifecycleMethods?: LifecycleMethod[];
   connectionType: 'chunk';
+  /** Lowercase file extensions (without leading dot) supported by this chunk provider. */
+  supportedExtensions?: string[];
 }
 
 export interface ProviderInferenceConnectionInfo {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -724,6 +724,8 @@ declare module '@openkaiden/api' {
     chunk(doc: Uri): Promise<Chunk[]>;
     status(): ProviderConnectionStatus;
     lifecycle?: ProviderConnectionLifecycle;
+    /** Lowercase file extensions (without leading dot) supported by this chunk provider. */
+    supportedExtensions?: string[];
   };
 
   export interface ProviderInferenceConnection {

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -2911,6 +2911,13 @@ describe('a chunk provider connection is registered', async () => {
       }),
     );
   });
+
+  test('should expose supportedExtensions in provider info', () => {
+    connection.supportedExtensions = ['pdf', 'txt'];
+
+    const chunkInfo = providerRegistry.getProviderChunkConnectionInfo(connection);
+    expect(chunkInfo.supportedExtensions).toEqual(['pdf', 'txt']);
+  });
 });
 
 test('rejects duplicate inference connection id for the same provider', () => {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -841,6 +841,7 @@ export class ProviderRegistry {
         name: connection.name,
         status: connection.status(),
         connectionType: 'chunk',
+        supportedExtensions: connection.supportedExtensions,
       };
     } else {
       providerConnection = {

--- a/packages/renderer/src/lib/rag/RAGEnvironmentDetails.svelte
+++ b/packages/renderer/src/lib/rag/RAGEnvironmentDetails.svelte
@@ -5,7 +5,13 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
-import { getChunkProviderName, getDatabaseName } from '/@/lib/rag/rag-environment-utils';
+import {
+  buildDialogFilters,
+  formatSupportedExtensionsLabel,
+  getChunkProviderName,
+  getChunkProviderSupportedExtensions,
+  getDatabaseName,
+} from '/@/lib/rag/rag-environment-utils';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
@@ -29,6 +35,8 @@ const files = $derived.by(() => {
 
 const databaseName = $derived(getDatabaseName($providerInfos, ragEnvironment));
 const chunkProviderName = $derived(getChunkProviderName($providerInfos, ragEnvironment));
+const supportedExtensions = $derived(getChunkProviderSupportedExtensions($providerInfos, ragEnvironment));
+const supportedExtensionsLabel = $derived(formatSupportedExtensionsLabel(supportedExtensions ?? []));
 
 async function handleAddFile(): Promise<void> {
   if (!ragEnvironment) return;
@@ -37,29 +45,7 @@ async function handleAddFile(): Promise<void> {
     const selectedFiles = await window.openDialog({
       title: 'Select file to add to knowledge database',
       selectors: ['openFile'],
-      filters: [
-        {
-          // First filter is the dialog default — include all supported types so PDFs are visible
-          name: 'Supported documents',
-          extensions: ['pdf', 'txt', 'md', 'markdown', 'htm', 'html', 'shtm', 'shtml', 'xht', 'xhtml', 'hta'],
-        },
-        {
-          name: 'Normal text file',
-          extensions: ['txt'],
-        },
-        {
-          name: 'Markdown',
-          extensions: ['md', 'markdown'],
-        },
-        {
-          name: 'Hyper Text Markup Language',
-          extensions: ['htm', 'html', 'shtm', 'shtml', 'xht', 'xhtml', 'hta'],
-        },
-        {
-          name: 'Adobe PDF',
-          extensions: ['pdf'],
-        },
-      ],
+      filters: buildDialogFilters({ supportedExtensions }),
     });
 
     if (selectedFiles && selectedFiles.length > 0) {
@@ -165,7 +151,7 @@ async function handleRemoveFile(filePath: string): Promise<void> {
           >
             <Icon icon="fas fa-upload" class="fa-2x text-[var(--pd-content-text-secondary)] mb-3"/>
             <div class="text-base text-[var(--pd-content-text)] mb-1">Click to upload</div>
-            <div class="text-sm text-[var(--pd-content-text-secondary)]">Supports PDF, TXT, MD, and more</div>
+            <div class="text-sm text-[var(--pd-content-text-secondary)]">Supports {supportedExtensionsLabel}</div>
           </button>
 
           <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-divider)] rounded-lg overflow-hidden">

--- a/packages/renderer/src/lib/rag/rag-environment-utils.spec.ts
+++ b/packages/renderer/src/lib/rag/rag-environment-utils.spec.ts
@@ -16,12 +16,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test } from 'vitest';
-
 import type { ProviderInfo } from '/@api/provider-info';
 import type { RagEnvironment } from '/@api/rag/rag-environment';
+import { expect, test } from 'vitest';
 
-import { getChunkProviderName, getDatabaseName } from './rag-environment-utils';
+import {
+  buildDialogFilters,
+  formatSupportedExtensionsLabel,
+  getChunkProviderName,
+  getChunkProviderSupportedExtensions,
+  getDatabaseName,
+  type ChunkProviderFileFilterSource,
+} from './rag-environment-utils';
+
+function createMockChunkProviderConnection(
+  overrides: ChunkProviderFileFilterSource = {},
+): ChunkProviderFileFilterSource {
+  return { ...overrides };
+}
 
 const mockProviderInfos = [
   {
@@ -32,7 +44,7 @@ const mockProviderInfos = [
       { name: 'another-connection', id: 'conn-2' },
     ],
     chunkConnections: [
-      { id: 'chunker-1', name: 'Docling Chunker' },
+      { id: 'chunker-1', name: 'Docling Chunker', supportedExtensions: ['pdf', 'txt', 'md'] },
       { id: 'chunker-2', name: 'Simple Chunker' },
     ],
   },
@@ -241,4 +253,66 @@ test('getDatabaseName and getChunkProviderName both return N/A when both connect
 
   expect(getDatabaseName(mockProviderInfos, ragEnvironment)).toBe('N/A');
   expect(getChunkProviderName(mockProviderInfos, ragEnvironment)).toBe('N/A');
+});
+
+// --- getChunkProviderSupportedExtensions tests ---
+
+test('getChunkProviderSupportedExtensions returns supportedExtensions from chunk connection', () => {
+  const ragEnvironment: RagEnvironment = {
+    name: 'test-env',
+    ragConnection: { name: 'chroma-connection', providerId: 'chroma-1' },
+    chunkerConnection: { id: 'chunker-1', providerId: 'chroma-1' },
+    files: [],
+  };
+
+  expect(getChunkProviderSupportedExtensions(mockProviderInfos, ragEnvironment)).toEqual(['pdf', 'txt', 'md']);
+});
+
+test('getChunkProviderSupportedExtensions returns undefined when chunker has no supportedExtensions', () => {
+  const ragEnvironment: RagEnvironment = {
+    name: 'test-env',
+    ragConnection: { name: 'chroma-connection', providerId: 'chroma-1' },
+    chunkerConnection: { id: 'chunker-2', providerId: 'chroma-1' },
+    files: [],
+  };
+
+  expect(getChunkProviderSupportedExtensions(mockProviderInfos, ragEnvironment)).toBeUndefined();
+});
+
+// --- buildDialogFilters tests ---
+
+test('file picker filters are derived from chunker supportedExtensions', () => {
+  const connection = createMockChunkProviderConnection({
+    supportedExtensions: ['pdf', 'docx', 'csv'],
+  });
+  const filters = buildDialogFilters(connection);
+  const extensions = filters.flatMap(filter => filter.extensions);
+  expect(extensions).toContain('pdf');
+  expect(extensions).toContain('docx');
+  expect(extensions).not.toContain('txt');
+});
+
+test('falls back gracefully when supportedExtensions is undefined', () => {
+  const connection = createMockChunkProviderConnection({});
+  const filters = buildDialogFilters(connection);
+  expect(filters.length).toBeGreaterThan(0);
+  expect(filters[0]).toEqual({ name: 'All Files', extensions: ['*'] });
+});
+
+test('buildDialogFilters returns sorted unique extensions', () => {
+  expect(buildDialogFilters({ supportedExtensions: ['PDF', 'txt', 'pdf', 'md'] })).toEqual([
+    { name: 'Supported documents', extensions: ['md', 'pdf', 'txt'] },
+  ]);
+});
+
+// --- formatSupportedExtensionsLabel tests ---
+
+test('formatSupportedExtensionsLabel truncates long extension lists', () => {
+  expect(formatSupportedExtensionsLabel(['pdf', 'txt', 'md', 'markdown', 'html'])).toBe(
+    'PDF, TXT, MD, MARKDOWN, and more',
+  );
+});
+
+test('formatSupportedExtensionsLabel returns All file types for empty list', () => {
+  expect(formatSupportedExtensionsLabel([])).toBe('All file types');
 });

--- a/packages/renderer/src/lib/rag/rag-environment-utils.spec.ts
+++ b/packages/renderer/src/lib/rag/rag-environment-utils.spec.ts
@@ -16,17 +16,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { expect, test } from 'vitest';
+
 import type { ProviderInfo } from '/@api/provider-info';
 import type { RagEnvironment } from '/@api/rag/rag-environment';
-import { expect, test } from 'vitest';
 
 import {
   buildDialogFilters,
+  type ChunkProviderFileFilterSource,
   formatSupportedExtensionsLabel,
   getChunkProviderName,
   getChunkProviderSupportedExtensions,
   getDatabaseName,
-  type ChunkProviderFileFilterSource,
 } from './rag-environment-utils';
 
 function createMockChunkProviderConnection(

--- a/packages/renderer/src/lib/rag/rag-environment-utils.ts
+++ b/packages/renderer/src/lib/rag/rag-environment-utils.ts
@@ -1,12 +1,33 @@
+import type { OpenDialogOptions } from '@openkaiden/api';
+
 import type { ProviderInfo } from '/@api/provider-info';
 import type { RagEnvironment } from '/@api/rag/rag-environment';
 
-export function getDatabaseName(providerInfos: ProviderInfo[], ragEnvironment: RagEnvironment | undefined): string {
-  const ragProvider = providerInfos.find(provider => provider.id === ragEnvironment?.ragConnection?.providerId);
-  const ragConnection = ragProvider?.ragConnections.find(
-    connection => connection.name === ragEnvironment?.ragConnection?.name,
-  );
-  return ragConnection?.name ? `${ragConnection.name} (${ragProvider?.name})` : 'N/A';
+export type ChunkProviderFileFilterSource = {
+  supportedExtensions?: string[];
+};
+
+export function buildDialogFilters(
+  connection: ChunkProviderFileFilterSource,
+): NonNullable<OpenDialogOptions['filters']> {
+  if (connection.supportedExtensions && connection.supportedExtensions.length > 0) {
+    const uniqueExtensions = [
+      ...new Set(connection.supportedExtensions.map(extension => extension.toLowerCase())),
+    ].sort((a, b) => a.localeCompare(b));
+    return [{ name: 'Supported documents', extensions: uniqueExtensions }];
+  }
+
+  return [{ name: 'All Files', extensions: ['*'] }];
+}
+
+export function formatSupportedExtensionsLabel(extensions: string[]): string {
+  if (extensions.length === 0) {
+    return 'All file types';
+  }
+
+  const displayExtensions = extensions.slice(0, 4).map(extension => extension.toUpperCase());
+  const label = displayExtensions.join(', ');
+  return extensions.length > 4 ? `${label}, and more` : label;
 }
 
 export function getChunkProviderName(
@@ -17,4 +38,23 @@ export function getChunkProviderName(
   const provider = providerInfos.find(p => p.id === ragEnvironment.chunkerConnection.providerId);
   const connection = provider?.chunkConnections.find(c => c.id === ragEnvironment.chunkerConnection.id);
   return connection ? `${connection.name} (${provider?.name})` : 'N/A';
+}
+
+export function getChunkProviderSupportedExtensions(
+  providerInfos: ProviderInfo[],
+  ragEnvironment: RagEnvironment | undefined,
+): string[] | undefined {
+  if (!ragEnvironment?.chunkerConnection) return undefined;
+
+  const provider = providerInfos.find(p => p.id === ragEnvironment.chunkerConnection.providerId);
+  const connection = provider?.chunkConnections.find(c => c.id === ragEnvironment.chunkerConnection.id);
+  return connection?.supportedExtensions;
+}
+
+export function getDatabaseName(providerInfos: ProviderInfo[], ragEnvironment: RagEnvironment | undefined): string {
+  const ragProvider = providerInfos.find(provider => provider.id === ragEnvironment?.ragConnection?.providerId);
+  const ragConnection = ragProvider?.ragConnections.find(
+    connection => connection.name === ragEnvironment?.ragConnection?.name,
+  );
+  return ragConnection?.name ? `${ragConnection.name} (${ragProvider?.name})` : 'N/A';
 }

--- a/packages/renderer/src/lib/rag/rag-environment-utils.ts
+++ b/packages/renderer/src/lib/rag/rag-environment-utils.ts
@@ -10,7 +10,7 @@ export type ChunkProviderFileFilterSource = {
 export function buildDialogFilters(
   connection: ChunkProviderFileFilterSource,
 ): NonNullable<OpenDialogOptions['filters']> {
-  if (connection.supportedExtensions && connection.supportedExtensions.length > 0) {
+  if (connection.supportedExtensions?.length) {
     const uniqueExtensions = [
       ...new Set(connection.supportedExtensions.map(extension => extension.toLowerCase())),
     ].sort((a, b) => a.localeCompare(b));
@@ -28,6 +28,14 @@ export function formatSupportedExtensionsLabel(extensions: string[]): string {
   const displayExtensions = extensions.slice(0, 4).map(extension => extension.toUpperCase());
   const label = displayExtensions.join(', ');
   return extensions.length > 4 ? `${label}, and more` : label;
+}
+
+export function getDatabaseName(providerInfos: ProviderInfo[], ragEnvironment: RagEnvironment | undefined): string {
+  const ragProvider = providerInfos.find(provider => provider.id === ragEnvironment?.ragConnection?.providerId);
+  const ragConnection = ragProvider?.ragConnections.find(
+    connection => connection.name === ragEnvironment?.ragConnection?.name,
+  );
+  return ragConnection?.name ? `${ragConnection.name} (${ragProvider?.name})` : 'N/A';
 }
 
 export function getChunkProviderName(
@@ -49,12 +57,4 @@ export function getChunkProviderSupportedExtensions(
   const provider = providerInfos.find(p => p.id === ragEnvironment.chunkerConnection.providerId);
   const connection = provider?.chunkConnections.find(c => c.id === ragEnvironment.chunkerConnection.id);
   return connection?.supportedExtensions;
-}
-
-export function getDatabaseName(providerInfos: ProviderInfo[], ragEnvironment: RagEnvironment | undefined): string {
-  const ragProvider = providerInfos.find(provider => provider.id === ragEnvironment?.ragConnection?.providerId);
-  const ragConnection = ragProvider?.ragConnections.find(
-    connection => connection.name === ragEnvironment?.ragConnection?.name,
-  );
-  return ragConnection?.name ? `${ragConnection.name} (${ragProvider?.name})` : 'N/A';
 }


### PR DESCRIPTION
…abilities

Expose supportedExtensions on ChunkProviderConnection so chunk providers advertise supported formats once, and build the knowledge base upload dialog from that metadata instead of a duplicated hardcoded list.