### PR TITLE
feat(renderer): add gateway filter dropdown to Agentic Workspaces list

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
@@ -18,19 +18,24 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen, within } from '@testing-library/svelte';
+import { fireEvent, render, screen, within } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { notificationQueue } from '/@/stores/notifications';
-import { openshellSandboxes } from '/@/stores/openshell-sandboxes';
+import { openshellGateways } from '/@/stores/openshell-gateways';
+import { openshellSandboxes, selectedGateway } from '/@/stores/openshell-sandboxes';
 import type { NotificationCard } from '/@api/notification';
-import type { GatewaySandboxes } from '/@api/openshell-gateway-info';
+import type { GatewayInfo, GatewaySandboxes } from '/@api/openshell-gateway-info';
 
 import AgentWorkspaceList from './AgentWorkspaceList.svelte';
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
   openshellSandboxes.set([]);
+  openshellGateways.set([]);
+  selectedGateway.set('');
   notificationQueue.set([]);
 });
 
@@ -128,4 +133,93 @@ test('Expect NotificationsBox to be visible when there are highlighted notificat
 
   const notificationsBox = screen.queryByLabelText('Notifications Box');
   expect(notificationsBox).toBeInTheDocument();
+});
+
+test('Expect gateway filter dropdown is not shown when there is only one gateway', async () => {
+  render(AgentWorkspaceList);
+  openshellGateways.set([{ name: 'local', endpoint: 'http://localhost:18080' }]);
+  await tick();
+
+  expect(screen.queryByLabelText('Filter by gateway')).not.toBeInTheDocument();
+});
+
+test('Expect gateway filter dropdown is shown when there are multiple gateways', async () => {
+  const gateways: GatewayInfo[] = [
+    { name: 'local', endpoint: 'http://localhost:18080' },
+    { name: 'remote', endpoint: 'https://remote.example.com:18080' },
+  ];
+
+  render(AgentWorkspaceList);
+  openshellGateways.set(gateways);
+  await tick();
+
+  const dropdown = screen.getByLabelText('Filter by gateway');
+  expect(dropdown).toBeInTheDocument();
+});
+
+test('Expect selecting a gateway filters the workspace list', async () => {
+  const workspaces: GatewaySandboxes[] = [
+    {
+      gateway: { name: 'local', endpoint: 'http://localhost:18080' },
+      sandboxes: [{ id: 'ws-1', name: 'local-workspace', phase: 'Ready', created_at: Date.now().toString() }],
+    },
+    {
+      gateway: { name: 'remote', endpoint: 'https://remote.example.com:18080' },
+      sandboxes: [{ id: 'ws-2', name: 'remote-workspace', phase: 'Ready', created_at: Date.now().toString() }],
+    },
+  ];
+
+  render(AgentWorkspaceList);
+  openshellGateways.set([
+    { name: 'local', endpoint: 'http://localhost:18080' },
+    { name: 'remote', endpoint: 'https://remote.example.com:18080' },
+  ]);
+  openshellSandboxes.set(workspaces);
+  await tick();
+
+  expect(screen.getByText('local-workspace')).toBeInTheDocument();
+  expect(screen.getByText('remote-workspace')).toBeInTheDocument();
+
+  const dropdownTrigger = within(screen.getByLabelText('Filter by gateway')).getByRole('button');
+  await fireEvent.click(dropdownTrigger);
+  await fireEvent.click(screen.getByRole('button', { name: 'local' }));
+  await tick();
+
+  expect(screen.getByText('local-workspace')).toBeInTheDocument();
+  expect(screen.queryByText('remote-workspace')).not.toBeInTheDocument();
+});
+
+test('Expect "All" option shows all workspaces', async () => {
+  const workspaces: GatewaySandboxes[] = [
+    {
+      gateway: { name: 'local', endpoint: 'http://localhost:18080' },
+      sandboxes: [{ id: 'ws-1', name: 'local-workspace', phase: 'Ready', created_at: Date.now().toString() }],
+    },
+    {
+      gateway: { name: 'remote', endpoint: 'https://remote.example.com:18080' },
+      sandboxes: [{ id: 'ws-2', name: 'remote-workspace', phase: 'Ready', created_at: Date.now().toString() }],
+    },
+  ];
+
+  render(AgentWorkspaceList);
+  openshellGateways.set([
+    { name: 'local', endpoint: 'http://localhost:18080' },
+    { name: 'remote', endpoint: 'https://remote.example.com:18080' },
+  ]);
+  openshellSandboxes.set(workspaces);
+  await tick();
+
+  const dropdownTrigger = within(screen.getByLabelText('Filter by gateway')).getByRole('button');
+  await fireEvent.click(dropdownTrigger);
+  await fireEvent.click(screen.getByRole('button', { name: 'local' }));
+  await tick();
+
+  expect(screen.queryByText('remote-workspace')).not.toBeInTheDocument();
+
+  await fireEvent.click(dropdownTrigger);
+  await fireEvent.click(screen.getByRole('button', { name: 'All' }));
+  await tick();
+
+  expect(screen.getByText('local-workspace')).toBeInTheDocument();
+  expect(screen.getByText('remote-workspace')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
@@ -43,6 +43,14 @@ $effect(() => {
   sandboxSearchPattern.set(searchTerm);
 });
 
+// Clear gateway filter when the selected gateway is no longer available
+$effect(() => {
+  const gateways = $openshellGateways;
+  if (gateways.length < 2 || (gatewayFilter && !gateways.some(g => g.name === gatewayFilter))) {
+    gatewayFilter = '';
+  }
+});
+
 // Sync gatewayFilter with sandbox store's selectedGateway
 $effect(() => {
   sandboxSelectedGateway.set(gatewayFilter);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
@@ -2,6 +2,8 @@
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import {
   Button,
+  Dropdown,
+  EmptyScreen,
   FilteredEmptyScreen,
   NavPage,
   SearchInput,
@@ -14,11 +16,13 @@ import {
 import NotificationsBox from '/@/lib/dashboard/NotificationsBox.svelte';
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
 import { handleNavigation } from '/@/navigation';
+import { openshellGateways } from '/@/stores/openshell-gateways';
 import {
   allOpenshellSandboxes,
   filteredOpenshellSandboxes,
   type SandboxInfoWithGateway,
   searchPattern as sandboxSearchPattern,
+  selectedGateway as sandboxSelectedGateway,
 } from '/@/stores/openshell-sandboxes';
 import { NavigationPage } from '/@api/navigation-page';
 
@@ -32,14 +36,36 @@ import SandboxPhase from './columns/SandboxPhase.svelte';
 type SandboxSelectable = SandboxInfoWithGateway & { selected: boolean };
 
 let searchTerm = $state('');
+let gatewayFilter = $state('');
 
 // Sync searchTerm with sandbox store's searchPattern
 $effect(() => {
   sandboxSearchPattern.set(searchTerm);
 });
 
+// Sync gatewayFilter with sandbox store's selectedGateway
+$effect(() => {
+  sandboxSelectedGateway.set(gatewayFilter);
+});
+
+const gatewayOptions = $derived.by(() => {
+  const options: { label: string; value: string }[] = [{ label: 'All', value: '' }];
+  for (const gateway of $openshellGateways) {
+    options.push({ label: gateway.name, value: gateway.name });
+  }
+  return options;
+});
+
+const longestGatewayLabel = $derived(
+  gatewayOptions.reduce((longest, option) => (option.label.length > longest.length ? option.label : longest), ''),
+);
+
 function navigateToCreate(): void {
   handleNavigation({ page: NavigationPage.AGENT_WORKSPACE_CREATE });
+}
+
+function clearGatewayFilter(): void {
+  gatewayFilter = '';
 }
 
 const filteredSandboxes: SandboxSelectable[] = $derived(
@@ -104,13 +130,44 @@ const sandboxColumns = [
       <NotificationsBox />
       <div class="px-5 pt-4 pb-4">
         <AgentWorkspaceStatCards sandboxes={$allOpenshellSandboxes} />
-        <SearchInput bind:searchTerm={searchTerm} title="Agentic Workspaces" />
+        <div class="flex flex-row items-center gap-3">
+          <div class="w-72">
+            <SearchInput bind:searchTerm={searchTerm} title="Agentic Workspaces" />
+          </div>
+          {#if $openshellGateways.length > 1}
+            <div class="inline-grid max-w-64">
+              <div class="invisible col-start-1 row-start-1 flex items-center px-1 py-1 whitespace-nowrap" aria-hidden="true">
+                <span class="mr-1">Gateway:</span>
+                <span class="truncate">{longestGatewayLabel}</span>
+                <span class="w-4 shrink-0"></span>
+              </div>
+              <Dropdown
+                ariaLabel="Filter by gateway"
+                id="gateway-filter"
+                name="gateway-filter"
+                class="col-start-1 row-start-1 whitespace-nowrap grow-0!"
+                bind:value={gatewayFilter}
+                options={gatewayOptions}>
+                {#snippet left()}
+                  <div class="mr-1 text-(--pd-input-field-placeholder-text)">Gateway:</div>
+                {/snippet}
+              </Dropdown>
+            </div>
+          {/if}
+        </div>
       </div>
 
       <div class="flex flex-col min-w-full min-h-0 flex-1 overflow-auto">
         {#if filteredSandboxes.length === 0}
           {#if searchTerm}
-            <FilteredEmptyScreen icon={NoLogIcon} kind="sessions" bind:searchTerm={searchTerm} />
+            <FilteredEmptyScreen icon={NoLogIcon} kind="workspaces" bind:searchTerm={searchTerm} />
+          {:else if gatewayFilter}
+            <EmptyScreen
+              icon={NoLogIcon}
+              title="No workspaces on gateway '{gatewayFilter}'"
+              message="This gateway has no workspaces yet. Create one or select a different gateway.">
+              <Button type="link" onclick={clearGatewayFilter}>Show all gateways</Button>
+            </EmptyScreen>
           {:else}
             <AgentWorkspaceEmptyScreen />
           {/if}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
@@ -160,7 +160,7 @@ const sandboxColumns = [
       <div class="flex flex-col min-w-full min-h-0 flex-1 overflow-auto">
         {#if filteredSandboxes.length === 0}
           {#if searchTerm}
-            <FilteredEmptyScreen icon={NoLogIcon} kind="workspaces" bind:searchTerm={searchTerm} />
+            <FilteredEmptyScreen icon={NoLogIcon} kind="sessions" bind:searchTerm={searchTerm} />
           {:else if gatewayFilter}
             <EmptyScreen
               icon={NoLogIcon}

--- a/packages/renderer/src/stores/openshell-sandboxes.ts
+++ b/packages/renderer/src/stores/openshell-sandboxes.ts
@@ -93,19 +93,29 @@ export const allOpenshellSandboxes = derived(openshellSandboxes, $sandboxes => {
 // Search pattern for filtering sandboxes
 export const searchPattern = writable('');
 
-// Derived store: filtered sandboxes based on search pattern
+// Gateway filter: empty string means "all gateways"
+export const selectedGateway = writable('');
+
+// Derived store: filtered sandboxes based on search pattern and selected gateway
 export const filteredOpenshellSandboxes = derived(
-  [searchPattern, allOpenshellSandboxes],
-  ([$searchPattern, $allSandboxes]) => {
-    const term = $searchPattern.trim().toLowerCase();
-    if (!term) {
-      return $allSandboxes;
+  [searchPattern, selectedGateway, allOpenshellSandboxes],
+  ([$searchPattern, $selectedGateway, $allSandboxes]) => {
+    let result = $allSandboxes;
+
+    if ($selectedGateway) {
+      result = result.filter(sandbox => sandbox.gatewayName === $selectedGateway);
     }
-    return $allSandboxes.filter(
-      sandbox =>
-        sandbox.name.toLowerCase().includes(term) ||
-        sandbox.id.toLowerCase().includes(term) ||
-        sandbox.gatewayName.toLowerCase().includes(term),
-    );
+
+    const term = $searchPattern.trim().toLowerCase();
+    if (term) {
+      result = result.filter(
+        sandbox =>
+          sandbox.name.toLowerCase().includes(term) ||
+          sandbox.id.toLowerCase().includes(term) ||
+          sandbox.gatewayName.toLowerCase().includes(term),
+      );
+    }
+
+    return result;
   },
 );


### PR DESCRIPTION
## Summary

- Adds a gateway filter dropdown to the Agentic Workspaces list page, visible only when multiple gateways are available
- Filters workspaces by the selected gateway, matching the Podman Desktop "Environment" filter UX pattern
- Provides contextual empty state messages: gateway-specific message when filtering by gateway vs search-specific message when using text search

https://github.com/user-attachments/assets/4fe37a29-0b23-45df-8a9e-1d7654787e95

## Test plan

- [ ] With a single gateway configured, verify the gateway filter dropdown is **not** shown
- [ ] Configure two or more gateways (i.e. ``openshell gateway add http://127.0.0.1:8080 --local --name local`` just verify the port is available), verify the dropdown appears next to the search field with a "Gateway:" prefix
- [ ] Select a specific gateway from the dropdown — only workspaces belonging to that gateway should be displayed
- [ ] Select "All" — all workspaces across all gateways should be displayed again
- [ ] With a gateway selected that has no workspaces, verify the message shows "No workspaces on gateway '{name}'" with a "Show all gateways" button
- [ ] Click "Show all gateways" — verify it clears the filter and shows all workspaces
- [ ] Type a search term that matches no workspaces — verify the standard "No workspaces matching '...' found" message appears
- [ ] Combine both filters (gateway + search) — verify results are filtered by both criteria

Closes #2560