### PR TITLE
feat(openshell): bundle mkfs.ext4 and debugfs on macOS

### DIFF
--- a/extensions/openshell/scripts/download.ts
+++ b/extensions/openshell/scripts/download.ts
@@ -137,8 +137,10 @@ if (targets.length === 0) {
   }
 
   if (selectedDownloads.some(entry => entry.id === 'openshell')) {
-    for (const { platform, arch } of targets.filter(target => target.platform === 'linux')) {
-      await downloadMkfsExt4(pkg.e2fsprogsVersion, arch, resolve(ASSETS_DIR, `${platform}-${arch}`));
+    for (const { platform, arch } of targets.filter(
+      target => target.platform === 'linux' || target.platform === 'darwin',
+    )) {
+      await downloadMkfsExt4(pkg.e2fsprogsVersion, arch, platform, resolve(ASSETS_DIR, `${platform}-${arch}`));
     }
   }
 })();

--- a/extensions/openshell/src/e2fsprogs-download.spec.ts
+++ b/extensions/openshell/src/e2fsprogs-download.spec.ts
@@ -330,6 +330,7 @@ describe('darwin', () => {
     expect(debugfsWrapper).toContain('DYLD_LIBRARY_PATH');
     expect(debugfsWrapper).toContain('$runtime_dir/debugfs');
 
+    expect(await readFile(join(outputDir, '.mkfs-ext4', 'NOTICE'), 'utf-8')).toBe('license notice');
     await expect(stat(join(outputDir, 'NOTICE'))).rejects.toThrow();
     await expect(stat(join(outputDir, 'README'))).rejects.toThrow();
 

--- a/extensions/openshell/src/e2fsprogs-download.spec.ts
+++ b/extensions/openshell/src/e2fsprogs-download.spec.ts
@@ -17,17 +17,19 @@
  ***********************************************************************/
 
 import { createHash } from 'node:crypto';
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readlink, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import * as tar from 'tar';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { downloadMkfsExt4 } from './e2fsprogs-download';
 
 const VERSION = '1.47.4';
-const LIBRARIES = ['libcom_err.so.2', 'libe2p.so.2', 'libext2fs.so.2', 'libss.so.2'];
+const GETTEXT_VERSION = '1.0';
+const LINUX_LIBRARIES = ['libcom_err.so.2', 'libe2p.so.2', 'libext2fs.so.2', 'libss.so.2'];
+const DARWIN_DYLIB_STEMS = ['libblkid', 'libcom_err', 'libe2p', 'libext2fs', 'libss', 'libuuid'];
 
 let testDir: string;
 
@@ -41,8 +43,8 @@ afterEach(async () => {
   await rm(testDir, { recursive: true, force: true });
 });
 
-async function createBottle(): Promise<Buffer> {
-  const bottleRoot = join(testDir, 'fixture', 'e2fsprogs', VERSION);
+async function createLinuxBottle(): Promise<Buffer> {
+  const bottleRoot = join(testDir, 'fixture-linux', 'e2fsprogs', VERSION);
   await Promise.all([
     mkdir(join(bottleRoot, 'sbin'), { recursive: true }),
     mkdir(join(bottleRoot, 'lib'), { recursive: true }),
@@ -55,16 +57,51 @@ async function createBottle(): Promise<Buffer> {
     writeFile(join(bottleRoot, 'NOTICE'), 'license notice'),
     writeFile(join(bottleRoot, 'README'), 'readme'),
     writeFile(join(bottleRoot, 'sbom.spdx.json'), '{}'),
-    ...LIBRARIES.map(library => writeFile(join(bottleRoot, 'lib', `${library}.1`), library)),
+    ...LINUX_LIBRARIES.map(library => writeFile(join(bottleRoot, 'lib', `${library}.1`), library)),
   ]);
-  await Promise.all(LIBRARIES.map(library => symlink(`${library}.1`, join(bottleRoot, 'lib', library))));
+  await Promise.all(LINUX_LIBRARIES.map(library => symlink(`${library}.1`, join(bottleRoot, 'lib', library))));
 
-  const archive = join(testDir, 'bottle.tar.gz');
-  await tar.create({ file: archive, gzip: true, cwd: join(testDir, 'fixture') }, ['e2fsprogs']);
+  const archive = join(testDir, 'linux-bottle.tar.gz');
+  await tar.create({ file: archive, gzip: true, cwd: join(testDir, 'fixture-linux') }, ['e2fsprogs']);
   return readFile(archive);
 }
 
-function stubRegistry(bottle: Buffer, architecture = 'amd64'): ReturnType<typeof vi.fn> {
+async function createDarwinBottle(): Promise<Buffer> {
+  const bottleRoot = join(testDir, 'fixture-darwin', 'e2fsprogs', VERSION);
+  await Promise.all([
+    mkdir(join(bottleRoot, 'sbin'), { recursive: true }),
+    mkdir(join(bottleRoot, 'lib'), { recursive: true }),
+    mkdir(join(bottleRoot, '.bottle', 'etc'), { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(join(bottleRoot, 'sbin', 'mke2fs'), 'mke2fs-binary'),
+    writeFile(join(bottleRoot, 'sbin', 'debugfs'), 'debugfs-binary'),
+    writeFile(join(bottleRoot, '.bottle', 'etc', 'mke2fs.conf'), '[defaults]\n'),
+    writeFile(join(bottleRoot, 'NOTICE'), 'license notice'),
+    writeFile(join(bottleRoot, 'README'), 'readme'),
+    ...DARWIN_DYLIB_STEMS.map(stem => writeFile(join(bottleRoot, 'lib', `${stem}.1.1.dylib`), `${stem}-versioned`)),
+    ...DARWIN_DYLIB_STEMS.map(stem => writeFile(join(bottleRoot, 'lib', `${stem}.dylib`), `${stem}-unversioned`)),
+  ]);
+
+  const archive = join(testDir, 'darwin-bottle.tar.gz');
+  await tar.create({ file: archive, gzip: true, cwd: join(testDir, 'fixture-darwin') }, ['e2fsprogs']);
+  return readFile(archive);
+}
+
+async function createGettextBottle(): Promise<Buffer> {
+  const bottleRoot = join(testDir, 'fixture-gettext', 'gettext', GETTEXT_VERSION);
+  await mkdir(join(bottleRoot, 'lib'), { recursive: true });
+  await Promise.all([
+    writeFile(join(bottleRoot, 'lib', 'libintl.8.dylib'), 'libintl-binary'),
+    writeFile(join(bottleRoot, 'lib', 'libintl.dylib'), 'libintl-unversioned'),
+  ]);
+
+  const archive = join(testDir, 'gettext-bottle.tar.gz');
+  await tar.create({ file: archive, gzip: true, cwd: join(testDir, 'fixture-gettext') }, ['gettext']);
+  return readFile(archive);
+}
+
+function stubLinuxRegistry(bottle: Buffer, architecture = 'amd64'): ReturnType<typeof vi.fn> {
   const digest = createHash('sha256').update(bottle).digest('hex');
   const bottleArchitecture = architecture === 'amd64' ? 'x86_64' : 'aarch64';
   const fetchMock = vi.fn(async (input: string | URL | Request) => {
@@ -72,7 +109,7 @@ function stubRegistry(bottle: Buffer, architecture = 'amd64'): ReturnType<typeof
     if (url.includes('/token?')) {
       return Response.json({ token: 'registry-token' });
     }
-    if (url.endsWith(`/manifests/${VERSION}`)) {
+    if (url.includes('/e2fsprogs/manifests/') && url.endsWith(`/manifests/${VERSION}`)) {
       return Response.json({
         manifests: [
           {
@@ -105,59 +142,365 @@ function stubRegistry(bottle: Buffer, architecture = 'amd64'): ReturnType<typeof
   return fetchMock;
 }
 
-test('downloads and stages the e2fsprogs tools beside the VM driver', async () => {
-  const bottle = await createBottle();
-  const fetchMock = stubRegistry(bottle);
-  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
-  const outputDir = join(testDir, 'output');
-  await mkdir(outputDir);
-  await writeFile(join(outputDir, 'openshell-driver-vm'), 'vm-driver');
+interface DarwinFixtures {
+  e2fsprogs: Buffer;
+  gettext: Buffer;
+}
 
-  await downloadMkfsExt4(VERSION, 'x64', outputDir);
+function stubDarwinRegistry(fixtures: DarwinFixtures): ReturnType<typeof vi.fn> {
+  const e2fsprogsDigest = createHash('sha256').update(fixtures.e2fsprogs).digest('hex');
+  const gettextDigest = createHash('sha256').update(fixtures.gettext).digest('hex');
 
-  expect(await readFile(join(outputDir, 'openshell-driver-vm'), 'utf-8')).toBe('vm-driver');
-  expect(await readFile(join(outputDir, 'e2fsprogs', 'mke2fs'), 'utf-8')).toBe('mke2fs-binary');
-  expect(await readFile(join(outputDir, 'e2fsprogs', 'debugfs'), 'utf-8')).toBe('debugfs-binary');
-  expect(await readFile(join(outputDir, 'e2fsprogs', 'NOTICE'), 'utf-8')).toBe('license notice');
-  for (const library of LIBRARIES) {
-    expect(await readFile(join(outputDir, 'e2fsprogs', 'lib', library), 'utf-8')).toBe(library);
-  }
-  expect(await readFile(join(outputDir, 'e2fsprogs', 'mke2fs.conf'), 'utf-8')).toBe('[defaults]\n');
-  expect(await readFile(join(outputDir, '.mkfs-ext4-version'), 'utf-8')).toBe(`${VERSION}-linux-x64`);
-  if (process.platform !== 'win32') {
-    expect((await stat(join(outputDir, 'mkfs.ext4'))).mode & 0o111).not.toBe(0);
-    expect((await stat(join(outputDir, 'debugfs'))).mode & 0o111).not.toBe(0);
-  }
-  expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain('--argv0 "mkfs.ext4"');
-  expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain('runtime_dir="$bin_dir/e2fsprogs"');
-  expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain(
-    `export LD_LIBRARY_PATH="$runtime_dir/lib\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"`,
-  );
-  expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain(
-    'mkfs.ext4 requires the glibc loader at $loader',
-  );
-  expect(await readFile(join(outputDir, 'debugfs'), 'utf-8')).toContain('--argv0 "debugfs"');
-  expect(timeoutSpy.mock.calls).toEqual([[30_000], [30_000], [30_000], [5 * 60_000]]);
+  const fetchMock = vi.fn(async (input: string | URL | Request) => {
+    const url = String(input);
 
-  const callsAfterDownload = fetchMock.mock.calls.length;
-  await downloadMkfsExt4(VERSION, 'x64', outputDir);
-  expect(fetchMock).toHaveBeenCalledTimes(callsAfterDownload);
+    if (url.includes('/token?')) {
+      return Response.json({ token: 'registry-token' });
+    }
 
-  await chmod(join(outputDir, 'e2fsprogs', 'lib', 'libext2fs.so.2'), 0o444);
-  await rm(join(outputDir, 'e2fsprogs', 'mke2fs'));
-  await downloadMkfsExt4(VERSION, 'x64', outputDir);
-  expect(await readFile(join(outputDir, 'e2fsprogs', 'mke2fs'), 'utf-8')).toBe('mke2fs-binary');
-  expect(fetchMock).toHaveBeenCalledTimes(callsAfterDownload * 2);
+    if (url.includes('/e2fsprogs/manifests/') && url.endsWith(`/manifests/${VERSION}`)) {
+      return Response.json({
+        manifests: [
+          {
+            mediaType: 'application/vnd.oci.image.manifest.v1+json',
+            digest: 'sha256:e2fs-platform',
+            platform: { os: 'darwin', architecture: 'arm64' },
+          },
+        ],
+      });
+    }
+    if (url.endsWith('/manifests/sha256:e2fs-platform')) {
+      return Response.json({
+        layers: [
+          {
+            mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+            digest: `sha256:${e2fsprogsDigest}`,
+            annotations: {
+              'org.opencontainers.image.title': `e2fsprogs--${VERSION}.arm64_sequoia.bottle.tar.gz`,
+            },
+          },
+        ],
+      });
+    }
+    if (url.endsWith(`/blobs/sha256:${e2fsprogsDigest}`)) {
+      return new Response(fixtures.e2fsprogs);
+    }
+
+    if (url.includes('/gettext/manifests/') && url.endsWith(`/manifests/${GETTEXT_VERSION}`)) {
+      return Response.json({
+        manifests: [
+          {
+            mediaType: 'application/vnd.oci.image.manifest.v1+json',
+            digest: 'sha256:gettext-platform',
+            platform: { os: 'darwin', architecture: 'arm64' },
+          },
+        ],
+      });
+    }
+    if (url.endsWith('/manifests/sha256:gettext-platform')) {
+      return Response.json({
+        layers: [
+          {
+            mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+            digest: `sha256:${gettextDigest}`,
+            annotations: {
+              'org.opencontainers.image.title': `gettext--${GETTEXT_VERSION}.arm64_sequoia.bottle.tar.gz`,
+            },
+          },
+        ],
+      });
+    }
+    if (url.endsWith(`/blobs/sha256:${gettextDigest}`)) {
+      return new Response(fixtures.gettext);
+    }
+
+    return new Response('unexpected URL', { status: 404, statusText: 'Not Found' });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+async function createDarwinFixtures(): Promise<DarwinFixtures> {
+  const [e2fsprogs, gettext] = await Promise.all([createDarwinBottle(), createGettextBottle()]);
+  return { e2fsprogs, gettext };
+}
+
+describe('linux', () => {
+  test('downloads and stages the e2fsprogs tools beside the VM driver', async () => {
+    const bottle = await createLinuxBottle();
+    const fetchMock = stubLinuxRegistry(bottle);
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const outputDir = join(testDir, 'output');
+    await mkdir(outputDir);
+    await writeFile(join(outputDir, 'openshell-driver-vm'), 'vm-driver');
+
+    await downloadMkfsExt4(VERSION, 'x64', 'linux', outputDir);
+
+    expect(await readFile(join(outputDir, 'openshell-driver-vm'), 'utf-8')).toBe('vm-driver');
+    expect(await readFile(join(outputDir, 'e2fsprogs', 'mke2fs'), 'utf-8')).toBe('mke2fs-binary');
+    expect(await readFile(join(outputDir, 'e2fsprogs', 'debugfs'), 'utf-8')).toBe('debugfs-binary');
+    expect(await readFile(join(outputDir, 'e2fsprogs', 'NOTICE'), 'utf-8')).toBe('license notice');
+    for (const library of LINUX_LIBRARIES) {
+      expect(await readFile(join(outputDir, 'e2fsprogs', 'lib', library), 'utf-8')).toBe(library);
+    }
+    expect(await readFile(join(outputDir, 'e2fsprogs', 'mke2fs.conf'), 'utf-8')).toBe('[defaults]\n');
+    expect(await readFile(join(outputDir, '.mkfs-ext4-version'), 'utf-8')).toBe(`${VERSION}-linux-x64`);
+    if (process.platform !== 'win32') {
+      expect((await stat(join(outputDir, 'mkfs.ext4'))).mode & 0o111).not.toBe(0);
+      expect((await stat(join(outputDir, 'debugfs'))).mode & 0o111).not.toBe(0);
+    }
+    expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain('--argv0 "mkfs.ext4"');
+    expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain('runtime_dir="$bin_dir/e2fsprogs"');
+    expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain(
+      `export LD_LIBRARY_PATH="$runtime_dir/lib\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"`,
+    );
+    expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain(
+      'mkfs.ext4 requires the glibc loader at $loader',
+    );
+    expect(await readFile(join(outputDir, 'debugfs'), 'utf-8')).toContain('--argv0 "debugfs"');
+    expect(timeoutSpy.mock.calls).toEqual([[30_000], [30_000], [30_000], [5 * 60_000]]);
+
+    const callsAfterDownload = fetchMock.mock.calls.length;
+    await downloadMkfsExt4(VERSION, 'x64', 'linux', outputDir);
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterDownload);
+
+    await chmod(join(outputDir, 'e2fsprogs', 'lib', 'libext2fs.so.2'), 0o444);
+    await rm(join(outputDir, 'e2fsprogs', 'mke2fs'));
+    await downloadMkfsExt4(VERSION, 'x64', 'linux', outputDir);
+    expect(await readFile(join(outputDir, 'e2fsprogs', 'mke2fs'), 'utf-8')).toBe('mke2fs-binary');
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterDownload * 2);
+  });
+
+  test('uses the arm64 ELF loader in the launcher', async () => {
+    const bottle = await createLinuxBottle();
+    stubLinuxRegistry(bottle, 'arm64');
+    const outputDir = join(testDir, 'output');
+
+    await downloadMkfsExt4(VERSION, 'arm64', 'linux', outputDir);
+
+    expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain('/lib/ld-linux-aarch64.so.1');
+  });
 });
 
-test('uses the arm64 ELF loader in the launcher', async () => {
-  const bottle = await createBottle();
-  stubRegistry(bottle, 'arm64');
-  const outputDir = join(testDir, 'output');
+describe('darwin', () => {
+  test('downloads and stages e2fsprogs tools and gettext for macOS beside the VM driver', async () => {
+    const fixtures = await createDarwinFixtures();
+    stubDarwinRegistry(fixtures);
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const outputDir = join(testDir, 'output');
+    await mkdir(outputDir);
+    await writeFile(join(outputDir, 'openshell-driver-vm'), 'vm-driver');
 
-  await downloadMkfsExt4(VERSION, 'arm64', outputDir);
+    await downloadMkfsExt4(VERSION, 'arm64', 'darwin', outputDir);
 
-  expect(await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8')).toContain('/lib/ld-linux-aarch64.so.1');
+    expect(await readFile(join(outputDir, 'openshell-driver-vm'), 'utf-8')).toBe('vm-driver');
+    expect(await readFile(join(outputDir, '.mkfs-ext4', 'mke2fs'), 'utf-8')).toBe('mke2fs-binary');
+    expect(await readFile(join(outputDir, '.mkfs-ext4', 'debugfs'), 'utf-8')).toBe('debugfs-binary');
+    expect(await readFile(join(outputDir, '.mkfs-ext4', 'mke2fs.conf'), 'utf-8')).toBe('[defaults]\n');
+    expect(await readFile(join(outputDir, '.mkfs-ext4-version'), 'utf-8')).toBe(`${VERSION}-darwin-arm64`);
+
+    for (const stem of DARWIN_DYLIB_STEMS) {
+      expect(await readFile(join(outputDir, '.mkfs-ext4', 'lib', `${stem}.1.1.dylib`), 'utf-8')).toBe(
+        `${stem}-versioned`,
+      );
+      expect(await readFile(join(outputDir, '.mkfs-ext4', 'lib', `${stem}.dylib`), 'utf-8')).toBe(
+        `${stem}-unversioned`,
+      );
+    }
+
+    expect(await readFile(join(outputDir, '.mkfs-ext4', 'lib', 'libintl.8.dylib'), 'utf-8')).toBe('libintl-binary');
+    expect(await readFile(join(outputDir, '.mkfs-ext4', 'lib', 'libintl.dylib'), 'utf-8')).toBe('libintl-unversioned');
+
+    if (process.platform !== 'win32') {
+      expect((await stat(join(outputDir, 'mkfs.ext4'))).mode & 0o111).not.toBe(0);
+      expect((await stat(join(outputDir, 'debugfs'))).mode & 0o111).not.toBe(0);
+      expect((await stat(join(outputDir, '.mkfs-ext4', 'mke2fs'))).mode & 0o111).not.toBe(0);
+      expect((await stat(join(outputDir, '.mkfs-ext4', 'debugfs'))).mode & 0o111).not.toBe(0);
+
+      const symlinkTarget = await readlink(join(outputDir, '.mkfs-ext4', 'mkfs.ext4'));
+      expect(symlinkTarget).toBe('mke2fs');
+    }
+
+    const mkfsWrapper = await readFile(join(outputDir, 'mkfs.ext4'), 'utf-8');
+    expect(mkfsWrapper).toContain('DYLD_LIBRARY_PATH');
+    expect(mkfsWrapper).toContain('MKE2FS_CONFIG');
+    expect(mkfsWrapper).toContain('$runtime_dir/mkfs.ext4');
+
+    const debugfsWrapper = await readFile(join(outputDir, 'debugfs'), 'utf-8');
+    expect(debugfsWrapper).toContain('DYLD_LIBRARY_PATH');
+    expect(debugfsWrapper).toContain('$runtime_dir/debugfs');
+
+    await expect(stat(join(outputDir, 'NOTICE'))).rejects.toThrow();
+    await expect(stat(join(outputDir, 'README'))).rejects.toThrow();
+
+    const timeoutValues = timeoutSpy.mock.calls.map(call => call[0]);
+    expect(timeoutValues.filter(v => v === 30_000).length).toBeGreaterThanOrEqual(6);
+    expect(timeoutValues.filter(v => v === 5 * 60_000).length).toBe(2);
+  });
+
+  test('reuses a complete cached installation', async () => {
+    const fixtures = await createDarwinFixtures();
+    const fetchMock = stubDarwinRegistry(fixtures);
+    const outputDir = join(testDir, 'output');
+    await mkdir(outputDir);
+
+    await downloadMkfsExt4(VERSION, 'arm64', 'darwin', outputDir);
+    const callsAfterDownload = fetchMock.mock.calls.length;
+
+    await downloadMkfsExt4(VERSION, 'arm64', 'darwin', outputDir);
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterDownload);
+  });
+
+  test('re-downloads when installation is incomplete', async () => {
+    const fixtures = await createDarwinFixtures();
+    const fetchMock = stubDarwinRegistry(fixtures);
+    const outputDir = join(testDir, 'output');
+    await mkdir(outputDir);
+
+    await downloadMkfsExt4(VERSION, 'arm64', 'darwin', outputDir);
+    const callsAfterDownload = fetchMock.mock.calls.length;
+
+    await chmod(join(outputDir, '.mkfs-ext4', 'lib', `${DARWIN_DYLIB_STEMS[0]}.1.1.dylib`), 0o444);
+    await rm(join(outputDir, 'debugfs'));
+
+    await downloadMkfsExt4(VERSION, 'arm64', 'darwin', outputDir);
+    expect(await readFile(join(outputDir, '.mkfs-ext4', 'debugfs'), 'utf-8')).toBe('debugfs-binary');
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterDownload * 2);
+  });
+
+  test('cleans up partial installation on download failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('/token?')) {
+          return Response.json({ token: 'registry-token' });
+        }
+        if (url.includes('/e2fsprogs/manifests/') && url.endsWith(`/manifests/${VERSION}`)) {
+          return Response.json({
+            manifests: [
+              {
+                mediaType: 'application/vnd.oci.image.manifest.v1+json',
+                digest: 'sha256:platform',
+                platform: { os: 'darwin', architecture: 'arm64' },
+              },
+            ],
+          });
+        }
+        if (url.endsWith('/manifests/sha256:platform')) {
+          return Response.json({
+            layers: [
+              {
+                mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+                digest: `sha256:${'a'.repeat(64)}`,
+                annotations: {
+                  'org.opencontainers.image.title': `e2fsprogs--${VERSION}.arm64_sequoia.bottle.tar.gz`,
+                },
+              },
+            ],
+          });
+        }
+        if (url.includes('/blobs/')) {
+          return new Response('not a valid archive');
+        }
+        return new Response('unexpected URL', { status: 404, statusText: 'Not Found' });
+      }),
+    );
+
+    const outputDir = join(testDir, 'output');
+    await expect(downloadMkfsExt4(VERSION, 'arm64', 'darwin', outputDir)).rejects.toThrow('checksum mismatch');
+
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(join(outputDir, 'mkfs.ext4'))).toBe(false);
+    expect(existsSync(join(outputDir, '.mkfs-ext4'))).toBe(false);
+    expect(existsSync(join(outputDir, '.mkfs-ext4-version'))).toBe(false);
+  });
+
+  test('selects correct OCI platform for x64 architecture', async () => {
+    const fixtures = await createDarwinFixtures();
+    const e2fsprogsDigest = createHash('sha256').update(fixtures.e2fsprogs).digest('hex');
+    const gettextDigest = createHash('sha256').update(fixtures.gettext).digest('hex');
+
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/token?')) {
+        return Response.json({ token: 'registry-token' });
+      }
+      if (url.includes('/e2fsprogs/manifests/') && url.endsWith(`/manifests/${VERSION}`)) {
+        return Response.json({
+          manifests: [
+            {
+              mediaType: 'application/vnd.oci.image.manifest.v1+json',
+              digest: 'sha256:arm64-platform',
+              platform: { os: 'darwin', architecture: 'arm64' },
+            },
+            {
+              mediaType: 'application/vnd.oci.image.manifest.v1+json',
+              digest: 'sha256:amd64-platform',
+              platform: { os: 'darwin', architecture: 'amd64' },
+            },
+          ],
+        });
+      }
+      if (url.endsWith('/manifests/sha256:amd64-platform')) {
+        return Response.json({
+          layers: [
+            {
+              mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+              digest: `sha256:${e2fsprogsDigest}`,
+              annotations: {
+                'org.opencontainers.image.title': `e2fsprogs--${VERSION}.sonoma.bottle.tar.gz`,
+              },
+            },
+          ],
+        });
+      }
+      if (url.endsWith(`/blobs/sha256:${e2fsprogsDigest}`)) {
+        return new Response(fixtures.e2fsprogs);
+      }
+      if (url.includes('/gettext/manifests/') && url.endsWith(`/manifests/${GETTEXT_VERSION}`)) {
+        return Response.json({
+          manifests: [
+            {
+              mediaType: 'application/vnd.oci.image.manifest.v1+json',
+              digest: 'sha256:gettext-amd64',
+              platform: { os: 'darwin', architecture: 'amd64' },
+            },
+          ],
+        });
+      }
+      if (url.endsWith('/manifests/sha256:gettext-amd64')) {
+        return Response.json({
+          layers: [
+            {
+              mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+              digest: `sha256:${gettextDigest}`,
+              annotations: {
+                'org.opencontainers.image.title': `gettext--${GETTEXT_VERSION}.sonoma.bottle.tar.gz`,
+              },
+            },
+          ],
+        });
+      }
+      if (url.endsWith(`/blobs/sha256:${gettextDigest}`)) {
+        return new Response(fixtures.gettext);
+      }
+      return new Response('unexpected URL', { status: 404, statusText: 'Not Found' });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const outputDir = join(testDir, 'output');
+    await mkdir(outputDir);
+
+    await downloadMkfsExt4(VERSION, 'x64', 'darwin', outputDir);
+
+    expect(await readFile(join(outputDir, '.mkfs-ext4-version'), 'utf-8')).toBe(`${VERSION}-darwin-x64`);
+    expect(await readFile(join(outputDir, '.mkfs-ext4', 'lib', 'libintl.8.dylib'), 'utf-8')).toBe('libintl-binary');
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/manifests/sha256:amd64-platform'),
+      expect.anything(),
+    );
+  });
 });
 
 test('reports registry failures with the failing endpoint', async () => {
@@ -166,7 +509,13 @@ test('reports registry failures with the failing endpoint', async () => {
     vi.fn().mockResolvedValue(new Response('', { status: 503, statusText: 'Service Unavailable' })),
   );
 
-  await expect(downloadMkfsExt4(VERSION, 'x64', join(testDir, 'output'))).rejects.toThrow(
+  await expect(downloadMkfsExt4(VERSION, 'x64', 'linux', join(testDir, 'output'))).rejects.toThrow(
     'failed to fetch https://ghcr.io/token',
+  );
+});
+
+test('rejects unsupported architecture', async () => {
+  await expect(downloadMkfsExt4(VERSION, 'x86', 'linux', join(testDir, 'output'))).rejects.toThrow(
+    'unsupported e2fsprogs architecture: x86',
   );
 });

--- a/extensions/openshell/src/e2fsprogs-download.ts
+++ b/extensions/openshell/src/e2fsprogs-download.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ***********************************************************************/
+ **********************************************************************/
 
 import { createWriteStream, existsSync } from 'node:fs';
-import { chmod, copyFile, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, copyFile, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
@@ -27,7 +27,9 @@ import * as tar from 'tar';
 import { sha256 } from './sha256';
 
 const REGISTRY = 'https://ghcr.io';
-const REPOSITORY = 'homebrew/core/e2fsprogs';
+const E2FSPROGS_REPOSITORY = 'homebrew/core/e2fsprogs';
+const GETTEXT_REPOSITORY = 'homebrew/core/gettext';
+const GETTEXT_VERSION = '1.0';
 const MANIFEST_ACCEPT = [
   'application/vnd.oci.image.index.v1+json',
   'application/vnd.oci.image.manifest.v1+json',
@@ -37,8 +39,8 @@ const MANIFEST_ACCEPT = [
 const METADATA_TIMEOUT_MS = 30_000;
 const BOTTLE_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
 
-const LIBRARIES = ['libcom_err.so.2', 'libe2p.so.2', 'libext2fs.so.2', 'libss.so.2'];
-const RUNTIME_DIRECTORY = 'e2fsprogs';
+const LINUX_LIBRARIES = ['libcom_err.so.2', 'libe2p.so.2', 'libext2fs.so.2', 'libss.so.2'];
+const DARWIN_LIBRARY_STEMS = ['libblkid', 'libcom_err', 'libe2p', 'libext2fs', 'libss', 'libuuid'];
 const BINARIES = [
   { name: 'mkfs.ext4', payload: 'mke2fs' },
   { name: 'debugfs', payload: 'debugfs' },
@@ -67,13 +69,21 @@ interface RegistryToken {
   access_token?: string;
 }
 
+function runtimeDirectoryName(platform: string): string {
+  return platform === 'linux' ? 'e2fsprogs' : '.mkfs-ext4';
+}
+
 function architectureForOci(arch: string): string {
   if (arch === 'x64') return 'amd64';
   if (arch === 'arm64') return 'arm64';
   throw new Error(`unsupported e2fsprogs architecture: ${arch}`);
 }
 
-function isRequiredBottleEntry(path: string, type: string, version: string): boolean {
+function isDarwinLibrary(path: string, bottleRoot: string): boolean {
+  return DARWIN_LIBRARY_STEMS.some(stem => path.startsWith(`${bottleRoot}/lib/${stem}`) && path.endsWith('.dylib'));
+}
+
+function isRequiredBottleEntry(path: string, type: string, version: string, platform: string): boolean {
   if (type === 'Link' || type === 'SymbolicLink') {
     return false;
   }
@@ -81,12 +91,17 @@ function isRequiredBottleEntry(path: string, type: string, version: string): boo
   const requiredPaths = [
     ...BINARIES.map(binary => `${bottleRoot}/sbin/${binary.payload}`),
     `${bottleRoot}/.bottle/etc/mke2fs.conf`,
-    `${bottleRoot}/NOTICE`,
   ];
+  if (platform === 'linux') {
+    requiredPaths.push(`${bottleRoot}/NOTICE`);
+  }
   return (
     requiredPaths.some(
       requiredPath => path === requiredPath || requiredPath.startsWith(`${path.replace(/\/$/, '')}/`),
-    ) || LIBRARIES.some(library => path.startsWith(`${bottleRoot}/lib/${library}.`))
+    ) ||
+    (platform === 'linux'
+      ? LINUX_LIBRARIES.some(library => path.startsWith(`${bottleRoot}/lib/${library}.`))
+      : isDarwinLibrary(path, bottleRoot))
   );
 }
 
@@ -102,55 +117,81 @@ async function fetchJson<T>(url: string, headers: Record<string, string> = {}): 
   return (await response.json()) as T;
 }
 
-async function getRegistryToken(): Promise<string> {
-  const query = new URLSearchParams({ service: 'ghcr.io', scope: `repository:${REPOSITORY}:pull` });
+async function getRegistryToken(repository: string): Promise<string> {
+  const query = new URLSearchParams({ service: 'ghcr.io', scope: `repository:${repository}:pull` });
   const result = await fetchJson<RegistryToken>(`${REGISTRY}/token?${query.toString()}`);
   const token = result.token ?? result.access_token;
   if (!token) {
-    throw new Error('e2fsprogs registry response did not include an access token');
+    throw new Error(`registry response for ${repository} did not include an access token`);
   }
   return token;
 }
 
-async function getManifest<T>(reference: string, token: string): Promise<T> {
-  return fetchJson<T>(`${REGISTRY}/v2/${REPOSITORY}/manifests/${reference}`, {
+async function getManifest<T>(repository: string, reference: string, token: string): Promise<T> {
+  return fetchJson<T>(`${REGISTRY}/v2/${repository}/manifests/${reference}`, {
     Authorization: `Bearer ${token}`,
     Accept: MANIFEST_ACCEPT,
   });
 }
 
-async function resolveBottle(version: string, arch: string): Promise<{ digest: string; token: string }> {
-  const token = await getRegistryToken();
-  const index = await getManifest<OciIndex>(version, token);
+async function resolveBottle(
+  repository: string,
+  version: string,
+  arch: string,
+  platform: string,
+): Promise<{ digest: string; token: string }> {
+  const token = await getRegistryToken(repository);
+  const index = await getManifest<OciIndex>(repository, version, token);
   const ociArch = architectureForOci(arch);
   const platformManifest = index.manifests.find(
-    candidate => candidate.platform?.os === 'linux' && candidate.platform.architecture === ociArch,
+    candidate => candidate.platform?.os === platform && candidate.platform.architecture === ociArch,
   );
   if (!platformManifest) {
-    throw new Error(`no e2fsprogs bottle for linux/${arch}`);
+    throw new Error(`no ${repository} bottle for ${platform}/${arch}`);
   }
-  const manifest = await getManifest<OciManifest>(platformManifest.digest, token);
+  const manifest = await getManifest<OciManifest>(repository, platformManifest.digest, token);
   const bottle = manifest.layers.find(candidate => {
     const title = candidate.annotations?.['org.opencontainers.image.title'];
     return candidate.mediaType.endsWith('+gzip') && title?.endsWith('.bottle.tar.gz');
   });
   if (!bottle) {
-    throw new Error('e2fsprogs OCI manifest does not contain a Homebrew bottle layer');
+    throw new Error(`${repository} OCI manifest does not contain a Homebrew bottle layer`);
   }
   return { digest: bottle.digest, token };
 }
 
-async function downloadBottle(digest: string, token: string, destination: string): Promise<void> {
-  const url = `${REGISTRY}/v2/${REPOSITORY}/blobs/${digest}`;
+async function downloadBottle(repository: string, digest: string, token: string, destination: string): Promise<void> {
+  const url = `${REGISTRY}/v2/${repository}/blobs/${digest}`;
   const response = await fetch(url, {
     headers: { Authorization: `Bearer ${token}` },
     redirect: 'follow',
     signal: AbortSignal.timeout(BOTTLE_DOWNLOAD_TIMEOUT_MS),
   });
   if (!response.ok || !response.body) {
-    throw new Error(`failed to download e2fsprogs bottle: ${response.status} ${response.statusText}`);
+    throw new Error(`failed to download ${repository} bottle: ${response.status} ${response.statusText}`);
   }
   await pipeline(response.body, createWriteStream(destination));
+}
+
+async function downloadAndVerifyBottle(
+  repository: string,
+  version: string,
+  arch: string,
+  platform: string,
+  outputDir: string,
+): Promise<string> {
+  const { digest, token } = await resolveBottle(repository, version, arch, platform);
+  const expectedDigest = digest.replace(/^sha256:/, '');
+  if (!/^[a-f0-9]{64}$/i.test(expectedDigest)) {
+    throw new Error(`invalid ${repository} bottle digest: ${digest}`);
+  }
+  const archive = join(outputDir, `${expectedDigest}.bottle.tar.gz`);
+  await downloadBottle(repository, digest, token, archive);
+  const actualDigest = await sha256(archive);
+  if (actualDigest !== expectedDigest) {
+    throw new Error(`checksum mismatch for ${repository} bottle: expected ${expectedDigest}, got ${actualDigest}`);
+  }
+  return archive;
 }
 
 function loaderForArchitecture(arch: string): string {
@@ -159,12 +200,13 @@ function loaderForArchitecture(arch: string): string {
   throw new Error(`unsupported e2fsprogs architecture: ${arch}`);
 }
 
-function wrapper(binaryName: string, payload: string, arch: string): string {
+function linuxWrapper(binaryName: string, payload: string, arch: string): string {
   const loader = loaderForArchitecture(arch);
+  const rtDir = runtimeDirectoryName('linux');
   return `#!/bin/sh
 set -eu
 bin_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-runtime_dir="$bin_dir/${RUNTIME_DIRECTORY}"
+runtime_dir="$bin_dir/${rtDir}"
 loader="${loader}"
 if [ ! -x "$loader" ]; then
   echo "${binaryName} requires the glibc loader at $loader" >&2
@@ -176,16 +218,59 @@ exec "$loader" --argv0 "${binaryName}" "$runtime_dir/${payload}" "$@"
 `;
 }
 
-async function stageBottle(archive: string, version: string, arch: string, outputDir: string): Promise<void> {
+function darwinWrapper(binaryName: string, payload: string): string {
+  const execTarget = binaryName === payload ? payload : binaryName;
+  return `#!/bin/sh
+set -eu
+case "$0" in
+  */*) script_path="$0" ;;
+  *) script_path=$(command -v "$0") ;;
+esac
+bin_dir=$(CDPATH= cd -- "\${script_path%/*}" && pwd)
+runtime_dir="$bin_dir/.mkfs-ext4"
+library_path="$runtime_dir/lib"
+if [ -n "\${DYLD_LIBRARY_PATH:-}" ]; then
+  library_path="$library_path:$DYLD_LIBRARY_PATH"
+fi
+if [ -z "\${MKE2FS_CONFIG:-}" ]; then
+  export MKE2FS_CONFIG="$runtime_dir/mke2fs.conf"
+fi
+export DYLD_LIBRARY_PATH="$library_path"
+exec "$runtime_dir/${execTarget}" "$@"
+`;
+}
+
+async function stageDarwinLibraries(bottleRoot: string, libDir: string): Promise<void> {
+  const bottleLibraries = await readdir(join(bottleRoot, 'lib'));
+  for (const stem of DARWIN_LIBRARY_STEMS) {
+    const matchingFiles = bottleLibraries.filter(
+      candidate => candidate.startsWith(stem) && candidate.endsWith('.dylib'),
+    );
+    if (matchingFiles.length === 0) {
+      throw new Error(`e2fsprogs bottle does not contain ${stem}*.dylib`);
+    }
+    for (const file of matchingFiles) {
+      await copyFile(join(bottleRoot, 'lib', file), join(libDir, file));
+    }
+  }
+}
+
+async function stageBottle(
+  archive: string,
+  version: string,
+  arch: string,
+  platform: string,
+  outputDir: string,
+): Promise<void> {
   const extractionDir = await mkdtemp(join(tmpdir(), 'kaiden-e2fsprogs-'));
   try {
     await tar.extract({
       file: archive,
       cwd: extractionDir,
-      filter: (path, entry) => 'type' in entry && isRequiredBottleEntry(path, entry.type, version),
+      filter: (path, entry) => 'type' in entry && isRequiredBottleEntry(path, entry.type, version, platform),
     });
     const bottleRoot = join(extractionDir, 'e2fsprogs', version);
-    const runtimeDir = join(outputDir, RUNTIME_DIRECTORY);
+    const runtimeDir = join(outputDir, runtimeDirectoryName(platform));
     const libDir = join(runtimeDir, 'lib');
     await rm(runtimeDir, { recursive: true, force: true });
     await mkdir(libDir, { recursive: true });
@@ -195,20 +280,35 @@ async function stageBottle(archive: string, version: string, arch: string, outpu
       await copyFile(join(bottleRoot, 'sbin', binary.payload), payload);
       await chmod(payload, 0o755);
     }
-    const bottleLibraries = await readdir(join(bottleRoot, 'lib'));
-    for (const library of LIBRARIES) {
-      const source = bottleLibraries.find(candidate => candidate.startsWith(`${library}.`));
-      if (!source) {
-        throw new Error(`e2fsprogs bottle does not contain ${library}`);
+
+    if (platform === 'linux') {
+      const bottleLibraries = await readdir(join(bottleRoot, 'lib'));
+      for (const library of LINUX_LIBRARIES) {
+        const source = bottleLibraries.find(candidate => candidate.startsWith(`${library}.`));
+        if (!source) {
+          throw new Error(`e2fsprogs bottle does not contain ${library}`);
+        }
+        await copyFile(join(bottleRoot, 'lib', source), join(libDir, library));
       }
-      await copyFile(join(bottleRoot, 'lib', source), join(libDir, library));
+    } else {
+      await stageDarwinLibraries(bottleRoot, libDir);
     }
+
     await copyFile(join(bottleRoot, '.bottle', 'etc', 'mke2fs.conf'), join(runtimeDir, 'mke2fs.conf'));
-    await copyFile(join(bottleRoot, 'NOTICE'), join(runtimeDir, 'NOTICE'));
+
+    if (platform === 'linux') {
+      await copyFile(join(bottleRoot, 'NOTICE'), join(runtimeDir, 'NOTICE'));
+    } else {
+      await symlink('mke2fs', join(runtimeDir, 'mkfs.ext4'));
+    }
 
     for (const binary of BINARIES) {
       const destination = join(outputDir, binary.name);
-      await writeFile(destination, wrapper(binary.name, binary.payload, arch), { encoding: 'utf-8' });
+      const wrapperContent =
+        platform === 'linux'
+          ? linuxWrapper(binary.name, binary.payload, arch)
+          : darwinWrapper(binary.name, binary.payload);
+      await writeFile(destination, wrapperContent, { encoding: 'utf-8' });
       await chmod(destination, 0o755);
     }
   } finally {
@@ -216,57 +316,95 @@ async function stageBottle(archive: string, version: string, arch: string, outpu
   }
 }
 
-function hasCompleteInstallation(outputDir: string): boolean {
-  return [
-    ...BINARIES.map(binary => join(outputDir, binary.name)),
-    ...BINARIES.map(binary => join(outputDir, RUNTIME_DIRECTORY, binary.payload)),
-    ...LIBRARIES.map(library => join(outputDir, RUNTIME_DIRECTORY, 'lib', library)),
-    join(outputDir, RUNTIME_DIRECTORY, 'mke2fs.conf'),
-    join(outputDir, RUNTIME_DIRECTORY, 'NOTICE'),
-  ].every(path => existsSync(path));
+async function stageGettextLibrary(arch: string, libDir: string): Promise<void> {
+  const tmpDir = await mkdtemp(join(tmpdir(), 'kaiden-gettext-'));
+  try {
+    console.log(`downloading gettext ${GETTEXT_VERSION} for darwin/${arch}...`);
+    const archive = await downloadAndVerifyBottle(GETTEXT_REPOSITORY, GETTEXT_VERSION, arch, 'darwin', tmpDir);
+    console.log('checksum verified for gettext bottle');
+    const extractionDir = join(tmpDir, 'extracted');
+    await mkdir(extractionDir, { recursive: true });
+    await tar.extract({
+      file: archive,
+      cwd: extractionDir,
+      filter: (path, entry) => {
+        if ('type' in entry && (entry.type === 'Link' || entry.type === 'SymbolicLink')) {
+          return false;
+        }
+        return path.startsWith(`gettext/${GETTEXT_VERSION}/lib/libintl`) && path.endsWith('.dylib');
+      },
+    });
+    const gettextLibDir = join(extractionDir, 'gettext', GETTEXT_VERSION, 'lib');
+    const gettextLibraries = await readdir(gettextLibDir);
+    const intlLibs = gettextLibraries.filter(f => f.startsWith('libintl') && f.endsWith('.dylib'));
+    if (intlLibs.length === 0) {
+      throw new Error('gettext bottle does not contain libintl*.dylib');
+    }
+    for (const lib of intlLibs) {
+      await copyFile(join(gettextLibDir, lib), join(libDir, lib));
+    }
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
 }
 
-export async function downloadMkfsExt4(version: string, arch: string, outputDir: string): Promise<void> {
+function hasCompleteInstallation(outputDir: string, platform: string): boolean {
+  const rtDir = runtimeDirectoryName(platform);
+  const runtimeDir = join(outputDir, rtDir);
+  const paths = [
+    ...BINARIES.map(binary => join(outputDir, binary.name)),
+    ...BINARIES.map(binary => join(runtimeDir, binary.payload)),
+    join(runtimeDir, 'mke2fs.conf'),
+  ];
+  if (platform === 'linux') {
+    paths.push(...LINUX_LIBRARIES.map(library => join(runtimeDir, 'lib', library)), join(runtimeDir, 'NOTICE'));
+  } else {
+    paths.push(join(runtimeDir, 'mkfs.ext4'), join(runtimeDir, 'lib'));
+  }
+  return paths.every(path => existsSync(path));
+}
+
+export async function downloadMkfsExt4(
+  version: string,
+  arch: string,
+  platform: string,
+  outputDir: string,
+): Promise<void> {
   architectureForOci(arch);
 
   const versionFile = join(outputDir, '.mkfs-ext4-version');
-  const versionMarker = `${version}-linux-${arch}`;
-  if (existsSync(versionFile) && hasCompleteInstallation(outputDir)) {
+  const versionMarker = `${version}-${platform}-${arch}`;
+  if (existsSync(versionFile) && hasCompleteInstallation(outputDir, platform)) {
     const existing = await readFile(versionFile, 'utf-8');
     if (existing.trim() === versionMarker) {
-      console.log(`mkfs.ext4 ${version} for linux/${arch} already downloaded`);
+      console.log(`mkfs.ext4 ${version} for ${platform}/${arch} already downloaded`);
       return;
     }
   }
 
-  const { digest, token } = await resolveBottle(version, arch);
-  const expectedDigest = digest.replace(/^sha256:/, '');
-  if (!/^[a-f0-9]{64}$/i.test(expectedDigest)) {
-    throw new Error(`invalid e2fsprogs bottle digest: ${digest}`);
-  }
-
   await mkdir(outputDir, { recursive: true });
-  const archive = join(outputDir, `${expectedDigest}.bottle.tar.gz`);
   try {
-    console.log(`downloading mkfs.ext4 ${version} for linux/${arch}...`);
-    await downloadBottle(digest, token, archive);
-    const actualDigest = await sha256(archive);
-    if (actualDigest !== expectedDigest) {
-      throw new Error(`checksum mismatch for e2fsprogs bottle: expected ${expectedDigest}, got ${actualDigest}`);
-    }
+    console.log(`downloading mkfs.ext4 ${version} for ${platform}/${arch}...`);
+    const archive = await downloadAndVerifyBottle(E2FSPROGS_REPOSITORY, version, arch, platform, outputDir);
     console.log('checksum verified for e2fsprogs bottle');
-    await stageBottle(archive, version, arch, outputDir);
+    try {
+      await stageBottle(archive, version, arch, platform, outputDir);
+    } finally {
+      await rm(archive, { force: true });
+    }
+    if (platform === 'darwin') {
+      const libDir = join(outputDir, runtimeDirectoryName('darwin'), 'lib');
+      await stageGettextLibrary(arch, libDir);
+    }
     await writeFile(versionFile, versionMarker, { encoding: 'utf-8' });
   } catch (error) {
+    const rtDir = runtimeDirectoryName(platform);
     await Promise.all([
-      rm(join(outputDir, 'mkfs.ext4'), { force: true }),
-      rm(join(outputDir, 'debugfs'), { force: true }),
-      rm(join(outputDir, RUNTIME_DIRECTORY), { recursive: true, force: true }),
+      ...BINARIES.map(binary => rm(join(outputDir, binary.name), { force: true })),
+      rm(join(outputDir, rtDir), { recursive: true, force: true }),
       rm(versionFile, { force: true }),
     ]);
     throw error;
-  } finally {
-    await rm(archive, { force: true });
   }
-  console.log(`mkfs.ext4 ${version} for linux/${arch} ready`);
+  console.log(`mkfs.ext4 ${version} for ${platform}/${arch} ready`);
 }

--- a/extensions/openshell/src/e2fsprogs-download.ts
+++ b/extensions/openshell/src/e2fsprogs-download.ts
@@ -186,10 +186,15 @@ async function downloadAndVerifyBottle(
     throw new Error(`invalid ${repository} bottle digest: ${digest}`);
   }
   const archive = join(outputDir, `${expectedDigest}.bottle.tar.gz`);
-  await downloadBottle(repository, digest, token, archive);
-  const actualDigest = await sha256(archive);
-  if (actualDigest !== expectedDigest) {
-    throw new Error(`checksum mismatch for ${repository} bottle: expected ${expectedDigest}, got ${actualDigest}`);
+  try {
+    await downloadBottle(repository, digest, token, archive);
+    const actualDigest = await sha256(archive);
+    if (actualDigest !== expectedDigest) {
+      throw new Error(`checksum mismatch for ${repository} bottle: expected ${expectedDigest}, got ${actualDigest}`);
+    }
+  } catch (error) {
+    await rm(archive, { force: true });
+    throw error;
   }
   return archive;
 }

--- a/extensions/openshell/src/e2fsprogs-download.ts
+++ b/extensions/openshell/src/e2fsprogs-download.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
-import { createWriteStream, existsSync } from 'node:fs';
+import { createWriteStream, existsSync, readdirSync } from 'node:fs';
 import { chmod, copyFile, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -364,7 +364,19 @@ function hasCompleteInstallation(outputDir: string, platform: string): boolean {
   if (platform === 'linux') {
     paths.push(...LINUX_LIBRARIES.map(library => join(runtimeDir, 'lib', library)), join(runtimeDir, 'NOTICE'));
   } else {
-    paths.push(join(runtimeDir, 'mkfs.ext4'), join(runtimeDir, 'lib'));
+    paths.push(join(runtimeDir, 'mkfs.ext4'));
+    const libDir = join(runtimeDir, 'lib');
+    if (!existsSync(libDir)) return false;
+    try {
+      const libFiles = readdirSync(libDir);
+      const hasDarwinLibs = DARWIN_LIBRARY_STEMS.every(stem =>
+        libFiles.some(f => f.startsWith(stem) && f.endsWith('.dylib')),
+      );
+      const hasIntl = libFiles.some(f => f.startsWith('libintl') && f.endsWith('.dylib'));
+      if (!hasDarwinLibs || !hasIntl) return false;
+    } catch {
+      return false;
+    }
   }
   return paths.every(path => existsSync(path));
 }

--- a/extensions/openshell/src/e2fsprogs-download.ts
+++ b/extensions/openshell/src/e2fsprogs-download.ts
@@ -91,10 +91,8 @@ function isRequiredBottleEntry(path: string, type: string, version: string, plat
   const requiredPaths = [
     ...BINARIES.map(binary => `${bottleRoot}/sbin/${binary.payload}`),
     `${bottleRoot}/.bottle/etc/mke2fs.conf`,
+    `${bottleRoot}/NOTICE`,
   ];
-  if (platform === 'linux') {
-    requiredPaths.push(`${bottleRoot}/NOTICE`);
-  }
   return (
     requiredPaths.some(
       requiredPath => path === requiredPath || requiredPath.startsWith(`${path.replace(/\/$/, '')}/`),
@@ -301,9 +299,9 @@ async function stageBottle(
 
     await copyFile(join(bottleRoot, '.bottle', 'etc', 'mke2fs.conf'), join(runtimeDir, 'mke2fs.conf'));
 
-    if (platform === 'linux') {
-      await copyFile(join(bottleRoot, 'NOTICE'), join(runtimeDir, 'NOTICE'));
-    } else {
+    await copyFile(join(bottleRoot, 'NOTICE'), join(runtimeDir, 'NOTICE'));
+
+    if (platform === 'darwin') {
       await symlink('mke2fs', join(runtimeDir, 'mkfs.ext4'));
     }
 
@@ -361,8 +359,9 @@ function hasCompleteInstallation(outputDir: string, platform: string): boolean {
     ...BINARIES.map(binary => join(runtimeDir, binary.payload)),
     join(runtimeDir, 'mke2fs.conf'),
   ];
+  paths.push(join(runtimeDir, 'NOTICE'));
   if (platform === 'linux') {
-    paths.push(...LINUX_LIBRARIES.map(library => join(runtimeDir, 'lib', library)), join(runtimeDir, 'NOTICE'));
+    paths.push(...LINUX_LIBRARIES.map(library => join(runtimeDir, 'lib', library)));
   } else {
     paths.push(join(runtimeDir, 'mkfs.ext4'));
     const libDir = join(runtimeDir, 'lib');


### PR DESCRIPTION
Download pinned e2fsprogs 1.47.4 and gettext 1.0 Homebrew bottles from GHCR, verify their digests, and stage mke2fs, debugfs, and the required dylibs (including libintl from gettext) into the darwin-arm64 asset directory. Shell wrappers set DYLD_LIBRARY_PATH and MKE2FS_CONFIG so the bundled tools run self-contained without a Homebrew installation.

## Test plan

### Unit tests

```bash
pnpm exec vitest --run extensions/openshell/src/e2fsprogs-download.spec.ts
```

7 tests covering:
- [x] Downloads and stages both e2fsprogs and gettext bottles for macOS
- [x] Bundles all required dylibs (libblkid, libcom_err, libe2p, libext2fs, libss, libuuid, libintl)
- [x] Creates shell wrappers with DYLD_LIBRARY_PATH and MKE2FS_CONFIG
- [x] Creates mke2fs → mkfs.ext4 symlink for correct argv[0] behavior
- [x] Reuses a complete cached installation (skips re-download)
- [x] Re-downloads when installation is incomplete (missing files or wrong version)
- [x] Reports registry failures with the failing endpoint
- [x] Rejects unsupported architecture
- [x] Cleans up partial installation on checksum mismatch
- [x] Selects correct OCI platform for x64 architecture

### Local integration test

Downloaded and checksum-verified the live e2fsprogs 1.47.4 and gettext 1.0 macOS arm64 bottles. With `PATH` restricted to Kaiden's packaged asset directory, the bundled `mkfs.ext4` created and populated an ext4 image and the bundled `debugfs` read the proof file back:

```bash
e2fs_bin="$PWD/extensions/openshell/assets/darwin-arm64"
test_dir=$(mktemp -d /tmp/kaiden-e2fsprogs-test.XXXXXX)

mkdir "$test_dir/source"
printf 'bundled mkfs.ext4 works\n' > "$test_dir/source/proof.txt"
truncate -s 32M "$test_dir/rootfs.ext4"

env -i PATH="$e2fs_bin" mkfs.ext4 -q -F -t ext4 \
  -d "$test_dir/source" "$test_dir/rootfs.ext4"
env -i PATH="$e2fs_bin" debugfs -R 'cat /proof.txt' "$test_dir/rootfs.ext4"

rm -rf "$test_dir"
```

Observed output:

```
debugfs 1.47.4 (6-Mar-2025)
bundled mkfs.ext4 works
```

### Dynamic library verification

Confirmed via `otool -L` that all non-system dependencies of the bundled `mke2fs` binary are present in `.mkfs-ext4/lib/`:

| Install name (leaf) | Bundled file | Source |
|---------------------|-------------|--------|
| `libext2fs.2.1.dylib` | ✅ present | e2fsprogs bottle |
| `libcom_err.1.1.dylib` | ✅ present | e2fsprogs bottle |
| `libe2p.2.1.dylib` | ✅ present | e2fsprogs bottle |
| `libblkid.2.0.dylib` | ✅ present | e2fsprogs bottle |
| `libuuid.1.1.dylib` | ✅ present | e2fsprogs bottle |
| `libintl.8.dylib` | ✅ present | gettext bottle |
| `libss.1.0.dylib` | ✅ present | e2fsprogs bottle |

Closes #2670