### PR TITLE
chore: fix the creation of sandboxes when using OpenShell 0.0.113

### DIFF
--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenShell",
   "description": "Registers the openshell CLI binary for managing sandboxed workspaces.",
   "version": "0.4.0-next",
-  "openshellVersion": "0.0.92",
+  "openshellVersion": "0.0.113",
   "openshellImageBuilderVersion": "0.9.0",
   "icon": "icon.png",
   "publisher": "kaiden",

--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -120,6 +120,8 @@ export interface CreateSandboxOptions {
   uploads?: Array<{ local: string; remote: string }>;
   command?: string[];
   noTty?: boolean;
+  tty?: boolean;
+  detach?: boolean;
   policy?: string;
 }
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -397,8 +397,8 @@ describe('create – OpenShell mode', () => {
         gateway: 'kaiden',
         providers: ['my-secret'],
         labels: { ...encodeWorkspaceLabels('/tmp/my-project'), [AGENT_LABEL]: 'claude' },
-        noTty: true,
-        command: ['true'],
+        detach: true,
+        tty: true,
       }),
     );
   });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -267,8 +267,8 @@ export class AgentWorkspaceManager implements Disposable {
         [AGENT_LABEL]: options.agent,
       },
       uploads: dedupedUploads.length > 0 ? dedupedUploads : undefined,
-      noTty: true,
-      command: ['true'],
+      detach: true,
+      tty: true,
     });
 
     const tSandbox = performance.now();

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -219,6 +219,12 @@ export class OpenshellCli {
     if (options.noTty) {
       args.push('--no-tty');
     }
+    if (options.tty) {
+      args.push('--tty');
+    }
+    if (options.detach) {
+      args.push('--detach');
+    }
     if (options.policy) {
       args.push('--policy', options.policy);
     }


### PR DESCRIPTION
note: this is a PR against a branch (OpenShell update)

we were mostly creating the sandboxes as a background task but were using a "true" command

now, use detach mode. Also ensure we give --tty mode on the creation else it won't be possible to connect later

note: I noticed that now, when we logout from connecting to the sandbox, the sandbox is dropped as a container using podman (but it's not related to this issue)