### PR TITLE
test(e2e): add coverage for bundled OpenShell CLI tools

### DIFF
--- a/tests/playwright/src/model/pages/settings-cli-tab-page.ts
+++ b/tests/playwright/src/model/pages/settings-cli-tab-page.ts
@@ -29,7 +29,7 @@ export class SettingsCliPage extends BasePage {
   }
 
   async waitForLoad(): Promise<void> {
-    await expect(this.toolName).toBeVisible();
+    await expect(this.toolName.first()).toBeVisible();
   }
 
   getToolRow(displayName: string): Locator {

--- a/tests/playwright/src/model/pages/settings-cli-tab-page.ts
+++ b/tests/playwright/src/model/pages/settings-cli-tab-page.ts
@@ -18,41 +18,33 @@
 
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import { TIMEOUTS } from '/@/model/core/types';
-
 import { BasePage } from './base-page';
 
 export class SettingsCliPage extends BasePage {
   readonly toolName: Locator;
-  readonly gooseVersionLabel: Locator;
-  readonly gooseInstallButton: Locator;
-  readonly versionDropdownDialog: Locator;
-  readonly latestVersion: Locator;
 
   constructor(page: Page) {
     super(page);
     this.toolName = page.getByLabel('cli-name');
-    this.gooseVersionLabel = page.getByLabel('no-cli-version');
-    this.gooseInstallButton = page.getByRole('button', { name: 'Install Goose' });
-    this.versionDropdownDialog = page.getByLabel('drop-down-dialog');
-    this.latestVersion = this.versionDropdownDialog.getByRole('button', { name: /^v\d+\.\d+\.\d+$/ }).first();
   }
 
   async waitForLoad(): Promise<void> {
     await expect(this.toolName).toBeVisible();
   }
 
-  async isGooseVersionDetected(): Promise<boolean> {
-    return !(await this.gooseVersionLabel.isVisible());
+  getToolRow(displayName: string): Locator {
+    return this.page.getByRole('row', { name: displayName, exact: true });
   }
 
-  async installGoose(): Promise<void> {
-    await expect(this.gooseInstallButton).toBeVisible();
-    await this.gooseInstallButton.click();
+  getToolVersion(displayName: string): Locator {
+    return this.getToolRow(displayName).getByLabel('cli-version');
+  }
 
-    await expect(this.versionDropdownDialog).toBeVisible({ timeout: TIMEOUTS.STANDARD });
-    await this.latestVersion.click();
+  getToolNoVersionLabel(displayName: string): Locator {
+    return this.getToolRow(displayName).getByLabel('no-cli-version');
+  }
 
-    await expect.poll(async () => await this.isGooseVersionDetected(), { timeout: TIMEOUTS.DEFAULT }).toBeTruthy();
+  async isToolVersionDetected(displayName: string): Promise<boolean> {
+    return !(await this.getToolNoVersionLabel(displayName).isVisible());
   }
 }

--- a/tests/playwright/src/model/pages/settings-cli-tab-page.ts
+++ b/tests/playwright/src/model/pages/settings-cli-tab-page.ts
@@ -47,4 +47,8 @@ export class SettingsCliPage extends BasePage {
   async isToolVersionDetected(displayName: string): Promise<boolean> {
     return !(await this.getToolNoVersionLabel(displayName).isVisible());
   }
+
+  getToolUninstallButton(displayName: string): Locator {
+    return this.getToolRow(displayName).getByRole('button', { name: 'Uninstall' });
+  }
 }

--- a/tests/playwright/src/model/pages/settings-page.ts
+++ b/tests/playwright/src/model/pages/settings-page.ts
@@ -134,15 +134,4 @@ export class SettingsPage extends BasePage {
     await resourcesPage.waitForLoad();
     await resourcesPage.deleteCreatedConnectionFor(provider.resourceId, connectionType);
   }
-
-  async installGoose(): Promise<void> {
-    const cliPage = await this.openCli();
-
-    if (await cliPage.isGooseVersionDetected()) {
-      console.log('Goose is already installed, skipping...');
-      return;
-    }
-
-    await cliPage.installGoose();
-  }
 }

--- a/tests/playwright/src/specs/settings-smoke.spec.ts
+++ b/tests/playwright/src/specs/settings-smoke.spec.ts
@@ -74,9 +74,15 @@ test.describe('Settings page navigation', { tag: '@smoke' }, () => {
     await cliPage.waitForLoad();
 
     for (const displayName of OPENSHELL_BUNDLED_TOOLS) {
-      await expect(cliPage.getToolRow(displayName)).toBeVisible();
-      await expect(cliPage.getToolVersion(displayName)).toBeVisible();
-      expect(await cliPage.isToolVersionDetected(displayName)).toBeTruthy();
+      await test.step(displayName, async () => {
+        await expect(cliPage.getToolRow(displayName)).toBeVisible();
+
+        const versionLabel = cliPage.getToolVersion(displayName);
+        await expect(versionLabel).toBeVisible();
+        expect(await cliPage.isToolVersionDetected(displayName)).toBeTruthy();
+
+        test.info().annotations.push({ type: displayName, description: (await versionLabel.textContent()) ?? '' });
+      });
     }
   });
 

--- a/tests/playwright/src/specs/settings-smoke.spec.ts
+++ b/tests/playwright/src/specs/settings-smoke.spec.ts
@@ -36,6 +36,7 @@ import {
 import { waitForNavigationReady } from '/@/utils/app-ready';
 
 const OPENSHELL_BUNDLED_TOOLS = ['OpenShell', 'OpenShell Image Builder', 'OpenShell Gateway'];
+const OPENSHELL_TOOLS_WITH_UNINSTALL = ['OpenShell', 'OpenShell Image Builder'];
 
 test.describe('Settings page navigation', { tag: '@smoke' }, () => {
   test.beforeEach(async ({ page, navigationBar }) => {
@@ -82,6 +83,12 @@ test.describe('Settings page navigation', { tag: '@smoke' }, () => {
         expect(await cliPage.isToolVersionDetected(displayName)).toBeTruthy();
 
         test.info().annotations.push({ type: displayName, description: (await versionLabel.textContent()) ?? '' });
+
+        if (OPENSHELL_TOOLS_WITH_UNINSTALL.includes(displayName)) {
+          const uninstallButton = cliPage.getToolUninstallButton(displayName);
+          await expect(uninstallButton).toBeVisible();
+          await expect(uninstallButton).toBeEnabled();
+        }
       });
     }
   });

--- a/tests/playwright/src/specs/settings-smoke.spec.ts
+++ b/tests/playwright/src/specs/settings-smoke.spec.ts
@@ -35,6 +35,8 @@ import {
 } from '/@/model/pages/onboarding-restart-workflow';
 import { waitForNavigationReady } from '/@/utils/app-ready';
 
+const OPENSHELL_BUNDLED_TOOLS = ['OpenShell', 'OpenShell Image Builder', 'OpenShell Gateway'];
+
 test.describe('Settings page navigation', { tag: '@smoke' }, () => {
   test.beforeEach(async ({ page, navigationBar }) => {
     await waitForNavigationReady(page);
@@ -64,6 +66,17 @@ test.describe('Settings page navigation', { tag: '@smoke' }, () => {
       const createButton = resourcesPage.getResourceCreateButton(displayName);
       await expect(createButton).toBeVisible();
       await expect(createButton).toBeEnabled();
+    }
+  });
+
+  test('[SET-03] CLI tab shows the bundled OpenShell tools with a detected version', async ({ settingsPage }) => {
+    const cliPage = await settingsPage.openCli();
+    await cliPage.waitForLoad();
+
+    for (const displayName of OPENSHELL_BUNDLED_TOOLS) {
+      await expect(cliPage.getToolRow(displayName)).toBeVisible();
+      await expect(cliPage.getToolVersion(displayName)).toBeVisible();
+      expect(await cliPage.isToolVersionDetected(displayName)).toBeTruthy();
     }
   });
 

--- a/tests/playwright/src/specs/settings-smoke.spec.ts
+++ b/tests/playwright/src/specs/settings-smoke.spec.ts
@@ -71,6 +71,8 @@ test.describe('Settings page navigation', { tag: '@smoke' }, () => {
   });
 
   test('[SET-03] CLI tab shows the bundled OpenShell tools with a detected version', async ({ settingsPage }) => {
+    test.skip(process.platform === 'win32', 'OpenShell CLI binaries are not bundled for Windows yet');
+
     const cliPage = await settingsPage.openCli();
     await cliPage.waitForLoad();
 


### PR DESCRIPTION
Closes https://github.com/openkaiden/kaiden/issues/2677

Add e2e test verifying the 3 bundled OpenShell CLI tools (OpenShell, OpenShell Image Builder, OpenShell Gateway) appear on the Settings > CLI tab with a detected version.