### PR TITLE
fix(agent-workspaces): reset stale wizard draft on onboarding restart

### DIFF
--- a/packages/renderer/src/stores/agent-workspace-create-draft.onboarding-restart.spec.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.onboarding-restart.spec.ts
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const callbacks = new Map<string, () => Promise<void> | void>();
+
+beforeEach(() => {
+  callbacks.clear();
+  vi.resetAllMocks();
+  vi.resetModules();
+  Object.defineProperty(window, 'events', {
+    value: {
+      receive: vi.fn((channel: string, callback: () => Promise<void> | void) => {
+        callbacks.set(channel, callback);
+      }),
+    },
+    configurable: true,
+  });
+});
+
+test('onboarding:restart resets wizard.draft.initialized so the next mount re-applies onboarding defaults', async () => {
+  const { wizard } = await import('./agent-workspace-create-draft.svelte');
+
+  wizard.draft.initialized = true;
+
+  await callbacks.get('onboarding:restart')?.();
+
+  expect(wizard.draft.initialized).toBe(false);
+});
+
+test('onboarding:restart does not touch unrelated draft fields', async () => {
+  const { wizard } = await import('./agent-workspace-create-draft.svelte');
+
+  wizard.draft.initialized = true;
+  wizard.draft.sourcePath = '/home/user/project';
+  wizard.draft.sessionName = 'my-session';
+
+  await callbacks.get('onboarding:restart')?.();
+
+  expect(wizard.draft.sourcePath).toBe('/home/user/project');
+  expect(wizard.draft.sessionName).toBe('my-session');
+});

--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
@@ -127,3 +127,8 @@ ragEnvironments.subscribe(envs => {
   wizard.draft.selectedKnowledgeIds = [...wizard.draft.selectedKnowledgeIds.filter(id => available.has(id)), ...added];
   prevKnowledge = available;
 });
+
+// re-running guided setup can change the default agent/model; invalidate so a live draft picks up the new defaults on next mount
+window.events?.receive('onboarding:restart', () => {
+  wizard.draft.initialized = false;
+});


### PR DESCRIPTION
## Summary
- The Create Workspace wizard's draft only re-applies onboarding defaults on first mount (`wizard.draft.initialized`), which is reset by `resetDraft()` on Cancel/create — but never on "Onboard again". A live, unfinished draft kept its stale default agent/model after re-running guided setup with different picks.
- Reset `wizard.draft.initialized` on the existing `onboarding:restart` event so the next mount re-applies the fresh defaults.

Fixes #2691

## Test plan
- [x] Added `agent-workspace-create-draft.onboarding-restart.spec.ts` covering the reset behavior
- [x] `pnpm run test:unit`, `pnpm run typecheck`, `pnpm run lint:check` pass

## Manual test steps

1. Launch Kaiden fresh (or use "Onboard again" if already set up) and complete guided setup, picking a specific model for an agent (e.g. OpenCode).
2. Go to Workspaces → Create workspace, navigate to the Agent & Model step. Confirm it shows the model from step 1.
3. Navigate away (e.g. click Chat or any other nav item) — do not click Cancel and do not create the workspace.
4. Go to Settings → Preferences → Onboarding → Onboard again.
5. Complete guided setup again, picking a different model for the same agent.
6. Go back to Workspaces → Create workspace → Agent & Model step again.

Expected (with the fix): the wizard shows the model you picked in step 5.
Before the fix: it would still show the stale model from step 1.