### PR TITLE
fix(openshell): manage created gateway lifecycle

### DIFF
--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -121,6 +121,18 @@ beforeEach(() => {
 });
 
 describe('init', () => {
+  test('does not inspect storage paths for invalid registered gateway names', async () => {
+    vi.mocked(openshellCli.listGateways).mockResolvedValue([
+      { name: '../outside', endpoint: 'http://127.0.0.1:17675', active: true, type: 'local' },
+    ]);
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+
+    await gateway.init();
+
+    expect(existsSync).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
   test('starts a stopped gateway previously created by Kaiden', async () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
@@ -446,6 +458,29 @@ describe('createLocalGateway', () => {
     expect(openshellCli.removeGateway).toHaveBeenCalledWith('local-dev');
   });
 
+  test('force-stops a failed gateway process that ignores SIGTERM', async () => {
+    vi.useFakeTimers();
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(openshellCli.getGatewayInfo).mockRejectedValue(new Error('not ready'));
+
+    const creation = expect(
+      gateway.createLocalGateway({
+        name: 'local-dev',
+        bindAddress: '127.0.0.1',
+        port: 17675,
+        driver: 'podman',
+      }),
+    ).rejects.toThrow('Gateway did not become ready');
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await creation;
+    expect(proc.kill).toHaveBeenNthCalledWith(1, 'SIGTERM');
+    expect(proc.kill).toHaveBeenNthCalledWith(2, 'SIGKILL');
+    vi.useRealTimers();
+  });
+
   test('closes the log without registering when spawn throws', async () => {
     vi.mocked(spawn).mockImplementation(() => {
       throw new Error('spawn failed');
@@ -478,6 +513,21 @@ describe('getGatewayBinaryPath', () => {
 });
 
 describe('start', () => {
+  test('can retry after the gateway process emits an error without exiting', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const failedProcess = createMockChildProcess();
+    const retryProcess = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValueOnce(failedProcess).mockReturnValueOnce(retryProcess);
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+
+    await gateway.start();
+    failedProcess.emit('error', new Error('spawn error'));
+    await gateway.start();
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(gateway.isRunning()).toBe(true);
+  });
+
   test('spawns the gateway process and writes its output only to the log', async () => {
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -18,7 +18,7 @@
 
 import { type ChildProcess, spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { createWriteStream, type WriteStream } from 'node:fs';
+import { createWriteStream, existsSync, type WriteStream } from 'node:fs';
 import { type FileHandle, mkdir, open, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -68,7 +68,6 @@ function createMockChildProcess(): ChildProcess & { _stdout: EventEmitter; _stde
   Object.defineProperty(proc, 'stdout', { get: (): EventEmitter => proc._stdout });
   Object.defineProperty(proc, 'stderr', { get: (): EventEmitter => proc._stderr });
   proc.kill = vi.fn().mockReturnValue(true);
-  proc.unref = vi.fn();
   return proc;
 }
 
@@ -111,6 +110,7 @@ beforeEach(() => {
     { name: 'openshell-gateway', path: GATEWAY_BINARY },
   ] as unknown as CliToolInfo[]);
   vi.mocked(createWriteStream).mockReturnValue(gatewayLogStream);
+  vi.mocked(existsSync).mockReturnValue(false);
   vi.mocked(open).mockResolvedValue({ fd: 42, close: closeLogFile } as unknown as FileHandle);
   vi.mocked(exec.exec).mockResolvedValue({ command: '', stdout: '', stderr: '' });
   vi.mocked(isFreePort).mockResolvedValue(true);
@@ -121,6 +121,29 @@ beforeEach(() => {
 });
 
 describe('init', () => {
+  test('starts a stopped gateway previously created by Kaiden', async () => {
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(openshellCli.listGateways).mockResolvedValue([
+      { name: 'local-dev', endpoint: 'http://127.0.0.1:17675', active: true, type: 'local' },
+    ]);
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    await gateway.init();
+
+    expect(spawn).toHaveBeenCalledWith(
+      GATEWAY_BINARY,
+      expect.arrayContaining([
+        '--config',
+        join(KAIDEN_DATA_DIRECTORY, 'openshell-gateways', 'local-dev', 'gateway.toml'),
+        '--port',
+        '17675',
+      ]),
+      expect.objectContaining({ detached: false }),
+    );
+  });
+
   test('skips auto-start when existing gateway is healthy and already active', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const existingGateways: GatewayInfo[] = [
@@ -315,7 +338,7 @@ describe('createLocalGateway', () => {
         '--disable-tls',
       ]),
       expect.objectContaining({
-        detached: true,
+        detached: false,
         stdio: ['ignore', 42, 42],
       }),
     );
@@ -334,7 +357,6 @@ describe('createLocalGateway', () => {
       { env: { XDG_CONFIG_HOME: join(storageDirectory, 'xdg-config') } },
     );
     expect(closeLogFile).toHaveBeenCalled();
-    expect(proc.unref).toHaveBeenCalled();
   });
 
   test('infers the Docker driver from the active gateway when no override is supplied', async () => {
@@ -850,6 +872,23 @@ describe('isRunning', () => {
 });
 
 describe('dispose', () => {
+  test('stops gateways created from the settings UI', async () => {
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+
+    await gateway.createLocalGateway({
+      name: 'local-dev',
+      bindAddress: '127.0.0.1',
+      port: 17675,
+      driver: 'podman',
+    });
+
+    gateway.dispose();
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    proc.emit('exit', 0, undefined);
+  });
+
   test('stops the gateway process and closes its log', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -19,7 +19,7 @@
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import type { WriteStream } from 'node:fs';
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, existsSync } from 'node:fs';
 import { mkdir, open, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -64,7 +64,7 @@ const DEFAULT_GATEWAY_NAME = KAIDEN_LOCAL_GATEWAY_NAME;
  */
 @injectable()
 export class OpenshellGateway implements Disposable {
-  #gatewayProcess: ChildProcess | undefined;
+  #gatewayProcesses = new Map<string, ChildProcess>();
   #gatewayLogStream: WriteStream | undefined;
   #port: number = DEFAULT_PORT;
   #bindAddress: string = DEFAULT_BIND_ADDRESS;
@@ -92,6 +92,16 @@ export class OpenshellGateway implements Disposable {
     try {
       const gateways = await this.openshellCli.listGateways();
       const localGateways = gateways.filter(gw => gw.type === 'local' || this.isLocalEndpoint(gw.endpoint));
+      for (const gateway of localGateways) {
+        if (this.isCreatedGateway(gateway.name) && !(await this.isEndpointHealthy(gateway.endpoint))) {
+          try {
+            await this.startCreatedGateway(gateway.name, gateway.endpoint);
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn(`[openshell-gateway] failed to start created gateway "${gateway.name}": ${message}`);
+          }
+        }
+      }
       if (localGateways.length > 0) {
         for (const gw of localGateways) {
           if (await this.isEndpointHealthy(gw.endpoint)) {
@@ -191,25 +201,15 @@ export class OpenshellGateway implements Disposable {
     }
     const storageDirectory = this.getGatewayStorageDirectory(name);
     const configPath = await this.createNamedGatewayConfig(binaryPath, storageDirectory, driver);
-    const logFile = await open(join(storageDirectory, GATEWAY_LOG_FILENAME), 'w');
-    let gatewayProcess: ChildProcess | undefined;
-    const processState: { spawnError?: Error } = {};
-    try {
-      gatewayProcess = spawn(
-        binaryPath,
-        this.buildArgs(true, configPath, storageDirectory, options.port, bindAddress),
-        {
-          stdio: ['ignore', logFile.fd, logFile.fd],
-          detached: true,
-        },
-      );
-      gatewayProcess.once('error', err => (processState.spawnError = err));
-    } finally {
-      await logFile.close();
-    }
-    if (!gatewayProcess) {
-      throw new Error(`Failed to spawn local gateway "${name}"`);
-    }
+    const { gatewayProcess, processState } = await this.spawnCreatedGateway(
+      name,
+      binaryPath,
+      configPath,
+      storageDirectory,
+      options.port,
+      bindAddress,
+      'w',
+    );
 
     let registered = false;
     try {
@@ -220,9 +220,11 @@ export class OpenshellGateway implements Disposable {
       });
       registered = true;
       await this.waitForIndependentGateway(gatewayProcess, name, processState);
-      gatewayProcess.unref();
     } catch (err: unknown) {
       gatewayProcess.kill('SIGTERM');
+      if (this.#gatewayProcesses.get(name) === gatewayProcess) {
+        this.#gatewayProcesses.delete(name);
+      }
       if (registered) {
         await this.openshellCli.removeGateway(name).catch(() => undefined);
       }
@@ -231,8 +233,69 @@ export class OpenshellGateway implements Disposable {
     this._onDidGatewayStart.fire();
   }
 
+  private isCreatedGateway(name: string): boolean {
+    return name !== DEFAULT_GATEWAY_NAME && existsSync(join(this.getGatewayStorageDirectory(name), 'gateway.toml'));
+  }
+
+  private async startCreatedGateway(name: string, endpoint: string): Promise<void> {
+    const binaryPath = this.getGatewayBinaryPath();
+    if (!binaryPath) {
+      throw new Error('openshell-gateway binary not registered in CLI tool registry');
+    }
+    const url = new URL(endpoint);
+    const port = Number(url.port);
+    if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+      throw new Error(`Gateway "${name}" has an invalid endpoint port`);
+    }
+    const storageDirectory = this.getGatewayStorageDirectory(name);
+    const configPath = join(storageDirectory, 'gateway.toml');
+    const { gatewayProcess, processState } = await this.spawnCreatedGateway(
+      name,
+      binaryPath,
+      configPath,
+      storageDirectory,
+      port,
+      url.hostname,
+      'a',
+    );
+    try {
+      await this.waitForIndependentGateway(gatewayProcess, name, processState);
+    } catch (err: unknown) {
+      gatewayProcess.kill('SIGTERM');
+      if (this.#gatewayProcesses.get(name) === gatewayProcess) {
+        this.#gatewayProcesses.delete(name);
+      }
+      throw err;
+    }
+  }
+
+  private async spawnCreatedGateway(
+    name: string,
+    binaryPath: string,
+    configPath: string,
+    storageDirectory: string,
+    port: number,
+    bindAddress: string,
+    logFlags: 'a' | 'w',
+  ): Promise<{ gatewayProcess: ChildProcess; processState: { spawnError?: Error } }> {
+    const logFile = await open(join(storageDirectory, GATEWAY_LOG_FILENAME), logFlags);
+    const processState: { spawnError?: Error } = {};
+    let gatewayProcess: ChildProcess;
+    try {
+      gatewayProcess = spawn(binaryPath, this.buildArgs(true, configPath, storageDirectory, port, bindAddress), {
+        stdio: ['ignore', logFile.fd, logFile.fd],
+        detached: false,
+      });
+      gatewayProcess.once('error', err => (processState.spawnError = err));
+      this.trackGatewayProcess(name, gatewayProcess);
+    } finally {
+      await logFile.close();
+    }
+    return { gatewayProcess, processState };
+  }
+
   async start(options?: OpenshellGatewayStartOptions): Promise<void> {
-    if (this.#gatewayProcess) {
+    if (this.#gatewayProcesses.has(DEFAULT_GATEWAY_NAME)) {
       console.log('[openshell-gateway] already running, skipping start');
       return;
     }
@@ -261,7 +324,7 @@ export class OpenshellGateway implements Disposable {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: false,
     });
-    this.#gatewayProcess = gatewayProcess;
+    this.trackGatewayProcess(DEFAULT_GATEWAY_NAME, gatewayProcess);
 
     gatewayProcess.stdout?.on('data', (data: Buffer) => {
       this.#gatewayLogStream?.write(data);
@@ -276,16 +339,10 @@ export class OpenshellGateway implements Disposable {
 
     gatewayProcess.on('exit', (code, signal) => {
       console.log(`[openshell-gateway] exited with code=${code ?? 'none'} signal=${signal ?? 'none'}`);
-      if (this.#gatewayProcess === gatewayProcess) {
-        this.#gatewayProcess = undefined;
-      }
     });
 
     gatewayProcess.on('error', (err: Error) => {
       console.error(`[openshell-gateway] failed to start: ${err.message}`);
-      if (this.#gatewayProcess === gatewayProcess) {
-        this.#gatewayProcess = undefined;
-      }
     });
 
     try {
@@ -315,43 +372,58 @@ export class OpenshellGateway implements Disposable {
   }
 
   async stop(): Promise<void> {
-    const proc = this.#gatewayProcess;
+    console.log('[openshell-gateway] stopping');
+    await this.stopGateway(DEFAULT_GATEWAY_NAME);
+  }
+
+  isRunning(): boolean {
+    const gatewayProcess = this.#gatewayProcesses.get(DEFAULT_GATEWAY_NAME);
+    return gatewayProcess !== undefined && typeof gatewayProcess.exitCode !== 'number';
+  }
+
+  @preDestroy()
+  dispose(): void {
+    Promise.all([...this.#gatewayProcesses.keys()].map(name => this.stopGateway(name)))
+      .catch((err: unknown) => console.error('[openshell-gateway] failed to stop: ', err))
+      .finally(() => {
+        this.#gatewayProcesses.clear();
+        this.closeGatewayLog();
+      });
+    this._onDidGatewayStart.dispose();
+    this._onDidGatewayInitFailed.dispose();
+  }
+
+  private trackGatewayProcess(name: string, gatewayProcess: ChildProcess): void {
+    gatewayProcess.once('exit', () => {
+      if (this.#gatewayProcesses.get(name) === gatewayProcess) {
+        this.#gatewayProcesses.delete(name);
+      }
+    });
+    this.#gatewayProcesses.set(name, gatewayProcess);
+  }
+
+  private async stopGateway(name: string): Promise<void> {
+    const proc = this.#gatewayProcesses.get(name);
     if (!proc) {
       return;
     }
-
-    console.log('[openshell-gateway] stopping');
     proc.kill('SIGTERM');
-
     await new Promise<void>(resolve => {
       const timeout = setTimeout(() => {
         if (typeof proc.exitCode !== 'number') {
-          console.warn('[openshell-gateway] did not exit after SIGTERM, sending SIGKILL');
+          console.warn(`[openshell-gateway] ${name} did not exit after SIGTERM, sending SIGKILL`);
           proc.kill('SIGKILL');
         }
         resolve();
       }, STOP_TIMEOUT_MS);
-
       proc.once('exit', () => {
         clearTimeout(timeout);
         resolve();
       });
     });
-
-    this.#gatewayProcess = undefined;
-  }
-
-  isRunning(): boolean {
-    return this.#gatewayProcess !== undefined && typeof this.#gatewayProcess.exitCode !== 'number';
-  }
-
-  @preDestroy()
-  dispose(): void {
-    this.stop()
-      .catch((err: unknown) => console.error('[openshell-gateway] failed to stop: ', err))
-      .finally(() => this.closeGatewayLog());
-    this._onDidGatewayStart.dispose();
-    this._onDidGatewayInitFailed.dispose();
+    if (this.#gatewayProcesses.get(name) === proc) {
+      this.#gatewayProcesses.delete(name);
+    }
   }
 
   private async generateCerts(binaryPath: string, gatewayDir: string, isolate = false): Promise<void> {

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -92,16 +92,18 @@ export class OpenshellGateway implements Disposable {
     try {
       const gateways = await this.openshellCli.listGateways();
       const localGateways = gateways.filter(gw => gw.type === 'local' || this.isLocalEndpoint(gw.endpoint));
-      for (const gateway of localGateways) {
-        if (this.isCreatedGateway(gateway.name) && !(await this.isEndpointHealthy(gateway.endpoint))) {
-          try {
-            await this.startCreatedGateway(gateway.name, gateway.endpoint);
-          } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            console.warn(`[openshell-gateway] failed to start created gateway "${gateway.name}": ${message}`);
+      await Promise.all(
+        localGateways.map(async gateway => {
+          if (this.isCreatedGateway(gateway.name) && !(await this.isEndpointHealthy(gateway.endpoint))) {
+            try {
+              await this.startCreatedGateway(gateway.name, gateway.endpoint);
+            } catch (err: unknown) {
+              const message = err instanceof Error ? err.message : String(err);
+              console.warn(`[openshell-gateway] failed to start created gateway "${gateway.name}": ${message}`);
+            }
           }
-        }
-      }
+        }),
+      );
       if (localGateways.length > 0) {
         for (const gw of localGateways) {
           if (await this.isEndpointHealthy(gw.endpoint)) {
@@ -221,10 +223,7 @@ export class OpenshellGateway implements Disposable {
       registered = true;
       await this.waitForIndependentGateway(gatewayProcess, name, processState);
     } catch (err: unknown) {
-      gatewayProcess.kill('SIGTERM');
-      if (this.#gatewayProcesses.get(name) === gatewayProcess) {
-        this.#gatewayProcesses.delete(name);
-      }
+      await this.stopGateway(name);
       if (registered) {
         await this.openshellCli.removeGateway(name).catch(() => undefined);
       }
@@ -234,7 +233,11 @@ export class OpenshellGateway implements Disposable {
   }
 
   private isCreatedGateway(name: string): boolean {
-    return name !== DEFAULT_GATEWAY_NAME && existsSync(join(this.getGatewayStorageDirectory(name), 'gateway.toml'));
+    return (
+      name !== DEFAULT_GATEWAY_NAME &&
+      GATEWAY_NAME_PATTERN.test(name) &&
+      existsSync(join(this.getGatewayStorageDirectory(name), 'gateway.toml'))
+    );
   }
 
   private async startCreatedGateway(name: string, endpoint: string): Promise<void> {
@@ -261,10 +264,7 @@ export class OpenshellGateway implements Disposable {
     try {
       await this.waitForIndependentGateway(gatewayProcess, name, processState);
     } catch (err: unknown) {
-      gatewayProcess.kill('SIGTERM');
-      if (this.#gatewayProcesses.get(name) === gatewayProcess) {
-        this.#gatewayProcesses.delete(name);
-      }
+      await this.stopGateway(name);
       throw err;
     }
   }
@@ -394,11 +394,13 @@ export class OpenshellGateway implements Disposable {
   }
 
   private trackGatewayProcess(name: string, gatewayProcess: ChildProcess): void {
-    gatewayProcess.once('exit', () => {
+    const cleanup = (): void => {
       if (this.#gatewayProcesses.get(name) === gatewayProcess) {
         this.#gatewayProcesses.delete(name);
       }
-    });
+    };
+    gatewayProcess.once('exit', cleanup);
+    gatewayProcess.once('error', cleanup);
     this.#gatewayProcesses.set(name, gatewayProcess);
   }
 
@@ -408,6 +410,10 @@ export class OpenshellGateway implements Disposable {
       return;
     }
     proc.kill('SIGTERM');
+    if (typeof proc.exitCode === 'number') {
+      this.#gatewayProcesses.delete(name);
+      return;
+    }
     await new Promise<void>(resolve => {
       const timeout = setTimeout(() => {
         if (typeof proc.exitCode !== 'number') {


### PR DESCRIPTION
Fixes #2664

## Summary

- keep UI-created local gateway processes owned by Kaiden instead of detaching them
- restart previously created gateways from their isolated saved configuration during startup
- track `kaiden-local` and created gateways in one shared process registry
- stop all managed gateways gracefully during shutdown, with a SIGKILL fallback
- continue starting other gateways if one created gateway fails to start

## Verification

- `pnpm vitest run packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts` (67 tests)
- `pnpm run typecheck:main`
- ESLint on changed files
- Prettier check on changed files
- `git diff --check`