### PR TITLE
test(e2e): add e2e tests for restarting onboarding from preferences

### DIFF
--- a/tests/playwright/src/fixtures/guided-setup-fixture.ts
+++ b/tests/playwright/src/fixtures/guided-setup-fixture.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ElectronApplication, Page } from '@playwright/test';
+import { type ElectronApplication, expect, type Page, test } from '@playwright/test';
 
 import { getFirstPage, launchElectronApp } from '/@/fixtures/electron-app';
 
@@ -39,4 +39,21 @@ export async function closeGuidedSetupSession(electronApp: ElectronApplication):
   await electronApp.close().catch(() => {});
 }
 
-export { expect, test } from '@playwright/test';
+/** Binds a fresh guided-setup Electron session to the enclosing describe block via beforeAll/afterAll. */
+export function bindGuidedSetupSession(): Partial<GuidedSetupSession> {
+  const session: Partial<GuidedSetupSession> = {};
+
+  test.beforeAll(async () => {
+    ({ electronApp: session.electronApp, page: session.page } = await launchGuidedSetupSession());
+  });
+
+  test.afterAll(async () => {
+    if (session.electronApp) {
+      await closeGuidedSetupSession(session.electronApp);
+    }
+  });
+
+  return session;
+}
+
+export { expect, test };

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -76,6 +76,7 @@ export enum PreferenceOption {
   EXIT_ON_CLOSE = 'Exit On Close',
   EXTENSIONS = 'Extensions',
   KUBERNETES = 'Kubernetes',
+  ONBOARDING = 'Onboarding',
   TASKS = 'Tasks',
   TELEMETRY = 'Telemetry',
   TERMINAL = 'Terminal',

--- a/tests/playwright/src/model/navigation/navigation.ts
+++ b/tests/playwright/src/model/navigation/navigation.ts
@@ -22,6 +22,7 @@ import { builtInExtensions, ExtensionStatus } from '/@/model/core/types';
 import { AgentWorkspacesPage } from '/@/model/pages/agent-workspaces-page';
 import type { BasePage } from '/@/model/pages/base-page';
 import { ChatPage } from '/@/model/pages/chat-page';
+import { CodingAgentsPage } from '/@/model/pages/coding-agents-page';
 import { ExtensionsPage } from '/@/model/pages/extensions-page';
 import { KnowledgePage } from '/@/model/pages/knowledge-page';
 import { McpPage } from '/@/model/pages/mcp-page';
@@ -37,6 +38,7 @@ export class NavigationBar {
   readonly knowledgesLink: Locator;
   readonly extensionsLink: Locator;
   readonly workspacesLink: Locator;
+  readonly codingAgentsLink: Locator;
   readonly settingsLink: Locator;
   private readonly links: Locator[];
 
@@ -49,6 +51,7 @@ export class NavigationBar {
     this.knowledgesLink = this.navigationLocator.getByRole('link', { name: 'Knowledges', exact: true });
     this.extensionsLink = this.navigationLocator.getByRole('link', { name: 'Extensions', exact: true });
     this.workspacesLink = this.navigationLocator.getByRole('link', { name: 'Workspaces', exact: true });
+    this.codingAgentsLink = this.navigationLocator.getByRole('link', { name: 'Coding agents', exact: true });
     this.settingsLink = this.navigationLocator.getByRole('link', { name: 'Settings', exact: true });
     this.links = [
       this.chatLink,
@@ -57,6 +60,7 @@ export class NavigationBar {
       this.knowledgesLink,
       this.extensionsLink,
       this.workspacesLink,
+      this.codingAgentsLink,
       this.settingsLink,
     ];
   }
@@ -115,6 +119,10 @@ export class NavigationBar {
 
   async navigateToWorkspacesPage(): Promise<AgentWorkspacesPage> {
     return this.navigateTo(this.workspacesLink, AgentWorkspacesPage);
+  }
+
+  async navigateToCodingAgentsPage(): Promise<CodingAgentsPage> {
+    return this.navigateTo(this.codingAgentsLink, CodingAgentsPage);
   }
 
   async navigateToSettingsPage(): Promise<SettingsPage> {

--- a/tests/playwright/src/model/pages/coding-agents-page.ts
+++ b/tests/playwright/src/model/pages/coding-agents-page.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import { BasePage } from './base-page';
+
+export class CodingAgentsPage extends BasePage {
+  readonly agentNav: Locator;
+  readonly detailHeading: Locator;
+  readonly selectedModel: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.agentNav = page.getByRole('navigation', { name: 'Coding agents' });
+    this.detailHeading = page.getByRole('heading', { level: 1 });
+    this.selectedModel = page.getByTestId('selected-model');
+  }
+
+  async waitForLoad(): Promise<void> {
+    await expect(this.agentNav).toBeVisible();
+  }
+
+  getAgentButton(agentName: string): Locator {
+    return this.agentNav.getByRole('button', { name: agentName });
+  }
+
+  async selectAgent(agentName: string): Promise<void> {
+    await this.getAgentButton(agentName).click();
+    await expect(this.detailHeading).toHaveText(agentName);
+  }
+
+  async expectDefaultModelSelected(modelLabel: string): Promise<void> {
+    await expect(this.selectedModel).toHaveText(`Selected: ${modelLabel}`);
+  }
+}

--- a/tests/playwright/src/model/pages/guided-setup-page.ts
+++ b/tests/playwright/src/model/pages/guided-setup-page.ts
@@ -132,13 +132,17 @@ export class GuidedSetupPage extends BasePage {
     return text?.replace(/^Selected:\s*/, '').trim() ?? '';
   }
 
-  async completeAgentModelFor(agent: CodingAgent): Promise<string> {
+  async ensureModelCatalogFor(agent: CodingAgent): Promise<void> {
     await this.selectAgent(agent);
     const setup = resolveAgentModelConnectionFor(agent);
     if (setup && (await this.dialog.getByTestId('no-models-create-connection').isVisible())) {
       await this.createInlineConnection(setup);
     }
     await this.waitForModelCatalog();
+  }
+
+  async completeAgentModelFor(agent: CodingAgent): Promise<string> {
+    await this.ensureModelCatalogFor(agent);
     await this.selectGuidedSetupDefaultModel(agent);
     return this.getSelectedModelLabel();
   }

--- a/tests/playwright/src/model/pages/guided-setup-workflow.ts
+++ b/tests/playwright/src/model/pages/guided-setup-workflow.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Page, test } from '@playwright/test';
+
+import type { CodingAgent } from '/@/model/core/types';
+import { WIZARD_STEP } from '/@/model/core/types';
+import { NavigationBar } from '/@/model/navigation/navigation';
+import { agentModelSetupSkipMessageFor, isAgentModelSetupAvailable } from '/@/model/pages/agent-model-setup';
+import { AgentWorkspacesPage } from '/@/model/pages/agent-workspaces-page';
+import type { GuidedSetupPage } from '/@/model/pages/guided-setup-page';
+
+export function describeAgentOnboarding(agent: CodingAgent, title: string, body: () => void): void {
+  const available = isAgentModelSetupAvailable(agent);
+  const describeFn = available ? test.describe : test.describe.skip;
+  describeFn(available ? title : agentModelSetupSkipMessageFor(agent), body);
+}
+
+export async function completeGuidedSetupFor(guidedSetup: GuidedSetupPage, agent: CodingAgent): Promise<string> {
+  await guidedSetup.startFromWelcome();
+  const selectedModel = await guidedSetup.completeAgentModelFor(agent);
+  await guidedSetup.complete();
+  return selectedModel;
+}
+
+export async function expectDefaultsInWorkspaceWizard(
+  page: Page,
+  agent: CodingAgent,
+  modelLabel: string,
+): Promise<void> {
+  const navigationBar = new NavigationBar(page);
+  const agentWorkspacesPage = new AgentWorkspacesPage(page);
+  await navigationBar.navigateToWorkspacesPage();
+  const createPage = await agentWorkspacesPage.openCreatePage();
+  await createPage.sessionNameInput.fill('guided-setup-test');
+  await createPage.navigateToStep(WIZARD_STEP.AGENT_MODEL);
+  await createPage.expectAgentSelected(agent);
+  await createPage.expectModelSelected(modelLabel);
+}

--- a/tests/playwright/src/model/pages/onboarding-restart-workflow.ts
+++ b/tests/playwright/src/model/pages/onboarding-restart-workflow.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect } from '@playwright/test';
+
+import type { CodingAgent } from '/@/model/core/types';
+import type { NavigationBar } from '/@/model/navigation/navigation';
+import type { GuidedSetupPage } from '/@/model/pages/guided-setup-page';
+
+export async function restartOnboarding(navigationBar: NavigationBar, guidedSetup: GuidedSetupPage): Promise<void> {
+  const settingsPage = await navigationBar.navigateToSettingsPage();
+  const preferencesPage = await settingsPage.openPreferences();
+  await preferencesPage.clickOnboardAgain();
+  await expect(guidedSetup.welcomePage).toBeVisible();
+}
+
+export async function expectDefaultModelInCodingAgents(
+  navigationBar: NavigationBar,
+  agent: CodingAgent,
+  modelLabel: string,
+): Promise<void> {
+  const codingAgentsPage = await navigationBar.navigateToCodingAgentsPage();
+  await codingAgentsPage.selectAgent(agent);
+  await codingAgentsPage.expectDefaultModelSelected(modelLabel);
+}
+
+export interface GuidedSetupCompletion {
+  modelLabel: string;
+  availableModelCount: number;
+}
+
+export async function completeGuidedSetupWithModel(
+  guidedSetup: GuidedSetupPage,
+  agent: CodingAgent,
+  pickLabel: (labels: string[]) => string,
+): Promise<GuidedSetupCompletion> {
+  await guidedSetup.startFromWelcome();
+  await guidedSetup.ensureModelCatalogFor(agent);
+  const modelLabels = await guidedSetup.getModelLabels();
+  const modelLabel = pickLabel(modelLabels);
+  await guidedSetup.selectModelByLabel(modelLabel);
+  await guidedSetup.complete();
+  return { modelLabel, availableModelCount: modelLabels.length };
+}

--- a/tests/playwright/src/model/pages/settings-preferences-tab-page.ts
+++ b/tests/playwright/src/model/pages/settings-preferences-tab-page.ts
@@ -25,11 +25,13 @@ import { BasePage } from './base-page';
 export class SettingsPreferencesPage extends BasePage {
   readonly searchField: Locator;
   readonly chatToggle: Locator;
+  readonly onboardAgainButton: Locator;
 
   constructor(page: Page) {
     super(page);
     this.searchField = page.getByLabel('search preferences');
     this.chatToggle = page.getByRole('checkbox', { name: 'Show or hide the chat window.' });
+    this.onboardAgainButton = page.getByRole('button', { name: 'Onboard again' });
   }
 
   async waitForLoad(): Promise<void> {
@@ -67,5 +69,10 @@ export class SettingsPreferencesPage extends BasePage {
   async enableChatWindow(): Promise<void> {
     await this.selectPreference(PreferenceOption.CHAT);
     await this.chatToggle.check({ force: true });
+  }
+
+  async clickOnboardAgain(): Promise<void> {
+    await this.selectPreference(PreferenceOption.ONBOARDING);
+    await this.onboardAgainButton.click();
   }
 }

--- a/tests/playwright/src/specs/dashboard.spec.ts
+++ b/tests/playwright/src/specs/dashboard.spec.ts
@@ -28,7 +28,7 @@ test.describe
 
     test('[APP-01] Navigation bar is visible and contains all expected navigation links', async ({ navigationBar }) => {
       await expect(navigationBar.navigationLocator).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
-      const expectedLinksCount = 7; // Chat, MCP, Skills, Knowledges, Extensions, Workspaces, Settings
+      const expectedLinksCount = 8; // Chat, MCP, Skills, Knowledges, Extensions, Workspaces, Coding agents, Settings
 
       const allLinks = navigationBar.getAllLinks();
       expect(allLinks).toHaveLength(expectedLinksCount);

--- a/tests/playwright/src/specs/guided-setup-smoke.spec.ts
+++ b/tests/playwright/src/specs/guided-setup-smoke.spec.ts
@@ -16,67 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ElectronApplication, Page } from '@playwright/test';
-
-import { closeGuidedSetupSession, expect, launchGuidedSetupSession, test } from '/@/fixtures/guided-setup-fixture';
-import { CODING_AGENT, type CodingAgent, ENABLED_CODING_AGENTS, WIZARD_STEP } from '/@/model/core/types';
+import { bindGuidedSetupSession, expect, test } from '/@/fixtures/guided-setup-fixture';
+import { CODING_AGENT, ENABLED_CODING_AGENTS, WIZARD_STEP } from '/@/model/core/types';
 import { NavigationBar } from '/@/model/navigation/navigation';
-import {
-  agentModelSetupSkipMessageFor,
-  isAgentModelSetupAvailable,
-  resolveAgentModelConnectionFor,
-} from '/@/model/pages/agent-model-setup';
+import { resolveAgentModelConnectionFor } from '/@/model/pages/agent-model-setup';
 import { AgentWorkspacesPage } from '/@/model/pages/agent-workspaces-page';
 import { GuidedSetupPage } from '/@/model/pages/guided-setup-page';
+import {
+  completeGuidedSetupFor,
+  describeAgentOnboarding,
+  expectDefaultsInWorkspaceWizard,
+} from '/@/model/pages/guided-setup-workflow';
 
 const candidateModels = [process.env.INFERENCE_MODEL, process.env.INFERENCE_SECOND_MODEL].filter(
   (model): model is string => Boolean(model),
 );
-
-function describeAgentOnboarding(agent: CodingAgent, title: string, body: () => void): void {
-  const available = isAgentModelSetupAvailable(agent);
-  const describeFn = available ? test.describe : test.describe.skip;
-  describeFn(available ? title : agentModelSetupSkipMessageFor(agent), body);
-}
-
-async function completeGuidedSetupFor(guidedSetup: GuidedSetupPage, agent: CodingAgent): Promise<string> {
-  await guidedSetup.startFromWelcome();
-  const selectedModel = await guidedSetup.completeAgentModelFor(agent);
-  await guidedSetup.complete();
-  return selectedModel;
-}
-
-async function expectDefaultsInWorkspaceWizard(
-  page: Page,
-  agent: CodingAgent,
-  modelLabel: string,
-  workingDir = '/tmp/guided-setup-test',
-): Promise<void> {
-  const navigationBar = new NavigationBar(page);
-  const agentWorkspacesPage = new AgentWorkspacesPage(page);
-  await navigationBar.navigateToWorkspacesPage();
-  const createPage = await agentWorkspacesPage.openCreatePage();
-  await createPage.workingDirInput.fill(workingDir);
-  await createPage.navigateToStep(WIZARD_STEP.AGENT_MODEL);
-  await createPage.expectAgentSelected(agent);
-  await createPage.expectModelSelected(modelLabel);
-}
-
-function bindGuidedSetupSession(): { electronApp?: ElectronApplication; page?: Page } {
-  const session: { electronApp?: ElectronApplication; page?: Page } = {};
-
-  test.beforeAll(async () => {
-    ({ electronApp: session.electronApp, page: session.page } = await launchGuidedSetupSession());
-  });
-
-  test.afterAll(async () => {
-    if (session.electronApp) {
-      await closeGuidedSetupSession(session.electronApp);
-    }
-  });
-
-  return session;
-}
 
 test.describe('Guided setup smoke', { tag: '@smoke' }, () => {
   describeAgentOnboarding(CODING_AGENT.OPENCODE, 'OpenCode onboarding', () => {

--- a/tests/playwright/src/specs/settings-smoke.spec.ts
+++ b/tests/playwright/src/specs/settings-smoke.spec.ts
@@ -16,12 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { expect, workerTest as test } from '/@/fixtures/electron-app';
+import { bindGuidedSetupSession, test as isolatedTest } from '/@/fixtures/guided-setup-fixture';
 import {
+  CODING_AGENT,
   featuredResources,
   preferenceOptions,
   proxyConfigurations,
   resourcesWithCreateButton,
 } from '/@/model/core/types';
+import { NavigationBar } from '/@/model/navigation/navigation';
+import { GuidedSetupPage } from '/@/model/pages/guided-setup-page';
+import { describeAgentOnboarding } from '/@/model/pages/guided-setup-workflow';
+import {
+  completeGuidedSetupWithModel,
+  expectDefaultModelInCodingAgents,
+  restartOnboarding,
+} from '/@/model/pages/onboarding-restart-workflow';
 import { waitForNavigationReady } from '/@/utils/app-ready';
 
 test.describe('Settings page navigation', { tag: '@smoke' }, () => {
@@ -92,5 +102,65 @@ test.describe('Settings page navigation', { tag: '@smoke' }, () => {
       await expect(preferencesPage.getPreferenceContent(option)).toBeVisible();
       await preferencesPage.clearSearch();
     }
+  });
+});
+
+isolatedTest.describe('Settings - onboarding restart', { tag: '@smoke' }, () => {
+  describeAgentOnboarding(CODING_AGENT.OPENCODE, 'OpenCode', () => {
+    const session = bindGuidedSetupSession();
+
+    isolatedTest('[SET-07] persists a newly selected default model', async () => {
+      const guidedSetup = new GuidedSetupPage(session.page!);
+      const navigationBar = new NavigationBar(session.page!);
+
+      const initialOnboardingRestart = await completeGuidedSetupWithModel(
+        guidedSetup,
+        CODING_AGENT.OPENCODE,
+        labels => labels.at(-1)!,
+      );
+      await expectDefaultModelInCodingAgents(navigationBar, CODING_AGENT.OPENCODE, initialOnboardingRestart.modelLabel);
+
+      await restartOnboarding(navigationBar, guidedSetup);
+
+      const updatedOnboardingRestart = await completeGuidedSetupWithModel(
+        guidedSetup,
+        CODING_AGENT.OPENCODE,
+        labels =>
+          labels.find(label => label !== initialOnboardingRestart.modelLabel) ?? initialOnboardingRestart.modelLabel,
+      );
+      await expectDefaultModelInCodingAgents(navigationBar, CODING_AGENT.OPENCODE, updatedOnboardingRestart.modelLabel);
+
+      // Only enough local Ollama/RamaLama models guarantee a different one was available to switch to.
+      if (updatedOnboardingRestart.availableModelCount > 1) {
+        expect(updatedOnboardingRestart.modelLabel).not.toBe(initialOnboardingRestart.modelLabel);
+      }
+    });
+  });
+
+  describeAgentOnboarding(CODING_AGENT.CLAUDE, 'Claude Code', () => {
+    const claudeSession = bindGuidedSetupSession();
+
+    isolatedTest('[SET-08] persists a newly selected default model', async () => {
+      const guidedSetup = new GuidedSetupPage(claudeSession.page!);
+      const navigationBar = new NavigationBar(claudeSession.page!);
+
+      const initialOnboardingRestart = await completeGuidedSetupWithModel(
+        guidedSetup,
+        CODING_AGENT.CLAUDE,
+        labels => labels.at(-1)!,
+      );
+      await expectDefaultModelInCodingAgents(navigationBar, CODING_AGENT.CLAUDE, initialOnboardingRestart.modelLabel);
+
+      await restartOnboarding(navigationBar, guidedSetup);
+
+      const updatedOnboardingRestart = await completeGuidedSetupWithModel(
+        guidedSetup,
+        CODING_AGENT.CLAUDE,
+        labels =>
+          labels.find(label => label !== initialOnboardingRestart.modelLabel) ?? initialOnboardingRestart.modelLabel,
+      );
+      await expectDefaultModelInCodingAgents(navigationBar, CODING_AGENT.CLAUDE, updatedOnboardingRestart.modelLabel);
+      expect(updatedOnboardingRestart.modelLabel).not.toBe(initialOnboardingRestart.modelLabel);
+    });
   });
 });


### PR DESCRIPTION
Adds e2e coverage for the "Onboard again" flow in Settings > Preferences.

Closes https://github.com/openkaiden/kaiden/issues/2681