### PR TITLE
fix(#2544): enable OpenClaw agent by default

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -413,7 +413,6 @@ export class ExtensionLoader implements IAsyncDisposable {
       .get<string[]>(ExtensionLoaderSettings.Disabled, [
         'kaiden.openai',
         'kaiden.codex',
-        'kaiden.openclaw',
         'kaiden.goose',
         'kaiden.gemini',
         'kaiden.cursor',


### PR DESCRIPTION
## What does this PR do?

Enables the OpenClaw coding agent by default. Previously the `openclaw` built-in extension was included in the default disabled-extensions list, so it did not load out of the box.

This removes `'kaiden.openclaw'` from the default disabled list in `ExtensionLoader.getDisabledExtensionIds()`, so the OpenClaw agent is available without the user having to manually enable it.

> [!NOTE]
> We are waiting for the OpenClaw image to be built officially.

## Screenshot / video

N/A

## What issues does this PR fix or reference?

Fixes https://github.com/openkaiden/kaiden/issues/2544

## How to test this PR?

1. Start the app fresh (no prior `extensions.disabled` config override).
2. Confirm the OpenClaw extension loads and starts automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)