### PR TITLE
ci(ramalama): probe readiness via 127.0.0.1 instead of localhost

### DIFF
--- a/.github/actions/setup-ramalama/action.yaml
+++ b/.github/actions/setup-ramalama/action.yaml
@@ -134,7 +134,7 @@ runs:
 
         # Wait for API readiness with periodic diagnostics
         for i in {1..60}; do
-          if curl -sf http://localhost:${{ inputs.port }}/v1/models > /dev/null 2>&1; then
+          if curl -sf http://127.0.0.1:${{ inputs.port }}/v1/models > /dev/null 2>&1; then
             LOAD_TIME=$((SECONDS - LOAD_START))
             echo "RamaLama API is ready (load time: ${LOAD_TIME}s)"
             echo "container_id=$CONTAINER_ID" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fix ramalama test setup on ubuntu runners