### PR TITLE
fix(workspaces): remove Home Directory and Full System filesystem options

### DIFF
--- a/.agents/skills/playwright-testing/workspace-provider-e2e.md
+++ b/.agents/skills/playwright-testing/workspace-provider-e2e.md
@@ -289,7 +289,7 @@ The `Workspace-Provider` project is defined in `tests/playwright/playwright.conf
 ## Adding a New Sandbox Scenario
 
 1. Add a `SandboxScenario` entry in `workspace-filesystem-network-smoke.spec.ts`:
-   - `id`: uppercase tag-aligned ID (e.g. `FS-HOME-NET-DENY`); describe title is derived in `helpers/workspace-sandbox-matrix.ts`
+   - `id`: uppercase tag-aligned ID (e.g. `FS-NONE-NET-DENY`); describe title is derived in `helpers/workspace-sandbox-matrix.ts`
    - `workspaceSlug`: required readable kebab slug (e.g. `none-dev`, `cust-multi`); final name is `{agentPrefix}-{slug}` and must be ≤ 19 chars (OpenShell limit)
    - `fileAccess`, `network`, and optional `customMounts` / `denyHosts` / `additionalHosts`
    - Reuse mount presets from `helpers/workspace-sandbox-matrix.ts` (`CUSTOM_RW_MOUNT`, etc.) when applicable
@@ -297,7 +297,7 @@ The `Workspace-Provider` project is defined in `tests/playwright/playwright.conf
 3. Use `host: ''` in `customMounts` to get a temp dir from the lifecycle helper; use `$SOURCES/...` hosts for sandbox-safe paths.
 4. Set `skipReason` if the combo is known broken on OpenShell until upstream fixes land.
 5. Workspace names are `{agentPrefix}-{workspaceSlug}` and must be ≤ 19 characters (OpenShell limit). `buildWorkspaceName` enforces this for matrix tests; hardcode short names in lifecycle smoke specs.
-6. Run the single scenario: `--grep "FS-HOME-NET-DENY"`.
+6. Run the single scenario: `--grep "FS-NONE-NET-DENY"`.
 
 ## Custom Mount Conventions
 

