### PR TITLE
chore: update fullsend to v0.37.0

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -21,6 +21,11 @@ create_issues:
         repos:
             - openkaiden/kaiden
             - fullsend-ai/fullsend
+agents:
+    - name: code
+      source: code.yaml
+    - name: fix
+      source: fix.yaml
 inference:
     project: fullsend-eval
     wif_provider: projects/457914409018/locations/global/workloadIdentityPools/fullsend-inference/providers/gh-openkaiden-kaiden

--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -3,7 +3,12 @@
 #
 # This file configures fullsend for per-repo installation mode.
 # See ADR 0033 for details.
+#
+# The "runtime" key selects which agent runtime runs the agents, claude
+# (default when unset) or pi. For one run, the 'fullsend run --runtime'
+# flag wins, then FULLSEND_RUNTIME, then this file. See docs/runtimes.md.
 version: "1"
+runtime: claude
 roles:
     - triage
     - coder
@@ -16,8 +21,6 @@ create_issues:
         repos:
             - openkaiden/kaiden
             - fullsend-ai/fullsend
-agents:
-    - name: code
-      source: code.yaml
-    - name: fix
-      source: fix.yaml
+inference:
+    project: fullsend-eval
+    wif_provider: projects/457914409018/locations/global/workloadIdentityPools/fullsend-inference/providers/gh-openkaiden-kaiden

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -19,14 +19,6 @@
 # stage jobs with -agent- suffix. Roles operate independently (#2452).
 name: fullsend
 
-permissions:
-  actions: write
-  id-token: write
-  contents: write
-  issues: write
-  packages: read
-  pull-requests: write
-
 on:
   issues:
     types: [opened, edited, labeled]
@@ -37,36 +29,47 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   dispatch:
     if: >-
-      github.event_name != 'issue_comment'
-      || github.event.comment.user.type != 'Bot'
-    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@65ceb961020290e43b008daa380765b44f35c5df # v0.36.0
+      (github.event_name != 'pull_request_target' && github.event_name != 'pull_request_review'
+       || github.event.pull_request.head.ref != 'fullsend/scaffold-install')
+      && (github.event_name != 'issue_comment'
+       || github.event.comment.user.type != 'Bot')
+    permissions:
+      actions: write
+      id-token: write
+      contents: write
+      issues: write
+      packages: read
+      pull-requests: write
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@84c8bbbb821ff85136854150b06740253709b3b8 # v0.37.0
     with:
       event_action: ${{ github.event.action }}
       install_mode: per-repo
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
+      project_number: ${{ vars.FULLSEND_PROJECT_NUMBER }}
       runner_image: ubuntu-24.04
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
       OTEL_EXPORTER_OTLP_TRACES_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_TRACES_HEADERS }}
+      OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
 
   stop-fix:
+    # Job-level if: is intentionally coarse — it only screens for the
+    # /fs-fix-stop command on a PR from a non-bot. The authoritative
+    # authorization decision (collaborator permission API + PR-author escape
+    # hatch) is made in the step below, so a maintainer whose author_association
+    # is not MEMBER (e.g. private org membership) is not filtered out (ADR 0054).
     if: >-
       github.event_name == 'issue_comment'
         && github.event.issue.pull_request
         && github.event.comment.user.type != 'Bot'
         && github.event.comment.body == '/fs-fix-stop'
-        && (
-          github.event.comment.author_association == 'OWNER'
-          || github.event.comment.author_association == 'MEMBER'
-          || github.event.comment.author_association == 'COLLABORATOR'
-          || github.event.comment.author_association == 'CONTRIBUTOR'
-          || github.event.comment.user.login == github.event.issue.user.login
-        )
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -78,8 +81,37 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
+          COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
+          ISSUE_USER_LOGIN: ${{ github.event.issue.user.login }}
         run: |
           set -euo pipefail
+          # ADR 0054: authorize via the collaborator permission API
+          # (admin|maintain|write), not author_association — the latter grants
+          # contributor status to anyone with a single merged PR (issue #5421).
+          # Mirrors has_repo_permission() in dispatch.yml; keep the two in sync.
+          # The PR author may always stop the fix agent on their own PR.
+          authorized=false
+          if [[ -n "$COMMENT_USER_LOGIN" && "$COMMENT_USER_LOGIN" == "$ISSUE_USER_LOGIN" ]]; then
+            authorized=true
+          else
+            if api_err=$(mktemp); then
+              if role=$(gh api "repos/$REPO/collaborators/$COMMENT_USER_LOGIN/permission" \
+                --jq '.role_name' 2>"$api_err"); then
+                case "$role" in
+                  admin|maintain|write) authorized=true ;;
+                esac
+              else
+                echo "::warning::Permission API call failed for $COMMENT_USER_LOGIN: $(cat "$api_err")"
+              fi
+              rm -f "$api_err"
+            else
+              echo "::warning::Failed to create temp file for permission check of $COMMENT_USER_LOGIN"
+            fi
+          fi
+          if [[ "$authorized" != "true" ]]; then
+            echo "::notice::User $COMMENT_USER_LOGIN is not authorized to stop the fix agent (requires write access or PR authorship)"
+            exit 0
+          fi
           gh label create "fullsend-no-fix" --repo "$REPO" \
             --description "Skip bot-triggered fix agent runs" --color "FBCA04" \
             --force 2>/dev/null || true

--- a/.github/workflows/prioritize.yml
+++ b/.github/workflows/prioritize.yml
@@ -1,0 +1,50 @@
+# This file is managed by fullsend. Do not edit it directly.
+# Upstream: https://github.com/fullsend-ai/fullsend/blob/main/internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml
+---
+# fullsend-stage: prioritize
+name: Prioritize
+
+permissions:
+  actions: write
+  contents: read
+  id-token: write
+  issues: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      event_type:
+        required: true
+        type: string
+      source_repo:
+        required: true
+        type: string
+      event_payload:
+        required: true
+        type: string
+      project_number:
+        description: GitHub Projects V2 project number for RICE scoring
+        required: false
+        type: string
+
+concurrency:
+  group: fullsend-prioritize-${{ inputs.source_repo }}-${{ fromJSON(inputs.event_payload).issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  prioritize:
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-prioritize.yml@84c8bbbb821ff85136854150b06740253709b3b8 # v0.37.0
+    with:
+      event_type: ${{ inputs.event_type }}
+      source_repo: ${{ inputs.source_repo }}
+      event_payload: ${{ inputs.event_payload }}
+      mint_url: ${{ vars.FULLSEND_MINT_URL }}
+      gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
+      project_number: ${{ inputs.project_number || vars.FULLSEND_PROJECT_NUMBER }}
+      install_mode: per-repo
+      runner_image: ubuntu-24.04
+    secrets:
+      FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
+      FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+      OTEL_EXPORTER_OTLP_TRACES_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_TRACES_HEADERS }}
+      OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}


### PR DESCRIPTION
This PR adds the fullsend scaffold files for per-repo installation.

Merge this PR to activate fullsend workflows.

## Runtime

Agents in this repository run on **claude** (`runtime:` in `.fullsend/config.yaml`). To change it later, edit that key, re-run `fullsend github setup <owner/repo> --runtime <claude|pi>`, or override a single run with `fullsend run --runtime`. See https://github.com/fullsend-ai/fullsend/blob/main/docs/runtimes.md.