### PR TITLE
test: add workspace creation coverage for no-project scenarios

### DIFF
--- a/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-lifecycle-helper.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-lifecycle-helper.ts
@@ -69,6 +69,8 @@ export interface WorkspaceLifecycleConfig {
   sandbox?: WorkspaceSandboxOptions;
   /** When false, caller owns create/delete (sandbox matrix agent scope). Default true. */
   manageResource?: boolean;
+  /** When true, creates the workspace without a project folder (sourcePath left empty). */
+  noProjectFolder?: boolean;
 }
 
 const SANDBOX_STEP_TITLES: Record<string, string> = {
@@ -130,7 +132,9 @@ export function registerWorkspaceLifecycleTests(
       }
     }
 
-    workingDir = mkdtempSync(join(homedir(), '.kdn-e2e-'));
+    if (!config.noProjectFolder) {
+      workingDir = mkdtempSync(join(homedir(), '.kdn-e2e-'));
+    }
 
     if (
       hasSandbox &&
@@ -143,7 +147,7 @@ export function registerWorkspaceLifecycleTests(
 
       for (const mount of config.sandbox!.customMounts) {
         if (mount.host.startsWith('$SOURCES/')) {
-          mkdirSync(join(workingDir, mount.host.slice('$SOURCES/'.length)), { recursive: true });
+          mkdirSync(join(workingDir!, mount.host.slice('$SOURCES/'.length)), { recursive: true });
         }
       }
     }
@@ -192,7 +196,9 @@ export function registerWorkspaceLifecycleTests(
     const createPage = await agentWorkspacesPage.openCreatePage();
 
     await createPage.sessionNameInput.fill(config.workspaceName);
-    await createPage.workingDirInput.fill(workingDir!);
+    if (!config.noProjectFolder) {
+      await createPage.workingDirInput.fill(workingDir!);
+    }
     await createPage.continueToStep(WIZARD_STEP.AGENT_MODEL);
 
     await createPage.selectAgent(config.agent);

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-claude-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-claude-smoke.spec.ts
@@ -39,3 +39,23 @@ test.describe
       },
     });
   });
+
+test.describe
+  .serial('Claude Code agent workspace without a project folder', { tag: '@workspace-provider' }, () => {
+    registerWorkspaceLifecycleTests(test, expect, {
+      testIdPrefix: 'WKS-CLAUDE-NOFOLDER',
+      workspaceName: 'claude-nofolder',
+      agent: CODING_AGENT.CLAUDE,
+      requiredResource: 'claude',
+      noProjectFolder: true,
+      selectModel: async createPage => {
+        await createPage.verifyModelRuntimes('Claude');
+        return createPage.selectDefaultModel();
+      },
+      terminalReadyPatterns: [/Claude Code/],
+      promptTest: {
+        prompt: 'what is 2+2? reply with just the number',
+        expectedResponse: /4|insufficient|balance|credit/i,
+      },
+    });
+  });

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-goose-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-goose-smoke.spec.ts
@@ -38,6 +38,23 @@ test.describe
   });
 
 test.describe
+  .serial('Goose agent workspace without a project folder', { tag: '@workspace-provider' }, () => {
+    registerWorkspaceLifecycleTests(test, expect, {
+      testIdPrefix: 'WKS-OPENAI-NOFOLDER',
+      workspaceName: 'goose-nofolder',
+      agent: CODING_AGENT.GOOSE,
+      requiredResource: 'openai',
+      noProjectFolder: true,
+      selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
+      terminalReadyPatterns: [/goose/i],
+      promptTest: {
+        prompt: 'what is 123+456? reply with just the number',
+        expectedResponse: /579|insufficient|balance|credit|quota exceeded/i,
+      },
+    });
+  });
+
+test.describe
   .serial('Goose agent workspace with Mistral model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-MISTRAL',

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-openclaw-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-openclaw-smoke.spec.ts
@@ -57,6 +57,24 @@ test.describe
   });
 
 test.describe
