### PR TITLE
fix(openclaw): configure default sandbox image

### DIFF
--- a/extensions/openclaw/src/extension.spec.ts
+++ b/extensions/openclaw/src/extension.spec.ts
@@ -48,6 +48,7 @@ describe('activate', () => {
         name: 'OpenClaw',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
+        baseImage: 'ghcr.io/openkaiden/openshell-image-openclaw:d08a4b181f2dbf714e7e17a487ee5a0462b1b78d',
         destinationSkillsFolder: '${HOME}/.openclaw/skills',
         isSupportedModelType: expect.any(Function),
       }),

--- a/extensions/openclaw/src/extension.ts
+++ b/extensions/openclaw/src/extension.ts
@@ -107,6 +107,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     },
     tags: ['Local'],
     command: 'openclaw',
+    baseImage: 'ghcr.io/openkaiden/openshell-image-openclaw:d08a4b181f2dbf714e7e17a487ee5a0462b1b78d',
     acp: { args: ['acp'] },
     configurationFiles: [
       {


### PR DESCRIPTION
## Summary

- configure the published OpenClaw OpenShell image as the agent default

## Testing

Enable openclaw extension and create a workspace identify if the tui comes up and using the right image!

Fixes #2725