--- a/.agents/skills/playwright-testing/workspace-provider-e2e.md
+++ b/.agents/skills/playwright-testing/workspace-provider-e2e.md
@@ -282,7 +282,7 @@ The `Workspace-Provider` project is defined in `tests/playwright/playwright.conf
 | ------------------------------------------------ | ---------------------------------------------------------------- |
 | Non-Linux without `PODMAN_ENABLED`               | Workspace tests require Podman                                   |
 | Missing `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`   | Per-agent skip in lifecycle helper                               |
-| `FILE_ACCESS_LEVEL.FULL_SYSTEM`                  | OpenShell tar fails on `/` mount                                 |
+| `home` / `full` filesystem options               | Removed — OpenShell upload not suited for broad trees (#2539)    |
 | `NETWORK_ACCESS_LEVEL.UNRESTRICTED` on OpenShell | Unrestricted disabled in create wizard when runtime is openshell |
 | Goose + Ollama                                   | Skipped until issue #1780 fixed                                  |
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -1510,36 +1510,6 @@ test('Expect createAgentWorkspace called without mounts when workspace (default)
   );
 });
 
-test('Expect createAgentWorkspace called with home mount when Home Directory selected', async () => {
-  render(AgentWorkspaceCreate);
-
-  await navigateToFileSystemStep();
-  await fireEvent.click(screen.getByRole('radio', { name: 'Use Home Directory' }));
-  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
-  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
-
-  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
-    expect.objectContaining({
-      mounts: [{ host: '$HOME', target: '$HOME', ro: false }],
-    }),
-  );
-});
-
-test('Expect createAgentWorkspace called with full mount when Full System Access selected', async () => {
-  render(AgentWorkspaceCreate);
-
-  await navigateToFileSystemStep();
-  await fireEvent.click(screen.getByRole('radio', { name: 'Use Full System Access' }));
-  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
-  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
-
-  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
-    expect.objectContaining({
-      mounts: [{ host: '/', target: '/', ro: false }],
-    }),
-  );
-});
-
 test('Expect createAgentWorkspace called with custom mounts when Custom Paths selected', async () => {
   render(AgentWorkspaceCreate);
 
@@ -2151,7 +2121,7 @@ describe('project filesystem mapping', () => {
     expect(screen.getByRole('radio', { name: 'Use Deny All' })).not.toBeChecked();
   });
 
-  test('Expect home mount mapped to home file access', async () => {
+  test('Expect home mount mapped to custom file access', async () => {
     const homeProject: WorkspaceProjectInfo = {
       ...sampleProject,
       id: 'home-mount',
@@ -2163,10 +2133,11 @@ describe('project filesystem mapping', () => {
     await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
     await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
 
-    expect(wizard.draft.selectedFileAccess).toBe('home');
+    expect(wizard.draft.selectedFileAccess).toBe('custom');
+    expect(wizard.draft.customMounts).toEqual([{ host: '$HOME', target: '$HOME', ro: false }]);
   });
 
-  test('Expect root mount mapped to full file access', async () => {
+  test('Expect root mount mapped to custom file access', async () => {
     const rootProject: WorkspaceProjectInfo = {
       ...sampleProject,
       id: 'root-mount',
@@ -2178,7 +2149,8 @@ describe('project filesystem mapping', () => {
     await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
     await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
 
-    expect(wizard.draft.selectedFileAccess).toBe('full');
+    expect(wizard.draft.selectedFileAccess).toBe('custom');
+    expect(wizard.draft.customMounts).toEqual([{ host: '/', target: '/', ro: false }]);
   });
 
   test('Expect custom mounts mapped to custom file access', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -66,16 +66,8 @@ function applyFilesystemFromProject(fs: FilesystemConfiguration): void {
     wizard.draft.customMounts = [{ host: '', target: '', ro: false }];
     return;
   }
-  const hasHome = fs.mounts.some(m => m.host === '$HOME' && m.target === '$HOME');
-  const hasRoot = fs.mounts.some(m => m.host === '/' && m.target === '/');
-  if (hasRoot) {
-    wizard.draft.selectedFileAccess = 'full';
-  } else if (hasHome && fs.mounts.length === 1) {
-    wizard.draft.selectedFileAccess = 'home';
-  } else {
-    wizard.draft.selectedFileAccess = 'custom';
-    wizard.draft.customMounts = fs.mounts.map(m => ({ host: m.host, target: m.target, ro: m.ro ?? false }));
-  }
+  wizard.draft.selectedFileAccess = 'custom';
+  wizard.draft.customMounts = fs.mounts.map(m => ({ host: m.host, target: m.target, ro: m.ro ?? false }));
 }
 
 const REGISTRY_PRESET = ['registry.npmjs.org', 'pypi.python.org'];
@@ -454,26 +446,19 @@ function getFirstCompatibleModel(): ModelInfo | undefined {
 }
 
 function buildMountsFrom(fileAccess: string, mounts: CustomMount[]): AgentWorkspaceMount[] | undefined {
-  switch (fileAccess) {
-    case 'home':
-      return [{ host: '$HOME', target: '$HOME', ro: false }];
-    case 'full':
-      return [{ host: '/', target: '/', ro: false }];
-    case 'custom': {
-      const filtered = mounts
-        .filter(m => m.host.trim() !== '')
-        .map(m => {
-          const host = m.host.trim();
-          const trimmedTarget = m.target.trim();
-          const basename = host.split('/').filter(Boolean).pop();
-          const target = trimmedTarget !== '' ? trimmedTarget : (basename ?? host);
-          return { host, target, ro: m.ro };
-        });
-      return filtered.length > 0 ? filtered : undefined;
-    }
-    default:
-      return undefined;
+  if (fileAccess !== 'custom') {
+    return undefined;
   }
+  const filtered = mounts
+    .filter(m => m.host.trim() !== '')
+    .map(m => {
+      const host = m.host.trim();
+      const trimmedTarget = m.target.trim();
+      const basename = host.split('/').filter(Boolean).pop();
+      const target = trimmedTarget !== '' ? trimmedTarget : (basename ?? host);
+      return { host, target, ro: m.ro };
+    });
+  return filtered.length > 0 ? filtered : undefined;
 }
 
 function startAsIs(): void {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte
@@ -28,25 +28,11 @@ export const fileAccessOptions: FileAccessOption[] = [
     badge: 'Recommended',
   },
   {
-    value: 'home',
-    name: 'Home Directory',
-    description: 'Agent can access your entire home directory (~/) and all subdirectories.',
-    access: 'Home (~)',
-    notes: 'Local development',
-  },
-  {
     value: 'custom',
     name: 'Custom Paths',
     description: 'Specify exact directories the agent can access.',
     access: 'Listed paths',
     notes: 'Set path below',
-  },
-  {
-    value: 'full',
-    name: 'Full System Access',
-    description: 'Agent can access the entire filesystem. Use with caution.',
-    access: 'Full host',
-    notes: 'High privilege',
   },
 ];
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -409,7 +409,7 @@ test('Expect switching file access mode shows unsaved changes', async () => {
   const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
   await fireEvent.click(fileAccessNav);
 
-  await fireEvent.click(screen.getByRole('button', { name: 'Home Directory' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Custom Paths' }));
 
   expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
 });
@@ -428,17 +428,20 @@ test('Expect toggling read-only updates the button text', async () => {
   expect(screen.getByRole('button', { name: 'Toggle read-only for mount 1' })).toHaveTextContent('read-only');
 });
 
-test('Expect saving Home Directory mode calls updateAgentWorkspaceConfiguration', async () => {
+test('Expect saving custom mount calls updateAgentWorkspaceConfiguration with mount data', async () => {
   render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: {} });
 
   const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
   await fireEvent.click(fileAccessNav);
 
-  await fireEvent.click(screen.getByRole('button', { name: 'Home Directory' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Custom Paths' }));
+  const hostInput = screen.getByRole('textbox', { name: 'Host path 1' });
+  await fireEvent.input(hostInput, { target: { value: '/home/user/projects' } });
+
   await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
 
   expect(window.updateAgentWorkspaceConfiguration).toHaveBeenCalledWith('ws-1', {
-    mounts: [{ host: '$HOME', target: '$HOME', ro: false }],
+    mounts: [{ host: '/home/user/projects', target: 'projects', ro: false }],
   });
 });
 
@@ -501,7 +504,7 @@ test('Expect discarding file access changes resets to original mode', async () =
   const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
   await fireEvent.click(fileAccessNav);
 
-  await fireEvent.click(screen.getByRole('button', { name: 'Home Directory' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'No host filesystem access' }));
   await fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
 
   const customRadio = screen.getByRole('radio', { name: 'Use Custom Paths' });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -86,8 +86,6 @@ const hasSkillChanges = $derived(
 
 function deriveFileAccessSelection(mounts: AgentWorkspaceMount[] | undefined): string {
   if (!mounts || mounts.length === 0) return 'workspace';
-  if (mounts.length === 1 && mounts[0].host === '$HOME' && mounts[0].target === '$HOME') return 'home';
-  if (mounts.length === 1 && mounts[0].host === '/' && mounts[0].target === '/') return 'full';
   return 'custom';
 }
 
@@ -103,24 +101,19 @@ let pendingFileAccess: string = $state(originalFileAccess);
 let pendingCustomMounts: CustomMount[] = $state(originalCustomMounts.map(m => ({ ...m })));
 
 function buildMountsFromSelection(fileAccess: string, mounts: CustomMount[]): AgentWorkspaceMount[] | undefined {
-  switch (fileAccess) {
-    case 'home':
-      return [{ host: '$HOME', target: '$HOME', ro: false }];
-    case 'full':
-      return [{ host: '/', target: '/', ro: false }];
-    case 'custom': {
-      const filtered = mounts
-        .filter(m => m.host.trim() !== '')
-        .map(m => {
-          const host = m.host.trim();
-          const trimmedTarget = m.target.trim();
-          const basename = host.split('/').filter(Boolean).pop();
-          const target = trimmedTarget !== '' ? trimmedTarget : (basename ?? host);
-          return { host, target, ro: m.ro };
-        });
-      return filtered.length > 0 ? filtered : undefined;
-    }
+  if (fileAccess !== 'custom') {
+    return undefined;
   }
+  const filtered = mounts
+    .filter(m => m.host.trim() !== '')
+    .map(m => {
+      const host = m.host.trim();
+      const trimmedTarget = m.target.trim();
+      const basename = host.split('/').filter(Boolean).pop();
+      const target = trimmedTarget !== '' ? trimmedTarget : (basename ?? host);
+      return { host, target, ro: m.ro };
+    });
+  return filtered.length > 0 ? filtered : undefined;
 }
 
 // --- Network section state ---

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -264,16 +264,13 @@ export type WizardStep = (typeof WIZARD_STEP)[keyof typeof WIZARD_STEP];
 
 export const FILE_ACCESS_LEVEL = {
   NO_HOST_ACCESS: 'No host filesystem access',
-  HOME_DIRECTORY: 'Home Directory',
   CUSTOM_PATHS: 'Custom Paths',
-  FULL_SYSTEM: 'Full System Access',
 } as const;
 export const FILE_ACCESS_LEVELS = Object.values(FILE_ACCESS_LEVEL);
 export type FileAccessLevel = (typeof FILE_ACCESS_LEVEL)[keyof typeof FILE_ACCESS_LEVEL];
 
 export const FILESYSTEM_BADGE = {
   STRICT: 'Strict',
-  HOME: 'Home',
   CUSTOM: 'Custom',
 } as const;
 export type FilesystemBadge = (typeof FILESYSTEM_BADGE)[keyof typeof FILESYSTEM_BADGE];

--- a/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-sandbox-matrix.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-sandbox-matrix.ts
@@ -38,8 +38,6 @@ export const CUSTOM_MOUNT_TARGET_2 = '$SOURCES/e2e-custom-2';
 export const CUSTOM_MOUNT_DEFAULT_HOST = '$SOURCES/e2e-default';
 export const CUSTOM_ALLOWED_HOST = 'api.example.com';
 
-export const FULL_SYSTEM_SKIP_LABEL = 'OpenShell tar fails on / mount';
-
 function skipTestTitle(scenarioId: string, skipReason: string): string {
   return `[SKIP] ${scenarioId} — ${skipReason}`;
 }
@@ -59,9 +57,7 @@ export const CUSTOM_MULTI_MOUNTS: WorkspaceCustomMount[] = [
 
 const FILESYSTEM_TAG: Record<FileAccessLevel, string> = {
   [FILE_ACCESS_LEVEL.NO_HOST_ACCESS]: '@fs-none',
-  [FILE_ACCESS_LEVEL.HOME_DIRECTORY]: '@fs-home',
   [FILE_ACCESS_LEVEL.CUSTOM_PATHS]: '@fs-custom',
-  [FILE_ACCESS_LEVEL.FULL_SYSTEM]: '@fs-full',
 };
 
 const NETWORK_TAG: Record<NetworkAccessLevel, string> = {
@@ -104,10 +100,6 @@ function filesystemLabel(scenario: SandboxScenario): string {
   switch (scenario.fileAccess) {
     case FILE_ACCESS_LEVEL.NO_HOST_ACCESS:
       return 'no host filesystem access';
-    case FILE_ACCESS_LEVEL.HOME_DIRECTORY:
-      return 'home directory filesystem';
-    case FILE_ACCESS_LEVEL.FULL_SYSTEM:
-      return 'full system filesystem';
     case FILE_ACCESS_LEVEL.CUSTOM_PATHS: {
       const mounts = scenario.customMounts;
       if (mounts?.some(mount => mount.readOnly)) {

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-filesystem-network-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-filesystem-network-smoke.spec.ts
@@ -26,7 +26,6 @@ import {
   CUSTOM_MULTI_MOUNTS,
   CUSTOM_RO_MOUNT,
   CUSTOM_RW_MOUNT,
-  FULL_SYSTEM_SKIP_LABEL,
   registerSandboxMatrixTests,
   type SandboxAgentSetup,
   type SandboxScenario,
@@ -74,12 +73,6 @@ const SANDBOX_SCENARIOS: SandboxScenario[] = [
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
   },
   {
-    id: 'FS-HOME-NET-DEVELOPER',
-    workspaceSlug: 'home-dev',
-    fileAccess: FILE_ACCESS_LEVEL.HOME_DIRECTORY,
-    network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
-  },
-  {
     id: 'FS-CUSTOM-NET-DEVELOPER',
     workspaceSlug: 'cust-dev',
     fileAccess: FILE_ACCESS_LEVEL.CUSTOM_PATHS,
@@ -94,23 +87,10 @@ const SANDBOX_SCENARIOS: SandboxScenario[] = [
   },
   // --- Extended filesystem × network ---
   {
-    id: 'FS-FULL-NET-DEVELOPER',
-    workspaceSlug: 'full-dev',
-    fileAccess: FILE_ACCESS_LEVEL.FULL_SYSTEM,
-    network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
-    skipReason: FULL_SYSTEM_SKIP_LABEL,
-  },
-  {
     id: 'FS-CUSTOM-NET-DENY',
     workspaceSlug: 'cust-deny',
     fileAccess: FILE_ACCESS_LEVEL.CUSTOM_PATHS,
     customMounts: CUSTOM_RW_MOUNT,
-    network: NETWORK_ACCESS_LEVEL.DENY_ALL,
-  },
-  {
-    id: 'FS-HOME-NET-DENY',
-    workspaceSlug: 'home-deny',
-    fileAccess: FILE_ACCESS_LEVEL.HOME_DIRECTORY,
     network: NETWORK_ACCESS_LEVEL.DENY_ALL,
   },
   {
@@ -149,14 +129,6 @@ const SANDBOX_SCENARIOS: SandboxScenario[] = [
     fileAccess: FILE_ACCESS_LEVEL.NO_HOST_ACCESS,
     network: NETWORK_ACCESS_LEVEL.DEVELOPER_PRESET,
     additionalHosts: [CUSTOM_ALLOWED_HOST],
-  },
-  // --- Known skips on OpenShell ---
-  {
-    id: 'FS-FULL-NET-DENY',
-    workspaceSlug: 'full-deny',
-    fileAccess: FILE_ACCESS_LEVEL.FULL_SYSTEM,
-    network: NETWORK_ACCESS_LEVEL.DENY_ALL,
-    skipReason: FULL_SYSTEM_SKIP_LABEL,
   },
 ];
 


### PR DESCRIPTION
Removed home directory and full system options from the create workspace wizard since OpenShell's upload mechanism was not designed for broad directory trees like $HOME or /. It aborts on permission-denied paths (macOS TCC) and exposes sensitive data into the sandbox. The OpenShell team confirmed volumes will be the proper alternative. See NVIDIA/OpenShell#2920 and NVIDIA/OpenShell#1760. Users can still mount specific directories via Custom Paths.

<img width="1238" height="795" alt="Captura de pantalla 2026-08-27 a las 12 12 46" src="https://github.com/user-attachments/assets/ee7d8c95-7311-46ea-9283-8d57db45cf1e" />

## Test plan ##
1. Go through the create workspace wizard
2. in the File system step check there are just two options, "No host filesystem access" and "Custom paths".

Closes #2539