### PR TITLE
feat(workspaces): support ports in network destinations

### DIFF
--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
@@ -44,6 +44,7 @@ describe('parseNetworkDestination', () => {
     'api.example.com:0',
     'api.example.com:65536',
     'api.example.com:https',
+    'api.example.com:',
     ':8080',
     '',
   ])('rejects invalid destination %j', destination => {

--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
@@ -25,8 +25,31 @@ import {
   formatEndpointFlag,
   OPENSHELL_CONTAINER_HOST,
   parseModelEndpoint,
+  parseNetworkDestination,
   rewriteLocalhostUrl,
 } from './openshell-network-policy.js';
+
+describe('parseNetworkDestination', () => {
+  test('parses a hostname without a port', () => {
+    expect(parseNetworkDestination('registry.npmjs.org')).toEqual({ host: 'registry.npmjs.org' });
+  });
+
+  test('parses a hostname with an explicit port', () => {
+    expect(parseNetworkDestination('api.example.com:8080')).toEqual({ host: 'api.example.com', port: 8080 });
+  });
+
+  test.each([
+    '[2001:db8::1]:8443',
+    '2001:db8::1',
+    'api.example.com:0',
+    'api.example.com:65536',
+    'api.example.com:https',
+    ':8080',
+    '',
+  ])('rejects invalid destination %j', destination => {
+    expect(parseNetworkDestination(destination)).toBeUndefined();
+  });
+});
 
 describe('rewriteLocalhostUrl', () => {
   test('rewrites localhost to host.openshell.internal', () => {
@@ -138,6 +161,18 @@ describe('buildPolicyObject', () => {
         },
       },
     });
+  });
+
+  test('builds one endpoint for a host with an explicit port', () => {
+    const policy = buildPolicyObject({ mode: 'deny', hosts: ['api.example.com:8080'] });
+
+    expect(policy!.network_policies!['kdn-network']!.endpoints).toEqual([
+      { host: 'api.example.com', port: 8080, protocol: 'rest', access: 'full', allow_encoded_slash: true },
+    ]);
+  });
+
+  test('omits invalid destinations', () => {
+    expect(buildPolicyObject({ mode: 'deny', hosts: ['api.example.com:99999'] })).toBeUndefined();
   });
 
   test('builds model rule for valid endpoint', () => {

--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { isIPv6 } from 'node:net';
+
 import z from 'zod';
 
 import type { NetworkConfiguration } from '/@api/agent-workspace-info.js';
@@ -135,6 +137,39 @@ export interface ModelEndpoint {
   port: number;
 }
 
+export interface NetworkDestination {
+  host: string;
+  port?: number;
+}
+
+/**
+ * Parses a network destination stored as either `host` or `host:port`.
+ * IPv6 is rejected because OpenShell endpoint flags use colon delimiters.
+ */
+export function parseNetworkDestination(destination: string): NetworkDestination | undefined {
+  const value = destination.trim();
+  if (!value) return undefined;
+
+  let parsed: URL;
+  try {
+    // A non-special scheme preserves explicit default ports such as 80 and 443.
+    parsed = new URL(`kdn://${value}`);
+  } catch {
+    return undefined;
+  }
+
+  if (parsed.username || parsed.password || parsed.pathname || parsed.search || parsed.hash) return undefined;
+
+  const host = parsed.hostname;
+  const unbracketedHost = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+  if (!host || isIPv6(unbracketedHost)) return undefined;
+
+  if (!parsed.port) return { host };
+
+  const port = Number(parsed.port);
+  return port > 0 ? { host, port } : undefined;
+}
+
 /**
  * Rewrites localhost URLs to {@link OPENSHELL_CONTAINER_HOST} so the
  * sandbox can reach host-local model servers (e.g. Ollama).
@@ -230,14 +265,25 @@ export function buildPolicyObject(network?: NetworkConfiguration, modelEndpoint?
   const networkPolicies: Record<string, OpenshellNetworkPolicyEntry> = {};
 
   if (network && network.mode !== 'allow' && network.hosts?.length) {
-    const endpoints: OpenshellEndpoint[] = network.hosts.flatMap(host => [
-      { host, port: 443, protocol: 'rest' as const, access: 'full' as const, allow_encoded_slash: true },
-      { host, port: 80, protocol: 'rest' as const, access: 'full' as const, allow_encoded_slash: true },
-    ]);
-    networkPolicies[NETWORK_RULE_NAME] = {
-      endpoints,
-      binaries: [{ path: '/**' }],
-    };
+    const endpoints: OpenshellEndpoint[] = network.hosts.flatMap(destination => {
+      const parsed = parseNetworkDestination(destination);
+      if (!parsed) return [];
+
+      const ports = parsed.port === undefined ? [443, 80] : [parsed.port];
+      return ports.map(port => ({
+        host: parsed.host,
+        port,
+        protocol: 'rest' as const,
+        access: 'full' as const,
+        allow_encoded_slash: true,
+      }));
+    });
+    if (endpoints.length > 0) {
+      networkPolicies[NETWORK_RULE_NAME] = {
+        endpoints,
+        binaries: [{ path: '/**' }],
+      };
+    }
   }
 
   if (modelEndpoint) {

--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
@@ -148,7 +148,7 @@ export interface NetworkDestination {
  */
 export function parseNetworkDestination(destination: string): NetworkDestination | undefined {
   const value = destination.trim();
-  if (!value) return undefined;
+  if (!value || value.endsWith(':')) return undefined;
 
   let parsed: URL;
   try {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
@@ -126,7 +126,9 @@ let showCustomHosts = $derived(selectedNetwork === 'blocked' || selectedNetwork 
 
 {#if showCustomHosts}
   <div class="mt-4 p-4 rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)]">
-    <p class="text-xs text-[var(--pd-content-card-text)] opacity-70 mb-3">Additional hosts to allow outbound access to. You can refine this list later in workspace settings.</p>
+    <p class="text-xs text-[var(--pd-content-card-text)] opacity-70 mb-3">
+      Additional destinations to allow outbound access to. Add an optional port with <code>host:port</code>; destinations without a port allow HTTP and HTTPS.
+    </p>
     {#each customHosts as host, index (index)}
       <div class="flex gap-3 mb-2 items-center">
         <Input


### PR DESCRIPTION
## Summary

- accept optional `host:port` notation in workspace network destinations
- preserve the existing HTTP/HTTPS defaults for destinations without a port
- reject invalid ports and IPv6 destinations that cannot be represented safely in OpenShell endpoint flags
- document the optional port notation in the workspace networking UI

Fixes #2579

## Local testing

Run the focused policy tests:

```bash
pnpm exec vitest run packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
```

To verify the feature end to end with a local OpenShell gateway (OpenShell 0.0.105):

1. Start Kaiden and wait for its OpenShell gateway to be ready.
2. In another terminal, start a temporary host-local server:

   ```bash
   python3 -m http.server 18081 --bind 0.0.0.0
   ```

3. Create a workspace in Kaiden. On the **Networking** step, add this destination:

   ```text
   host.openshell.internal:18081
   ```

4. After the workspace is ready, replace `<workspace-name>` below and inspect its full effective policy:

   ```bash
   openshell policy get <workspace-name> --full --output json
   ```

   The `kdn-network` policy should contain exactly one endpoint for this destination, with `host` set to `host.openshell.internal` and `port` set to `18081`; it should not add ports 80 or 443 for that destination.

5. Confirm the configured port is reachable:

   ```bash
   openshell sandbox exec --name <workspace-name> -- \
     curl --silent --show-error --max-time 5 http://host.openshell.internal:18081/
   ```

6. Confirm an unlisted adjacent port is still denied:

   ```bash
   openshell sandbox exec --name <workspace-name> -- \
     curl --silent --show-error --max-time 5 http://host.openshell.internal:18082/
   ```

   OpenShell should return a `policy_denied` response for port 18082.

Stop the temporary HTTP server with Ctrl+C and delete the test workspace from Kaiden when finished.