+  .serial('OpenClaw agent workspace without a project folder', { tag: '@workspace-provider' }, () => {
+    registerWorkspaceLifecycleTests(test, expect, {
+      testIdPrefix: 'WKS-OPENAI-NOFOLDER',
+      workspaceName: 'openclaw-nofolder',
+      agent: CODING_AGENT.OPENCLAW,
+      requiredResource: 'openai',
+      noProjectFolder: true,
+      selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
+      terminalReadyPatterns: [/openclaw/i],
+      prePrompts: [{ command: 'talk to agent', expectedResponse: /agent/i }],
+      promptTest: {
+        prompt: 'what is 123+456? reply with just the number',
+        expectedResponse: /579|insufficient|balance|credit|quota exceeded/i,
+      },
+    });
+  });
+
+test.describe
   .serial('OpenClaw agent workspace with Anthropic model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-ANTHROPIC',

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-opencode-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-opencode-smoke.spec.ts
@@ -39,6 +39,24 @@ test.describe
   });
 
 test.describe
+  .serial('OpenCode agent workspace without a project folder', { tag: '@workspace-provider' }, () => {
+    registerWorkspaceLifecycleTests(test, expect, {
+      testIdPrefix: 'WKS-OPENAI-NOFOLDER',
+      workspaceName: 'opencode-nofolder',
+      agent: CODING_AGENT.OPENCODE,
+      requiredResource: 'openai',
+      noProjectFolder: true,
+      selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
+      terminalReadyPatterns: [/Ask anything/i, /openai/i],
+      promptTimeout: TIMEOUTS.MODEL_RESPONSE,
+      promptTest: {
+        prompt: 'what is 123+456? reply with just the number',
+        expectedResponse: /579|insufficient|balance|credit|quota exceeded/i,
+      },
+    });
+  });
+
+test.describe
   .serial('OpenCode agent workspace with Gemini model', { tag: '@workspace-provider' }, () => {
     registerWorkspaceLifecycleTests(test, expect, {
       testIdPrefix: 'WKS-GEMINI',

--- a/tests/playwright/src/specs/workspaces-smoke.spec.ts
+++ b/tests/playwright/src/specs/workspaces-smoke.spec.ts
@@ -230,6 +230,42 @@ test.describe('Workspaces page - create wizard', { tag: '@smoke' }, () => {
   });
 });
 
+test.describe('Workspaces page - create wizard without project folder', { tag: '@smoke' }, () => {
+  test.beforeEach(async ({ page, navigationBar }) => {
+    await waitForNavigationReady(page);
+    await navigationBar.ensureExtensionsRunning();
+    await navigationBar.navigateToWorkspacesPage();
+  });
+
+  test('[WKS-NOFOLDER-01] Completes full wizard navigation without a project folder', async ({
+    agentWorkspacesPage,
+  }) => {
+    const createPage = await agentWorkspacesPage.openCreatePage();
+
+    await createPage.sessionNameInput.fill('no-folder-workspace');
+    await createPage.navigateToStep(WIZARD_STEP.NETWORKING, completeAgentModelStep);
+
+    await expect(createPage.submitButton).toBeVisible();
+    await expect(createPage.submitButton).toBeEnabled();
+    await expect(createPage.continueButton).not.toBeVisible();
+  });
+
+  test('[WKS-NOFOLDER-02] Use-defaults enables with session name and model but no folder', async ({
+    agentWorkspacesPage,
+  }) => {
+    const createPage = await agentWorkspacesPage.openCreatePage();
+
+    await expect(createPage.useDefaultsButton).toBeDisabled();
+
+    await createPage.sessionNameInput.fill('no-folder-defaults');
+    await createPage.continueToStep(WIZARD_STEP.AGENT_MODEL);
+    await createPage.completeAgentModelStepIfNeeded(completeAgentModelStep);
+
+    await createPage.backToStep(WIZARD_STEP.WORKSPACE);
+    await expect(createPage.useDefaultsButton).toBeEnabled();
+  });
+});
+
 test.describe('Workspaces page - skills integration', { tag: '@smoke' }, () => {
   test.beforeAll(async ({ page, electronApp, navigationBar, skillsPage }) => {
     await waitForNavigationReady(page);


### PR DESCRIPTION
Add no-project test cases across Claude, Goose, OpenClaw, and OpenCode workspace smoke tests.
Updated workspaces smoke spec with no-project coverage.

Closes https://github.com/openkaiden/kaiden/issues/2680