### PR TITLE
feat(#2650): add network access rule change capability for ACP sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "@expo/sudo-prompt": "^9.3.2",
     "@kubernetes/client-node": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@nvidia/openshell-sdk": "0.0.106",
+    "@nvidia/openshell-sdk": "0.0.113",
     "@oslojs/crypto": "^1.0.1",
     "@oslojs/encoding": "^1.1.0",
     "@segment/analytics-node": "^2.3.0",

--- a/packages/api/src/acp-session-info.ts
+++ b/packages/api/src/acp-session-info.ts
@@ -221,8 +221,12 @@ export interface AcpFlowDraftPolicyChunk {
   rationale: string;
   hasSecurityNotes: boolean;
   isL7: boolean;
+  protocol?: 'rest' | 'graphql';
   method?: string;
   path?: string;
+  operationType?: string;
+  operationName?: string;
+  graphqlFields?: string[];
 }
 
 export interface AcpFlowDraftPolicyEvent {

--- a/packages/api/src/acp-session-info.ts
+++ b/packages/api/src/acp-session-info.ts
@@ -108,7 +108,8 @@ export type AcpFlowEvent =
   | AcpFlowPermissionRequestEvent
   | AcpFlowElicitationEvent
   | AcpFlowStatusChangeEvent
-  | AcpFlowCostUpdateEvent;
+  | AcpFlowCostUpdateEvent
+  | AcpFlowDraftPolicyEvent;
 
 export interface AcpAttachment {
   filePath: string;
@@ -207,6 +208,27 @@ export interface AcpFlowStatusChangeEvent {
 export interface AcpFlowCostUpdateEvent {
   kind: 'cost_update';
   cost: AcpCost;
+  timestamp: number;
+}
+
+export interface AcpFlowDraftPolicyChunk {
+  chunkId: string;
+  ruleName: string;
+  status: 'pending' | 'approved' | 'rejected';
+  host: string;
+  port: number;
+  binaries: string[];
+  rationale: string;
+  hasSecurityNotes: boolean;
+  isL7: boolean;
+  method?: string;
+  path?: string;
+}
+
+export interface AcpFlowDraftPolicyEvent {
+  kind: 'draft_policy_update';
+  chunks: AcpFlowDraftPolicyChunk[];
+  totalPending: number;
   timestamp: number;
 }
 

--- a/packages/main/src/plugin/acp/acp-ipc-handler.ts
+++ b/packages/main/src/plugin/acp/acp-ipc-handler.ts
@@ -54,6 +54,8 @@ export class AcpIPCHandler {
     this.ipcHandle('acp:setSessionModel', this.setSessionModel.bind(this));
     this.ipcHandle('acp:setSessionMode', this.setSessionMode.bind(this));
     this.ipcHandle('acp:setSessionConfigOption', this.setSessionConfigOption.bind(this));
+    this.ipcHandle('acp:approveDraftChunk', this.approveDraftChunk.bind(this));
+    this.ipcHandle('acp:rejectDraftChunk', this.rejectDraftChunk.bind(this));
   }
 
   protected async createSession(_: IpcMainInvokeEvent, options: AcpSessionCreateOptions): Promise<AcpSessionInfo> {
@@ -117,5 +119,13 @@ export class AcpIPCHandler {
     value: string | boolean,
   ): Promise<void> {
     return this.sessionManager.setSessionConfigOption(sessionId, configId, value);
+  }
+
+  protected async approveDraftChunk(_: IpcMainInvokeEvent, sessionId: string, chunkId: string): Promise<void> {
+    return this.sessionManager.approveDraftChunk(sessionId, chunkId);
+  }
+
+  protected async rejectDraftChunk(_: IpcMainInvokeEvent, sessionId: string, chunkId: string): Promise<void> {
+    return this.sessionManager.rejectDraftChunk(sessionId, chunkId);
   }
 }

--- a/packages/main/src/plugin/acp/acp-session-manager.spec.ts
+++ b/packages/main/src/plugin/acp/acp-session-manager.spec.ts
@@ -24,6 +24,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { AgentRegistry } from '/@/plugin/agent-registry.js';
 import type { Directories } from '/@/plugin/directories.js';
+import type { DraftPolicyWatcher } from '/@/plugin/draft-policy/draft-policy-watcher.js';
 import type { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { AcpSessionCreateOptions, AcpSessionInfo } from '/@api/acp-session-info.js';
 import type { AgentInfo } from '/@api/agent-info.js';
@@ -71,6 +72,15 @@ const directories: Directories = {
   getAgentWorkspacesConfigDirectory: vi.fn(),
 } as unknown as Directories;
 
+const draftPolicyWatcher: DraftPolicyWatcher = {
+  watchSandbox: vi.fn().mockResolvedValue({ dispose: vi.fn() }),
+  unwatchSandbox: vi.fn(),
+  approveDraftChunk: vi.fn().mockResolvedValue(undefined),
+  rejectDraftChunk: vi.fn().mockResolvedValue(undefined),
+  onDraftPolicyUpdate: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  dispose: vi.fn(),
+} as unknown as DraftPolicyWatcher;
+
 function createSandbox(overrides?: Partial<SandboxInfo>): SandboxInfo {
   return {
     id: 'sandbox-1',
@@ -99,7 +109,9 @@ describe('AcpSessionManager', () => {
     vi.resetAllMocks();
     vi.mocked(directories.getAcpSessionsDirectory).mockReturnValue(FAKE_SESSIONS_DIR);
     vi.mocked(openshellCli.listSandboxes).mockResolvedValue([]);
-    manager = new AcpSessionManager(apiSender, openshellCli, agentRegistry, directories);
+    vi.mocked(draftPolicyWatcher.watchSandbox).mockResolvedValue({ dispose: vi.fn() });
+    vi.mocked(draftPolicyWatcher.onDraftPolicyUpdate).mockReturnValue({ dispose: vi.fn() });
+    manager = new AcpSessionManager(apiSender, openshellCli, agentRegistry, directories, draftPolicyWatcher);
   });
 
   describe('resolveAgentCommand', () => {

--- a/packages/main/src/plugin/acp/acp-session-manager.ts
+++ b/packages/main/src/plugin/acp/acp-session-manager.ts
@@ -1188,20 +1188,12 @@ export class AcpSessionManager {
       console.warn(`[ACP] skipping draft policy watch for session ${sessionId}: sandbox has no id`);
       return;
     }
-    console.log(
-      `[ACP] starting draft policy watch for session ${sessionId}, sandbox ${sandbox.name} (id=${sandbox.id})`,
-    );
-
     const listenerDisposable = this.draftPolicyWatcher.onDraftPolicyUpdate(event => {
       const session = this.sessions.get(sessionId);
       if (session?.info.sandboxId !== event.sandboxId) {
-        console.log(
-          `[ACP] draft policy event for sandbox ${event.sandboxId} does not match session ${sessionId} (sandboxId=${session?.info.sandboxId})`,
-        );
         return;
       }
 
-      console.log(`[ACP] received draft policy update for session ${sessionId}: ${event.chunks.length} chunks`);
       const flowEvent: AcpFlowDraftPolicyEvent = {
         kind: 'draft_policy_update',
         chunks: event.chunks,
@@ -1242,10 +1234,6 @@ export class AcpSessionManager {
     if (!session) throw new Error(`Session "${sessionId}" not found`);
     if (!session.info.sandboxId) throw new Error(`Session "${sessionId}" has no sandbox`);
 
-    console.log(
-      `[ACP] approveDraftChunk: session="${sessionId}", chunkId="${chunkId}", status="${session.info.status}"`,
-    );
-
     await this.draftPolicyWatcher.approveDraftChunk(session.info.sandboxId, chunkId);
 
     this.updateDraftPolicyEventStatus(session, chunkId, 'approved');
@@ -1253,23 +1241,23 @@ export class AcpSessionManager {
 
     if (session.info.status === 'running' || session.info.status === 'idle' || session.info.status === 'completed') {
       const chunk = this.findChunkInEvents(session, chunkId);
-      console.log(`[ACP] approveDraftChunk: chunk found=${!!chunk}, host=${chunk?.host}, port=${chunk?.port}`);
       let retryMessage = 'The network policy was updated. Please retry the blocked request.';
       if (chunk) {
-        const l7Detail = chunk.isL7 ? ` (${chunk.method} ${chunk.path})` : '';
+        let l7Detail = '';
+        if (chunk.protocol === 'graphql') {
+          const opName = chunk.operationName ? ' ' + chunk.operationName : '';
+          l7Detail = ' (GraphQL ' + (chunk.operationType ?? '') + opName + ')';
+        } else if (chunk.isL7) {
+          l7Detail = ' (' + chunk.method + ' ' + chunk.path + ')';
+        }
         retryMessage = `The network policy was updated. Access to ${chunk.host}:${chunk.port}${l7Detail} is now allowed. Please retry the blocked request.`;
       }
 
-      console.log(`[ACP] approveDraftChunk: scheduling retry message in 1000ms`);
-      // Short delay to let the policy hot-reload propagate inside the sandbox
       setTimeout(() => {
-        console.log(`[ACP] approveDraftChunk: sending retry message now`);
         this.sendFollowUp(sessionId, retryMessage).catch((err: unknown) => {
           console.error(`[ACP] Failed to send retry message for "${sessionId}":`, err);
         });
       }, 1000);
-    } else {
-      console.log(`[ACP] approveDraftChunk: NOT sending retry, session status="${session.info.status}"`);
     }
   }
 

--- a/packages/main/src/plugin/acp/acp-session-manager.ts
+++ b/packages/main/src/plugin/acp/acp-session-manager.ts
@@ -29,10 +29,12 @@ import { spawn as ptySpawn } from 'node-pty';
 
 import { AgentRegistry } from '/@/plugin/agent-registry.js';
 import { Directories } from '/@/plugin/directories.js';
+import { DraftPolicyWatcher } from '/@/plugin/draft-policy/draft-policy-watcher.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type {
   AcpAttachment,
   AcpElicitationResponseData,
+  AcpFlowDraftPolicyEvent,
   AcpFlowEvent,
   AcpPermissionResponseData,
   AcpSessionConfigOption,
@@ -43,6 +45,7 @@ import type {
 } from '/@api/acp-session-info.js';
 import type { AgentInfo } from '/@api/agent-info.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import type { IDisposable } from '/@api/disposable.js';
 import type { SandboxInfo } from '/@api/openshell-gateway-info.js';
 import { AGENT_LABEL } from '/@api/openshell-gateway-info.js';
 
@@ -85,12 +88,14 @@ interface AcpSession {
 @injectable()
 export class AcpSessionManager {
   private sessions = new Map<string, AcpSession>();
+  private readonly draftPolicyDisposables = new Map<string, IDisposable>();
 
   constructor(
     @inject(ApiSenderType) private readonly apiSender: ApiSenderType,
     @inject(OpenshellCli) private readonly openshellCli: OpenshellCli,
     @inject(AgentRegistry) private readonly agentRegistry: AgentRegistry,
     @inject(Directories) private readonly directories: Directories,
+    @inject(DraftPolicyWatcher) private readonly draftPolicyWatcher: DraftPolicyWatcher,
   ) {}
 
   async init(): Promise<void> {
@@ -272,6 +277,8 @@ export class AcpSessionManager {
     this.saveToDisk(sessionId).catch((err: unknown) => {
       console.error(`[ACP] Failed to persist session "${sessionId}":`, err);
     });
+
+    this.startDraftPolicyWatch(sessionId, sandbox, gatewayName);
 
     ptyProcess.onExit(({ exitCode }) => {
       debugPty(`${sandbox.name} process exited with code ${exitCode}`);
@@ -1095,6 +1102,7 @@ export class AcpSessionManager {
     }
 
     this.killPtyProcess(session);
+    this.stopDraftPolicyWatch(sessionId);
     this.updateSessionStatus(sessionId, 'cancelled');
   }
 
@@ -1118,6 +1126,7 @@ export class AcpSessionManager {
     }
 
     this.killPtyProcess(session);
+    this.stopDraftPolicyWatch(sessionId);
 
     this.sessions.delete(sessionId);
     await this.removeFromDisk(sessionId);
@@ -1174,6 +1183,130 @@ export class AcpSessionManager {
     });
   }
 
+  private startDraftPolicyWatch(sessionId: string, sandbox: SandboxInfo, gatewayName?: string): void {
+    if (!sandbox.id) {
+      console.warn(`[ACP] skipping draft policy watch for session ${sessionId}: sandbox has no id`);
+      return;
+    }
+    console.log(
+      `[ACP] starting draft policy watch for session ${sessionId}, sandbox ${sandbox.name} (id=${sandbox.id})`,
+    );
+
+    const listenerDisposable = this.draftPolicyWatcher.onDraftPolicyUpdate(event => {
+      const session = this.sessions.get(sessionId);
+      if (session?.info.sandboxId !== event.sandboxId) {
+        console.log(
+          `[ACP] draft policy event for sandbox ${event.sandboxId} does not match session ${sessionId} (sandboxId=${session?.info.sandboxId})`,
+        );
+        return;
+      }
+
+      console.log(`[ACP] received draft policy update for session ${sessionId}: ${event.chunks.length} chunks`);
+      const flowEvent: AcpFlowDraftPolicyEvent = {
+        kind: 'draft_policy_update',
+        chunks: event.chunks,
+        totalPending: event.totalPending,
+        timestamp: Date.now(),
+      };
+      session.events.push(flowEvent);
+      this.emitEvent(sessionId, flowEvent);
+    });
+
+    this.draftPolicyWatcher
+      .watchSandbox(sandbox.id, sandbox.name, gatewayName)
+      .then(watchDisposable => {
+        const combined: IDisposable = {
+          dispose: () => {
+            listenerDisposable.dispose();
+            watchDisposable.dispose();
+          },
+        };
+        this.draftPolicyDisposables.set(sessionId, combined);
+      })
+      .catch((err: unknown) => {
+        console.error(`[ACP] Failed to start draft policy watch for "${sandbox.name}":`, err);
+        listenerDisposable.dispose();
+      });
+  }
+
+  private stopDraftPolicyWatch(sessionId: string): void {
+    const disposable = this.draftPolicyDisposables.get(sessionId);
+    if (disposable) {
+      disposable.dispose();
+      this.draftPolicyDisposables.delete(sessionId);
+    }
+  }
+
+  async approveDraftChunk(sessionId: string, chunkId: string): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error(`Session "${sessionId}" not found`);
+    if (!session.info.sandboxId) throw new Error(`Session "${sessionId}" has no sandbox`);
+
+    console.log(
+      `[ACP] approveDraftChunk: session="${sessionId}", chunkId="${chunkId}", status="${session.info.status}"`,
+    );
+
+    await this.draftPolicyWatcher.approveDraftChunk(session.info.sandboxId, chunkId);
+
+    this.updateDraftPolicyEventStatus(session, chunkId, 'approved');
+    this.emitEvent(sessionId, session.events[session.events.length - 1]!);
+
+    if (session.info.status === 'running' || session.info.status === 'idle' || session.info.status === 'completed') {
+      const chunk = this.findChunkInEvents(session, chunkId);
+      console.log(`[ACP] approveDraftChunk: chunk found=${!!chunk}, host=${chunk?.host}, port=${chunk?.port}`);
+      let retryMessage = 'The network policy was updated. Please retry the blocked request.';
+      if (chunk) {
+        const l7Detail = chunk.isL7 ? ` (${chunk.method} ${chunk.path})` : '';
+        retryMessage = `The network policy was updated. Access to ${chunk.host}:${chunk.port}${l7Detail} is now allowed. Please retry the blocked request.`;
+      }
+
+      console.log(`[ACP] approveDraftChunk: scheduling retry message in 1000ms`);
+      // Short delay to let the policy hot-reload propagate inside the sandbox
+      setTimeout(() => {
+        console.log(`[ACP] approveDraftChunk: sending retry message now`);
+        this.sendFollowUp(sessionId, retryMessage).catch((err: unknown) => {
+          console.error(`[ACP] Failed to send retry message for "${sessionId}":`, err);
+        });
+      }, 1000);
+    } else {
+      console.log(`[ACP] approveDraftChunk: NOT sending retry, session status="${session.info.status}"`);
+    }
+  }
+
+  async rejectDraftChunk(sessionId: string, chunkId: string): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error(`Session "${sessionId}" not found`);
+    if (!session.info.sandboxId) throw new Error(`Session "${sessionId}" has no sandbox`);
+
+    await this.draftPolicyWatcher.rejectDraftChunk(session.info.sandboxId, chunkId);
+
+    this.updateDraftPolicyEventStatus(session, chunkId, 'rejected');
+    this.emitEvent(sessionId, session.events[session.events.length - 1]!);
+  }
+
+  private updateDraftPolicyEventStatus(session: AcpSession, chunkId: string, status: 'approved' | 'rejected'): void {
+    for (const event of session.events) {
+      if (event.kind !== 'draft_policy_update') continue;
+      const chunk = (event as AcpFlowDraftPolicyEvent).chunks.find(c => c.chunkId === chunkId);
+      if (chunk) {
+        chunk.status = status;
+        return;
+      }
+    }
+  }
+
+  private findChunkInEvents(
+    session: AcpSession,
+    chunkId: string,
+  ): AcpFlowDraftPolicyEvent['chunks'][number] | undefined {
+    for (const event of session.events) {
+      if (event.kind !== 'draft_policy_update') continue;
+      const chunk = (event as AcpFlowDraftPolicyEvent).chunks.find(c => c.chunkId === chunkId);
+      if (chunk) return chunk;
+    }
+    return undefined;
+  }
+
   private emitEvent(sessionId: string, _event: AcpFlowEvent): void {
     this.apiSender.send('acp-session-update');
     this.saveToDisk(sessionId).catch((err: unknown) => {
@@ -1183,11 +1316,12 @@ export class AcpSessionManager {
 
   @preDestroy()
   dispose(): void {
-    for (const [, session] of this.sessions) {
+    for (const [sessionId, session] of this.sessions) {
       for (const [, pending] of session.pendingRequests) {
         pending.reject(new Error('Manager disposing'));
       }
       this.killPtyProcess(session);
+      this.stopDraftPolicyWatch(sessionId);
     }
     this.sessions.clear();
   }

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -38,6 +38,7 @@ import * as configWriter from '/@/plugin/agent-workspace/workspace-config-writer
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { Directories } from '/@/plugin/directories.js';
+import type { DraftPolicyWatcher } from '/@/plugin/draft-policy/draft-policy-watcher.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import type { OpenshellGatewayStateManager } from '/@/plugin/openshell-cli/openshell-gateway-state-manager.js';
@@ -169,6 +170,11 @@ const directories = {
   getAgentWorkspacesConfigDirectory: vi.fn().mockReturnValue('/mock/data/agent-workspaces'),
 } as unknown as Directories;
 
+const draftPolicyWatcher = {
+  unwatchSandbox: vi.fn(),
+  unwatchSandboxByName: vi.fn(),
+} as unknown as DraftPolicyWatcher;
+
 function mockEnoent(): NodeJS.ErrnoException {
   const err: NodeJS.ErrnoException = new Error('ENOENT');
   err.code = 'ENOENT';
@@ -248,6 +254,7 @@ beforeEach(() => {
     openshellGateway,
     openshellGatewayStateManager,
     directories,
+    draftPolicyWatcher,
   );
   manager.init();
 });
@@ -1390,6 +1397,15 @@ describe('remove', () => {
       force: true,
     });
   });
+
+  test('unwatches draft policy for the sandbox being removed', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
+    vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
+
+    await manager.remove('ws-1', 'kaiden');
+
+    expect(draftPolicyWatcher.unwatchSandbox).toHaveBeenCalledWith('ws-1');
+  });
 });
 
 describe('deleteOpenshellSandbox', () => {
@@ -1410,6 +1426,14 @@ describe('deleteOpenshellSandbox', () => {
       recursive: true,
       force: true,
     });
+  });
+
+  test('unwatches draft policy by sandbox name', async () => {
+    vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
+
+    await manager.deleteOpenshellSandbox('my-workspace', 'kaiden');
+
+    expect(draftPolicyWatcher.unwatchSandboxByName).toHaveBeenCalledWith('my-workspace');
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -31,6 +31,7 @@ import { updateWorkspaceConfig, writeWorkspaceConfig } from '/@/plugin/agent-wor
 import { WritableConfigurationFile } from '/@/plugin/agent-workspace/writable-configuration-file.js';
 import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { Directories } from '/@/plugin/directories.js';
+import { DraftPolicyWatcher } from '/@/plugin/draft-policy/draft-policy-watcher.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import { OpenshellGatewayStateManager } from '/@/plugin/openshell-cli/openshell-gateway-state-manager.js';
@@ -118,6 +119,8 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly openshellGatewayStateManager: OpenshellGatewayStateManager,
     @inject(Directories)
     private readonly directories: Directories,
+    @inject(DraftPolicyWatcher)
+    private readonly draftPolicyWatcher: DraftPolicyWatcher,
   ) {}
 
   private getGlobalConfigDir(gateway: string, sandboxName: string): string {
@@ -477,6 +480,7 @@ export class AgentWorkspaceManager implements Disposable {
     task.state = 'running';
     task.status = 'in-progress';
     try {
+      this.draftPolicyWatcher.unwatchSandbox(id);
       await this.openshellCli.deleteSandbox(workspaceName, gateway);
       this.closeWorkspaceTerminal(id);
       await rm(this.getGlobalConfigDir(gateway, workspaceName), { recursive: true, force: true });
@@ -597,6 +601,7 @@ export class AgentWorkspaceManager implements Disposable {
     task.state = 'running';
     task.status = 'in-progress';
     try {
+      this.draftPolicyWatcher.unwatchSandboxByName(name);
       await this.openshellCli.deleteSandbox(name, gateway);
       await rm(this.getGlobalConfigDir(gateway, name), { recursive: true, force: true });
       this.apiSender.send('agent-workspace-update');

--- a/packages/main/src/plugin/draft-policy/draft-policy-watcher.spec.ts
+++ b/packages/main/src/plugin/draft-policy/draft-policy-watcher.spec.ts
@@ -1,0 +1,512 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { OpenshellSdkClientManager } from '/@/plugin/openshell-cli/openshell-sdk-client-manager.js';
+
+import type { DraftPolicyEvent } from './draft-policy-watcher.js';
+import { DraftPolicyWatcher } from './draft-policy-watcher.js';
+
+function createMockClient(): {
+  raw: {
+    watchSandbox: ReturnType<typeof vi.fn>;
+    getDraftPolicy: ReturnType<typeof vi.fn>;
+    approveDraftChunk: ReturnType<typeof vi.fn>;
+    rejectDraftChunk: ReturnType<typeof vi.fn>;
+    updateConfig: ReturnType<typeof vi.fn>;
+  };
+} {
+  return {
+    raw: {
+      watchSandbox: vi.fn(),
+      getDraftPolicy: vi.fn().mockResolvedValue({ chunks: [] }),
+      approveDraftChunk: vi.fn().mockResolvedValue({ policyVersion: 1 }),
+      rejectDraftChunk: vi.fn().mockResolvedValue({}),
+      updateConfig: vi.fn().mockResolvedValue({ version: 1 }),
+    },
+  };
+}
+
+function neverEndingStream(): AsyncGenerator<never> {
+  // eslint-disable-next-line require-yield, sonarjs/generator-without-yield
+  return (async function* (): AsyncGenerator<never> {
+    await new Promise(() => {});
+  })();
+}
+
+function createSdkManager(client: ReturnType<typeof createMockClient>): OpenshellSdkClientManager {
+  return {
+    getClient: vi.fn().mockResolvedValue(client),
+    invalidate: vi.fn(),
+    dispose: vi.fn(),
+  } as unknown as OpenshellSdkClientManager;
+}
+
+describe('DraftPolicyWatcher', () => {
+  let watcher: DraftPolicyWatcher;
+  let client: ReturnType<typeof createMockClient>;
+  let sdkManager: OpenshellSdkClientManager;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    client = createMockClient();
+    sdkManager = createSdkManager(client);
+    watcher = new DraftPolicyWatcher(sdkManager);
+  });
+
+  afterEach(() => {
+    watcher.dispose();
+    vi.useRealTimers();
+  });
+
+  describe('watchSandbox', () => {
+    test('fetches existing drafts on connect', async () => {
+      const pendingChunk = {
+        id: 'chunk-1',
+        status: 'pending',
+        ruleName: 'allow-example',
+        proposedRule: {
+          endpoints: [{ host: 'example.com', port: 443 }],
+          binaries: [{ path: '/usr/bin/curl' }],
+        },
+        rationale: 'Denied by policy',
+        securityNotes: '',
+        confidence: 0.9,
+      };
+      client.raw.getDraftPolicy.mockResolvedValue({ chunks: [pendingChunk] });
+
+      // Create an empty async iterable that never yields
+      client.raw.watchSandbox.mockReturnValue(neverEndingStream());
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      // Let the microtask for getDraftPolicy resolve
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.sandboxId).toBe('sandbox-1');
+      expect(events[0]!.chunks).toHaveLength(1);
+      expect(events[0]!.chunks[0]!.host).toBe('example.com');
+      expect(events[0]!.chunks[0]!.port).toBe(443);
+      expect(events[0]!.chunks[0]!.status).toBe('pending');
+    });
+
+    test('does not duplicate subscriptions for same sandbox', async () => {
+      client.raw.watchSandbox.mockReturnValue(neverEndingStream());
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+
+      expect(client.raw.watchSandbox).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns disposable that unwatches', async () => {
+      client.raw.watchSandbox.mockReturnValue(neverEndingStream());
+
+      const disposable = await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      disposable.dispose();
+
+      // Should be able to watch again after disposing
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      expect(client.raw.watchSandbox).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('approveDraftChunk', () => {
+    test('calls approveDraftChunk RPC for L4 proposals', async () => {
+      const pendingChunk = {
+        id: 'chunk-1',
+        status: 'pending',
+        ruleName: 'allow-example',
+        proposedRule: {
+          endpoints: [{ host: 'example.com', port: 443 }],
+          binaries: [],
+        },
+        rationale: 'Denied',
+        securityNotes: '',
+        confidence: 0.9,
+        reviewToken: 'token-abc',
+      };
+      client.raw.getDraftPolicy.mockResolvedValue({ chunks: [pendingChunk] });
+      client.raw.watchSandbox.mockReturnValue(neverEndingStream());
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox', 'gateway-1');
+      await vi.advanceTimersByTimeAsync(0);
+
+      await watcher.approveDraftChunk('sandbox-1', 'chunk-1');
+
+      expect(client.raw.approveDraftChunk).toHaveBeenCalledWith({
+        name: 'my-sandbox',
+        chunkId: 'chunk-1',
+        reviewToken: 'token-abc',
+      });
+    });
+
+    test('throws for unknown sandbox', async () => {
+      await expect(watcher.approveDraftChunk('unknown', 'chunk-1')).rejects.toThrow('Not watching sandbox');
+    });
+
+    test('throws for unknown chunk', async () => {
+      client.raw.watchSandbox.mockReturnValue(neverEndingStream());
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      await expect(watcher.approveDraftChunk('sandbox-1', 'unknown-chunk')).rejects.toThrow('not found');
+    });
+  });
+
+  describe('rejectDraftChunk', () => {
+    test('calls rejectDraftChunk RPC for L4 proposals', async () => {
+      const pendingChunk = {
+        id: 'chunk-1',
+        status: 'pending',
+        ruleName: 'allow-example',
+        proposedRule: {
+          endpoints: [{ host: 'example.com', port: 443 }],
+          binaries: [],
+        },
+        rationale: 'Denied',
+        securityNotes: '',
+        confidence: 0.9,
+      };
+      client.raw.getDraftPolicy.mockResolvedValue({ chunks: [pendingChunk] });
+      client.raw.watchSandbox.mockReturnValue(neverEndingStream());
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      await watcher.rejectDraftChunk('sandbox-1', 'chunk-1');
+
+      expect(client.raw.rejectDraftChunk).toHaveBeenCalledWith({
+        name: 'my-sandbox',
+        chunkId: 'chunk-1',
+        reason: 'Rejected by user',
+      });
+    });
+  });
+
+  describe('unwatchSandbox', () => {
+    test('cleans up state', async () => {
+      client.raw.watchSandbox.mockReturnValue(neverEndingStream());
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      watcher.unwatchSandbox('sandbox-1');
+
+      // Should not throw for non-existent sandbox
+      watcher.unwatchSandbox('sandbox-1');
+    });
+  });
+
+  describe('unwatchSandboxByName', () => {
+    test('unwatches sandbox found by name', async () => {
+      client.raw.watchSandbox.mockReturnValue(neverEndingStream());
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      watcher.unwatchSandboxByName('my-sandbox');
+
+      // Should be able to watch again after unwatching by name
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      expect(client.raw.watchSandbox).toHaveBeenCalledTimes(2);
+    });
+
+    test('is a no-op when sandbox name not found', () => {
+      watcher.unwatchSandboxByName('nonexistent');
+    });
+  });
+
+  describe('log-based denial detection', () => {
+    function makeLogEvent(
+      message: string,
+      fields: Record<string, string> = {},
+    ): {
+      payload: {
+        case: 'log';
+        value: { fields: Record<string, string>; timestampMs: bigint; message: string; level: string; source: string };
+      };
+    } {
+      return {
+        payload: {
+          case: 'log' as const,
+          value: { fields, timestampMs: BigInt(Date.now()), message, level: 'INFO', source: 'sandbox' },
+        },
+      };
+    }
+
+    function setupStreamWithEvents(
+      events: Array<{ payload: { case: string; value: unknown } }>,
+    ): AsyncGenerator<{ payload: { case: string; value: unknown } }> {
+      return (async function* (): AsyncGenerator<{ payload: { case: string; value: unknown } }> {
+        for (const ev of events) {
+          yield ev;
+        }
+        await new Promise(() => {});
+      })();
+    }
+
+    test('emits L4 denial immediately from OCSF shorthand', async () => {
+      const logEvent = makeLogEvent(
+        'NET:CONNECT [MED] DENIED curl(1234) -> registry.npmjs.org:443 [policy:default] [reason:host not in allow list]',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      const chunk = events[0]!.chunks[0]!;
+      expect(chunk.host).toBe('registry.npmjs.org');
+      expect(chunk.port).toBe(443);
+      expect(chunk.isL7).toBe(false);
+      expect(chunk.status).toBe('pending');
+    });
+
+    test('emits L7 denial immediately from OCSF shorthand', async () => {
+      const logEvent = makeLogEvent(
+        'HTTP:POST [MED] DENIED curl(1234) -> POST https://api.github.com:443/repos/octocat/hello-world/issues [policy:default] [reason:method/path not in allow list]',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      const chunk = events[0]!.chunks[0]!;
+      expect(chunk.host).toBe('api.github.com');
+      expect(chunk.port).toBe(443);
+      expect(chunk.isL7).toBe(true);
+      expect(chunk.method).toBe('POST');
+      expect(chunk.status).toBe('pending');
+    });
+
+    test('does not emit duplicate denial when host:port already covered', async () => {
+      const pendingChunk = {
+        id: 'chunk-1',
+        status: 'pending',
+        ruleName: 'allow-api-github',
+        proposedRule: {
+          endpoints: [{ host: 'api.github.com', port: 443 }],
+          binaries: [],
+        },
+        rationale: 'L4 CONNECT denied',
+        securityNotes: '',
+        confidence: 0.9,
+      };
+      client.raw.getDraftPolicy.mockResolvedValue({ chunks: [pendingChunk] });
+
+      const logEvent = makeLogEvent(
+        'HTTP:POST [MED] DENIED curl(1234) -> POST https://api.github.com:443/repos/octocat/hello-world/issues [policy:default]',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Only the existing draft chunk, no duplicate from log
+      expect(events).toHaveLength(1);
+      expect(events[0]!.chunks[0]!.chunkId).toBe('chunk-1');
+    });
+
+    test('emits L4 denial immediately from structured fields', async () => {
+      const logEvent = makeLogEvent('some log message', {
+        l4_decision: 'deny',
+        dst_host: 'registry.npmjs.org',
+        dst_port: '443',
+        binary: '/usr/bin/curl',
+        l4_deny_reason: 'host not in allow list',
+      });
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      const chunk = events[0]!.chunks[0]!;
+      expect(chunk.host).toBe('registry.npmjs.org');
+      expect(chunk.port).toBe(443);
+      expect(chunk.isL7).toBe(false);
+    });
+
+    test('emits L7 denial immediately from structured fields', async () => {
+      const logEvent = makeLogEvent('some log message', {
+        l7_decision: 'deny',
+        dst_host: 'api.github.com',
+        dst_port: '443',
+        l7_action: 'POST',
+        l7_target: '/repos/octocat/hello-world/issues',
+        l7_deny_reason: 'method/path not in allow list',
+      });
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      const chunk = events[0]!.chunks[0]!;
+      expect(chunk.host).toBe('api.github.com');
+      expect(chunk.port).toBe(443);
+      expect(chunk.isL7).toBe(true);
+      expect(chunk.method).toBe('POST');
+    });
+
+    test('ignores transient policy-changed denials', async () => {
+      const logEvent = makeLogEvent(
+        'NET:CONNECT [MED] DENIED curl(1234) -> api.anthropic.com:443 [reason:L7 tunnel closed before inspection because policy changed while CONNECT was dialing upstream [captured_generation:2 current_generation:3]]',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(0);
+    });
+
+    test('ignores non-denial log lines', async () => {
+      const logEvent = makeLogEvent('INFO some normal log message');
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(0);
+    });
+
+    test('emits L4 denial from NET:CONNECT with no arrow actor prefix', async () => {
+      const logEvent = makeLogEvent('NET:CONNECT [HIGH] DENIED registry.npmjs.org:443 [reason:blocked]');
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.chunks[0]!.host).toBe('registry.npmjs.org');
+      expect(events[0]!.chunks[0]!.port).toBe(443);
+      expect(events[0]!.chunks[0]!.isL7).toBe(false);
+    });
+  });
+
+  describe('sandbox state change triggers draft refetch', () => {
+    test('refetches draft policy on sandbox state event', async () => {
+      const sandboxEvent = {
+        payload: {
+          case: 'sandbox' as const,
+          value: { status: 'running' },
+        },
+      };
+
+      client.raw.watchSandbox.mockReturnValue(
+        (async function* (): AsyncGenerator<{ payload: { case: string; value: unknown } }> {
+          yield sandboxEvent;
+          await new Promise(() => {});
+        })(),
+      );
+
+      // First getDraftPolicy call (on initial connect) returns empty
+      // Second call (after sandbox state change) returns a chunk
+      client.raw.getDraftPolicy.mockResolvedValueOnce({ chunks: [] }).mockResolvedValueOnce({
+        chunks: [
+          {
+            id: 'chunk-new',
+            status: 'pending',
+            ruleName: 'allow-new',
+            proposedRule: {
+              endpoints: [{ host: 'pypi.org', port: 443 }],
+              binaries: [],
+            },
+            rationale: 'L4 denied',
+            securityNotes: '',
+            confidence: 0.8,
+          },
+        ],
+      });
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.chunks[0]!.host).toBe('pypi.org');
+      expect(client.raw.getDraftPolicy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('policyChunkToFlowChunk mapping', () => {
+    test('maps PolicyChunk fields correctly', async () => {
+      const pendingChunk = {
+        id: 'chunk-42',
+        status: 'pending',
+        ruleName: 'allow-api-github',
+        proposedRule: {
+          endpoints: [{ host: 'api.github.com', port: 443 }],
+          binaries: [{ path: '/usr/bin/git' }, { path: '/usr/bin/curl' }],
+        },
+        rationale: 'L4 CONNECT denied',
+        securityNotes: 'May expose credentials',
+        confidence: 0.7,
+      };
+      client.raw.getDraftPolicy.mockResolvedValue({ chunks: [pendingChunk] });
+      client.raw.watchSandbox.mockReturnValue(neverEndingStream());
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      const chunk = events[0]!.chunks[0]!;
+      expect(chunk.chunkId).toBe('chunk-42');
+      expect(chunk.ruleName).toBe('allow-api-github');
+      expect(chunk.status).toBe('pending');
+      expect(chunk.host).toBe('api.github.com');
+      expect(chunk.port).toBe(443);
+      expect(chunk.binaries).toEqual(['/usr/bin/git', '/usr/bin/curl']);
+      expect(chunk.rationale).toBe('L4 CONNECT denied');
+      expect(chunk.hasSecurityNotes).toBe(true);
+      expect(chunk.isL7).toBe(false);
+    });
+  });
+});

--- a/packages/main/src/plugin/draft-policy/draft-policy-watcher.spec.ts
+++ b/packages/main/src/plugin/draft-policy/draft-policy-watcher.spec.ts
@@ -58,6 +58,34 @@ function createSdkManager(client: ReturnType<typeof createMockClient>): Openshel
   } as unknown as OpenshellSdkClientManager;
 }
 
+function makeLogEvent(
+  message: string,
+  fields: Record<string, string> = {},
+): {
+  payload: {
+    case: 'log';
+    value: { fields: Record<string, string>; timestampMs: bigint; message: string; level: string; source: string };
+  };
+} {
+  return {
+    payload: {
+      case: 'log' as const,
+      value: { fields, timestampMs: BigInt(Date.now()), message, level: 'INFO', source: 'sandbox' },
+    },
+  };
+}
+
+function setupStreamWithEvents(
+  events: Array<{ payload: { case: string; value: unknown } }>,
+): AsyncGenerator<{ payload: { case: string; value: unknown } }> {
+  return (async function* (): AsyncGenerator<{ payload: { case: string; value: unknown } }> {
+    for (const ev of events) {
+      yield ev;
+    }
+    await new Promise(() => {});
+  })();
+}
+
 describe('DraftPolicyWatcher', () => {
   let watcher: DraftPolicyWatcher;
   let client: ReturnType<typeof createMockClient>;
@@ -174,6 +202,190 @@ describe('DraftPolicyWatcher', () => {
     });
   });
 
+  describe('approveDraftChunk - L7 policy update', () => {
+    function mockGetConfig(
+      rules: Record<string, { endpoints: Array<{ host: string; port: number }>; binaries?: Array<{ path: string }> }>,
+    ): void {
+      (client as unknown as Record<string, unknown>)['sandbox'] = {
+        getConfig: vi.fn().mockResolvedValue({
+          policy: { networkPolicies: rules },
+        }),
+      };
+    }
+
+    test('uses addAllowRules when exactly one rule owns the host:port and binary is covered', async () => {
+      const logEvent = makeLogEvent(
+        'L7_REQUEST deny POST api.example.com:443/graphql graphql_ops=type=mutation name=CreateItem fields=createItem',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox', 'gateway-1');
+      await vi.advanceTimersByTimeAsync(0);
+
+      const chunkId = events[0]!.chunks[0]!.chunkId;
+
+      mockGetConfig({
+        single_rule: {
+          endpoints: [{ host: 'api.example.com', port: 443 }],
+          binaries: [{ path: '/**' }],
+        },
+      });
+
+      await watcher.approveDraftChunk('sandbox-1', chunkId);
+
+      expect(client.raw.updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mergeOperations: [
+            expect.objectContaining({
+              operation: expect.objectContaining({
+                case: 'addAllowRules',
+                value: expect.objectContaining({
+                  host: 'api.example.com',
+                  port: 443,
+                }),
+              }),
+            }),
+          ],
+        }),
+      );
+    });
+
+    test('falls back to addRule when multiple rules share the host:port', async () => {
+      const logEvent = makeLogEvent(
+        'L7_REQUEST deny POST api.github.com:443/graphql graphql_ops=type=mutation name=PullRequestCreate fields=createPullRequest',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox', 'gateway-1');
+      await vi.advanceTimersByTimeAsync(0);
+
+      const chunkId = events[0]!.chunks[0]!.chunkId;
+
+      mockGetConfig({
+        github_rest_api: { endpoints: [{ host: 'api.github.com', port: 443 }] },
+        copilot: { endpoints: [{ host: 'api.github.com', port: 443 }] },
+        pypi: { endpoints: [{ host: 'api.github.com', port: 443 }] },
+      });
+
+      await watcher.approveDraftChunk('sandbox-1', chunkId);
+
+      expect(client.raw.updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mergeOperations: [
+            expect.objectContaining({
+              operation: expect.objectContaining({
+                case: 'addRule',
+                value: expect.objectContaining({
+                  rule: expect.objectContaining({
+                    endpoints: [
+                      expect.objectContaining({
+                        host: 'api.github.com',
+                        port: 443,
+                        protocol: 'graphql',
+                        path: '/graphql',
+                      }),
+                    ],
+                  }),
+                }),
+              }),
+            }),
+          ],
+        }),
+      );
+    });
+
+    test('falls back to addRule when single rule does not cover the denial binary', async () => {
+      const logEvent = makeLogEvent('l7 deny', {
+        l7_decision: 'deny',
+        dst_host: 'api.example.com',
+        dst_port: '443',
+        l7_action: 'POST',
+        l7_target: '/repos/org/repo/pulls',
+        binary: '/usr/bin/git',
+        l7_deny_reason: 'method/path not in allow list',
+      });
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox', 'gateway-1');
+      await vi.advanceTimersByTimeAsync(0);
+
+      const chunkId = events[0]!.chunks[0]!.chunkId;
+
+      mockGetConfig({
+        single_rule: {
+          endpoints: [{ host: 'api.example.com', port: 443 }],
+          binaries: [{ path: '/usr/bin/curl' }],
+        },
+      });
+
+      await watcher.approveDraftChunk('sandbox-1', chunkId);
+
+      expect(client.raw.updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mergeOperations: [
+            expect.objectContaining({
+              operation: expect.objectContaining({
+                case: 'addRule',
+              }),
+            }),
+          ],
+        }),
+      );
+    });
+
+    test('falls back to addRule when no rules exist for host:port', async () => {
+      const logEvent = makeLogEvent(
+        'HTTP:POST [MED] DENIED curl(1234) -> POST https://api.new-host.com:443/some/path [policy:default]',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox', 'gateway-1');
+      await vi.advanceTimersByTimeAsync(0);
+
+      const chunkId = events[0]!.chunks[0]!.chunkId;
+
+      mockGetConfig({});
+
+      await watcher.approveDraftChunk('sandbox-1', chunkId);
+
+      expect(client.raw.updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mergeOperations: [
+            expect.objectContaining({
+              operation: expect.objectContaining({
+                case: 'addRule',
+                value: expect.objectContaining({
+                  rule: expect.objectContaining({
+                    endpoints: [
+                      expect.objectContaining({
+                        host: 'api.new-host.com',
+                        port: 443,
+                        protocol: 'rest',
+                        enforcement: 'enforce',
+                      }),
+                    ],
+                  }),
+                }),
+              }),
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
   describe('rejectDraftChunk', () => {
     test('calls rejectDraftChunk RPC for L4 proposals', async () => {
       const pendingChunk = {
@@ -234,34 +446,6 @@ describe('DraftPolicyWatcher', () => {
   });
 
   describe('log-based denial detection', () => {
-    function makeLogEvent(
-      message: string,
-      fields: Record<string, string> = {},
-    ): {
-      payload: {
-        case: 'log';
-        value: { fields: Record<string, string>; timestampMs: bigint; message: string; level: string; source: string };
-      };
-    } {
-      return {
-        payload: {
-          case: 'log' as const,
-          value: { fields, timestampMs: BigInt(Date.now()), message, level: 'INFO', source: 'sandbox' },
-        },
-      };
-    }
-
-    function setupStreamWithEvents(
-      events: Array<{ payload: { case: string; value: unknown } }>,
-    ): AsyncGenerator<{ payload: { case: string; value: unknown } }> {
-      return (async function* (): AsyncGenerator<{ payload: { case: string; value: unknown } }> {
-        for (const ev of events) {
-          yield ev;
-        }
-        await new Promise(() => {});
-      })();
-    }
-
     test('emits L4 denial immediately from OCSF shorthand', async () => {
       const logEvent = makeLogEvent(
         'NET:CONNECT [MED] DENIED curl(1234) -> registry.npmjs.org:443 [policy:default] [reason:host not in allow list]',
@@ -408,6 +592,68 @@ describe('DraftPolicyWatcher', () => {
       await vi.advanceTimersByTimeAsync(0);
 
       expect(events).toHaveLength(0);
+    });
+
+    test('emits GraphQL denial from L7_REQUEST format', async () => {
+      const logEvent = makeLogEvent(
+        'L7_REQUEST deny POST api.github.com:443/graphql graphql_ops=type=mutation name=PullRequestCreate fields=createPullRequest [policy:default]',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      const chunk = events[0]!.chunks[0]!;
+      expect(chunk.host).toBe('api.github.com');
+      expect(chunk.port).toBe(443);
+      expect(chunk.isL7).toBe(true);
+      expect(chunk.protocol).toBe('graphql');
+      expect(chunk.operationType).toBe('mutation');
+      expect(chunk.operationName).toBe('PullRequestCreate');
+      expect(chunk.graphqlFields).toEqual(['createPullRequest']);
+    });
+
+    test('does not duplicate GraphQL denial with same operation type', async () => {
+      const logEvent1 = makeLogEvent(
+        'L7_REQUEST deny POST api.github.com:443/graphql graphql_ops=type=mutation name=PullRequestCreate fields=createPullRequest',
+      );
+      const logEvent2 = makeLogEvent(
+        'L7_REQUEST deny POST api.github.com:443/graphql graphql_ops=type=mutation name=AddReview fields=addPullRequestReview',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent1, logEvent2]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Both are mutation type on same host:port, first pending suppresses second
+      expect(events).toHaveLength(1);
+    });
+
+    test('emits different GraphQL operation types separately', async () => {
+      const logEvent1 = makeLogEvent(
+        'L7_REQUEST deny POST api.github.com:443/graphql graphql_ops=type=mutation name=CreatePR fields=createPullRequest',
+      );
+      const logEvent2 = makeLogEvent(
+        'L7_REQUEST deny POST api.github.com:443/graphql graphql_ops=type=query name=GetRepo fields=repository',
+      );
+      client.raw.watchSandbox.mockReturnValue(setupStreamWithEvents([logEvent1, logEvent2]));
+
+      const events: DraftPolicyEvent[] = [];
+      watcher.onDraftPolicyUpdate(e => events.push(e));
+
+      await watcher.watchSandbox('sandbox-1', 'my-sandbox');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(2);
+      expect(events[0]!.chunks[0]!.operationType).toBe('mutation');
+      expect(events[1]!.chunks[0]!.operationType).toBe('query');
     });
 
     test('emits L4 denial from NET:CONNECT with no arrow actor prefix', async () => {

--- a/packages/main/src/plugin/draft-policy/draft-policy-watcher.ts
+++ b/packages/main/src/plugin/draft-policy/draft-policy-watcher.ts
@@ -34,12 +34,17 @@ export interface DraftPolicyEvent {
 
 interface DenialLogEntry {
   timestampMs: number;
+  isL7: boolean;
   host: string;
   port: number;
   method?: string;
   path?: string;
   binary?: string;
   denyReason?: string;
+  protocol?: 'rest' | 'graphql';
+  operationType?: string;
+  operationName?: string;
+  graphqlFields?: string[];
 }
 
 interface SandboxWatchState {
@@ -76,11 +81,8 @@ export class DraftPolicyWatcher {
 
   async watchSandbox(sandboxId: string, sandboxName: string, gatewayName?: string): Promise<IDisposable> {
     if (this.#subscriptions.has(sandboxId)) {
-      console.log(`[DraftPolicy] already watching sandbox ${sandboxName} (${sandboxId}), skipping`);
       return { dispose: () => this.unwatchSandbox(sandboxId) };
     }
-
-    console.log(`[DraftPolicy] watching sandbox ${sandboxName} (id=${sandboxId}, gateway=${gatewayName ?? 'default'})`);
 
     const state: SandboxWatchState = {
       sandboxName,
@@ -162,17 +164,27 @@ export class DraftPolicyWatcher {
     sandboxName: string,
     chunk: AcpFlowDraftPolicyChunk,
   ): Promise<void> {
+    const endpointProtocol = chunk.protocol ?? (chunk.isL7 ? 'rest' : undefined);
+    const allow = this.#buildAllowRule(chunk, endpointProtocol);
+
+    // Use addAllowRules when exactly one rule owns this host:port AND its binary
+    // scope covers the denial binary. addAllowRules appends to the existing
+    // endpoint (no ambiguity risk), but it can't update binaries — so if the
+    // denial binary isn't in scope, addAllowRules would have no effect.
     const config = await client.sandbox.getConfig(sandboxName);
-    const policy = config.policy;
+    const matchingRules = config.policy
+      ? Object.values(config.policy.networkPolicies).filter(rule =>
+          rule.endpoints.some(
+            (ep: { host: string; port: number; ports?: number[] }) =>
+              ep.host === chunk.host && (ep.port === chunk.port || ep.ports?.includes(chunk.port)),
+          ),
+        )
+      : [];
 
-    const matchingEndpoint =
-      policy &&
-      Object.values(policy.networkPolicies)
-        .flatMap(rule => rule.endpoints)
-        .find(ep => ep.host === chunk.host && (ep.port === chunk.port || ep.ports.includes(chunk.port)));
+    const canUseAddAllowRules =
+      matchingRules.length === 1 && this.#binaryCoveredByRule(chunk.binaries, matchingRules[0]!);
 
-    if (matchingEndpoint && matchingEndpoint.protocol) {
-      // Endpoint has L7 inspection — append allow rules
+    if (canUseAddAllowRules) {
       await client.raw.updateConfig({
         name: sandboxName,
         mergeOperations: [
@@ -182,30 +194,26 @@ export class DraftPolicyWatcher {
               value: {
                 host: chunk.host,
                 port: chunk.port,
-                rules: [
-                  {
-                    allow: {
-                      method: chunk.method ?? '*',
-                      path: chunk.path ?? '/**',
-                    },
-                  },
-                ],
+                rules: [{ allow }],
               },
             },
           },
         ],
       });
-    } else if (!matchingEndpoint) {
-      // Endpoint not in policy — create a new rule
-      const endpoint: { host: string; port: number; protocol?: string; enforcement?: string } = {
+    } else {
+      // Multiple rules (or none) share this host:port — addAllowRules can't
+      // disambiguate, so create a new rule instead.
+      const endpoint: Record<string, unknown> = {
         host: chunk.host,
         port: chunk.port,
       };
-      if (chunk.isL7) {
-        endpoint.protocol = 'rest';
-        endpoint.enforcement = 'enforce';
+      if (endpointProtocol) {
+        endpoint['protocol'] = endpointProtocol;
+        endpoint['enforcement'] = 'enforce';
+        if (endpointProtocol === 'graphql') {
+          endpoint['path'] = '/graphql';
+        }
       }
-
       await client.raw.updateConfig({
         name: sandboxName,
         mergeOperations: [
@@ -216,7 +224,7 @@ export class DraftPolicyWatcher {
                 ruleName: chunk.ruleName,
                 rule: {
                   name: chunk.ruleName,
-                  endpoints: [endpoint],
+                  endpoints: [{ ...endpoint, rules: [{ allow }] }],
                   binaries: chunk.binaries.map(path => ({ path })),
                 },
               },
@@ -225,19 +233,39 @@ export class DraftPolicyWatcher {
         ],
       });
     }
-    // else: endpoint exists as L4-only — already allowed, nothing to do
+  }
+
+  #buildAllowRule(chunk: AcpFlowDraftPolicyChunk, protocol?: string): Record<string, unknown> {
+    if (protocol === 'graphql') {
+      const allow: Record<string, unknown> = {};
+      if (chunk.operationType) allow['operation_type'] = chunk.operationType;
+      if (chunk.operationName) allow['operation_name'] = chunk.operationName;
+      if (chunk.graphqlFields?.length) allow['fields'] = chunk.graphqlFields;
+      return allow;
+    }
+    return {
+      method: chunk.method ?? '*',
+      path: chunk.path ?? '/**',
+    };
+  }
+
+  #binaryCoveredByRule(denialBinaries: string[], rule: { binaries?: Array<{ path: string }> }): boolean {
+    const ruleBinaries = rule.binaries?.map(b => b.path) ?? [];
+    if (ruleBinaries.length === 0) return true;
+    if (ruleBinaries.some(b => b === '/**' || b === '*')) return true;
+    return denialBinaries.every(
+      db =>
+        db === '/**' || ruleBinaries.some(rb => db === rb || (rb.endsWith('/**') && db.startsWith(rb.slice(0, -2)))),
+    );
   }
 
   async #fetchExistingDrafts(sandboxId: string, state: SandboxWatchState): Promise<void> {
     try {
-      console.log(`[DraftPolicy] fetching existing drafts for ${state.sandboxName}`);
       const client = await this.sdkClientManager.getClient(state.gatewayName);
       const response = await client.raw.getDraftPolicy({
         name: state.sandboxName,
         statusFilter: 'pending',
       });
-
-      console.log(`[DraftPolicy] got ${response.chunks.length} existing draft chunks for ${state.sandboxName}`);
 
       if (response.chunks.length > 0) {
         const mapped = response.chunks.map(c => this.#policyChunkToFlowChunk(c));
@@ -259,7 +287,6 @@ export class DraftPolicyWatcher {
   #startStream(sandboxId: string, state: SandboxWatchState): void {
     const iterate = async (): Promise<void> => {
       try {
-        console.log(`[DraftPolicy] starting WatchSandbox stream for ${state.sandboxName} (id=${sandboxId})`);
         const client = await this.sdkClientManager.getClient(state.gatewayName);
         const stream = client.raw.watchSandbox(
           {
@@ -273,7 +300,6 @@ export class DraftPolicyWatcher {
           { signal: state.abortController.signal },
         );
 
-        console.log(`[DraftPolicy] WatchSandbox stream connected for ${state.sandboxName}`);
         state.reconnectAttempt = 0;
 
         for await (const event of stream) {
@@ -281,28 +307,19 @@ export class DraftPolicyWatcher {
 
           switch (event.payload.case) {
             case 'draftPolicyUpdate':
-              console.log(
-                `[DraftPolicy] received draftPolicyUpdate for ${state.sandboxName}: newChunks=${event.payload.value.newChunks}, totalPending=${event.payload.value.totalPending}`,
-              );
-              await this.#handleDraftPolicyUpdate(sandboxId, state, event.payload.value);
+              await this.#handleDraftPolicyUpdate(sandboxId, state);
               break;
             case 'sandbox':
-              console.log(
-                `[DraftPolicy] sandbox state changed for ${state.sandboxName}, checking for new draft chunks`,
-              );
               await this.#handleSandboxStateChange(sandboxId, state);
               break;
             case 'log':
               this.#handleLogLine(sandboxId, state, event.payload.value);
               break;
             default:
-              console.log(`[DraftPolicy] received event type: ${event.payload.case} for ${state.sandboxName}`);
           }
         }
-        console.log(`[DraftPolicy] WatchSandbox stream ended for ${state.sandboxName}`);
       } catch (err: unknown) {
         if (state.abortController.signal.aborted) {
-          console.log(`[DraftPolicy] stream aborted for ${state.sandboxName}`);
           return;
         }
 
@@ -325,14 +342,7 @@ export class DraftPolicyWatcher {
     });
   }
 
-  async #handleDraftPolicyUpdate(
-    sandboxId: string,
-    state: SandboxWatchState,
-    update: { newChunks: number; totalPending: number; summary: string; draftVersion: bigint },
-  ): Promise<void> {
-    console.log(
-      `[DraftPolicy] fetching draft policy after update (version=${update.draftVersion}) for ${state.sandboxName}`,
-    );
+  async #handleDraftPolicyUpdate(sandboxId: string, state: SandboxWatchState): Promise<void> {
     await this.#refetchDraftPolicy(sandboxId, state);
   }
 
@@ -347,10 +357,6 @@ export class DraftPolicyWatcher {
         name: state.sandboxName,
         statusFilter: 'pending',
       });
-
-      console.log(
-        `[DraftPolicy] getDraftPolicy returned ${response.chunks.length} pending chunks for ${state.sandboxName}`,
-      );
 
       const newChunks: AcpFlowDraftPolicyChunk[] = [];
       for (const policyChunk of response.chunks) {
@@ -383,18 +389,12 @@ export class DraftPolicyWatcher {
       }
 
       if (newChunks.length > 0) {
-        console.log(
-          `[DraftPolicy] firing ${newChunks.length} new chunks for ${state.sandboxName}:`,
-          newChunks.map(c => `${c.host}:${c.port}`).join(', '),
-        );
         this.#onDraftPolicyUpdate.fire({
           sandboxId,
           sandboxName: state.sandboxName,
           chunks: newChunks,
           totalPending: newChunks.length,
         });
-      } else if (response.chunks.length > 0) {
-        console.log(`[DraftPolicy] no new chunks after filtering (${response.chunks.length} already known)`);
       }
     } catch (err: unknown) {
       console.error(`[DraftPolicy] failed to fetch draft policy for ${state.sandboxName}:`, err);
@@ -409,12 +409,6 @@ export class DraftPolicyWatcher {
     const denial = this.#parseDenialFromLogLine(logLine);
     if (!denial) return;
 
-    const layer = denial.isL7 ? 'L7' : 'L4';
-    const detail = denial.method ? ` ${denial.method} ${denial.path}` : '';
-    console.log(
-      `[DraftPolicy] denial detected for ${state.sandboxName}: ${layer} ${denial.host}:${denial.port}${detail}`,
-    );
-
     const entry: DenialLogEntry = {
       timestampMs: Number(logLine.timestampMs),
       ...denial,
@@ -426,17 +420,11 @@ export class DraftPolicyWatcher {
     this.#emitDenialFromLog(sandboxId, state, entry);
   }
 
-  #parseDenialFromLogLine(logLine: { fields: { [key: string]: string }; message: string; level: string }):
-    | {
-        isL7: boolean;
-        host: string;
-        port: number;
-        method?: string;
-        path?: string;
-        binary?: string;
-        denyReason?: string;
-      }
-    | undefined {
+  #parseDenialFromLogLine(logLine: {
+    fields: { [key: string]: string };
+    message: string;
+    level: string;
+  }): Omit<DenialLogEntry, 'timestampMs'> | undefined {
     const fields = logLine.fields;
 
     // Try structured fields first (sandbox-pushed non-OCSF logs may populate them)
@@ -447,6 +435,7 @@ export class DraftPolicyWatcher {
       const port = parseInt(portStr, 10);
       if (isNaN(port)) return undefined;
 
+      const protocol = fields['l7_protocol'] === 'graphql' ? ('graphql' as const) : undefined;
       return {
         isL7: fields['l7_decision'] === 'deny',
         host,
@@ -455,13 +444,44 @@ export class DraftPolicyWatcher {
         path: fields['l7_target'],
         binary: fields['binary'],
         denyReason: fields['l7_deny_reason'] ?? fields['l4_deny_reason'],
+        protocol,
       };
     }
 
-    // Parse OCSF shorthand message format:
-    //   NET:CONNECT [MED] DENIED proc(pid) -> host:port [policy:...] [reason:...]
-    //   HTTP:METHOD [MED] DENIED proc(pid) -> METHOD scheme://host:port/path [policy:...] [reason:...]
     const msg = logLine.message;
+
+    // L7_REQUEST denial (GraphQL, MCP, etc.):
+    //   L7_REQUEST deny POST host:port/path graphql_ops=type=mutation name=Op fields=f1,f2 ...
+    if (msg.startsWith('L7_REQUEST')) {
+      // eslint-disable-next-line sonarjs/slow-regex
+      const l7Match = /^L7_REQUEST\s+deny\s+(\w+)\s+([^/:]+):(\d+)(\/\S*)?/.exec(msg);
+      if (!l7Match) return undefined;
+
+      const result: Omit<DenialLogEntry, 'timestampMs'> = {
+        isL7: true,
+        host: l7Match[2]!,
+        port: parseInt(l7Match[3]!, 10),
+        method: l7Match[1],
+        path: l7Match[4] ?? '/',
+        denyReason: msg,
+      };
+
+      // eslint-disable-next-line sonarjs/slow-regex
+      const gqlOps = /graphql_ops=(.+?)(?:\s+persisted=|\s+\[|$)/.exec(msg);
+      if (gqlOps) {
+        result.protocol = 'graphql';
+        const opsStr = gqlOps[1]!;
+        const typeMatch = /type=(\w+)/.exec(opsStr);
+        const nameMatch = /name=(\w+)/.exec(opsStr);
+        const fieldsMatch = /fields=(\S+)/.exec(opsStr);
+        if (typeMatch) result.operationType = typeMatch[1];
+        if (nameMatch) result.operationName = nameMatch[1];
+        if (fieldsMatch) result.graphqlFields = fieldsMatch[1]!.split(',');
+      }
+
+      return result;
+    }
+
     if (!msg.includes('DENIED')) return undefined;
 
     const reasonMatch = /\[reason:([^\]]+)\]/.exec(msg);
@@ -474,6 +494,7 @@ export class DraftPolicyWatcher {
     if (httpMatch) {
       return {
         isL7: true,
+        protocol: 'rest',
         host: httpMatch[2]!,
         port: parseInt(httpMatch[3]!, 10),
         method: httpMatch[1],
@@ -501,20 +522,30 @@ export class DraftPolicyWatcher {
       return;
 
     const isL7 = denial.method !== undefined && denial.path !== undefined;
+    const isGraphql = denial.protocol === 'graphql';
     const alreadyCovered = Array.from(state.chunkState.values()).some(s => {
       if (s.chunk.host !== denial.host || s.chunk.port !== denial.port) return false;
-      // L4 chunk covers all traffic to host:port
       if (!s.chunk.isL7) return true;
-      // L7 chunk only covers its specific method — new paths need new cards
+      if (isGraphql && s.chunk.protocol === 'graphql') {
+        return s.chunk.operationType === denial.operationType && s.chunk.status !== 'approved';
+      }
       return isL7 && s.chunk.method === denial.method && s.chunk.status !== 'approved';
     });
     if (alreadyCovered) return;
 
-    const chunkId = isL7
-      ? `l7-${denial.host}-${denial.port}-${denial.method}-${Date.now()}`
-      : `l4-${denial.host}-${denial.port}-${Date.now()}`;
+    const suffix = isGraphql
+      ? `gql-${denial.host}-${denial.port}-${denial.operationType}-${denial.operationName}-${Date.now()}`
+      : isL7
+        ? `l7-${denial.host}-${denial.port}-${denial.method}-${Date.now()}`
+        : `l4-${denial.host}-${denial.port}-${Date.now()}`;
+    const chunkId = suffix;
     const sanitizedHost = denial.host.replace(/[.-]/g, '_').replace(/\W/g, '');
-    const ruleName = `allow_${sanitizedHost}_${denial.port}`;
+    const protocolSuffix = isGraphql
+      ? `_gql_${denial.operationType ?? 'op'}`
+      : isL7
+        ? `_${(denial.method ?? 'any').toLowerCase()}`
+        : '';
+    const ruleName = `allow_${sanitizedHost}_${denial.port}${protocolSuffix}`;
 
     const chunk: AcpFlowDraftPolicyChunk = {
       chunkId,
@@ -525,13 +556,19 @@ export class DraftPolicyWatcher {
       binaries: denial.binary ? [denial.binary] : ['/**'],
       rationale:
         denial.denyReason ??
-        (isL7
-          ? `${denial.method} ${denial.path} was denied`
-          : `Connection to ${denial.host}:${denial.port} was denied`),
+        (isGraphql
+          ? `GraphQL ${denial.operationType} ${denial.operationName} was denied`
+          : isL7
+            ? `${denial.method} ${denial.path} was denied`
+            : `Connection to ${denial.host}:${denial.port} was denied`),
       hasSecurityNotes: false,
       isL7,
+      protocol: denial.protocol,
       method: denial.method,
-      path: isL7 ? generalizeDenialPath(denial.host, denial.path!) : undefined,
+      path: isL7 && !isGraphql ? generalizeDenialPath(denial.host, denial.path!) : denial.path,
+      operationType: denial.operationType,
+      operationName: denial.operationName,
+      graphqlFields: denial.graphqlFields,
     };
 
     state.chunkState.set(chunkId, { chunk, isL4Proposal: false });

--- a/packages/main/src/plugin/draft-policy/draft-policy-watcher.ts
+++ b/packages/main/src/plugin/draft-policy/draft-policy-watcher.ts
@@ -500,12 +500,16 @@ export class DraftPolicyWatcher {
     if (denial.denyReason?.includes('policy changed') || denial.denyReason?.includes('policy generation is stale'))
       return;
 
-    const alreadyCovered = Array.from(state.chunkState.values()).some(
-      s => s.chunk.host === denial.host && s.chunk.port === denial.port,
-    );
+    const isL7 = denial.method !== undefined && denial.path !== undefined;
+    const alreadyCovered = Array.from(state.chunkState.values()).some(s => {
+      if (s.chunk.host !== denial.host || s.chunk.port !== denial.port) return false;
+      // L4 chunk covers all traffic to host:port
+      if (!s.chunk.isL7) return true;
+      // L7 chunk only covers its specific method — new paths need new cards
+      return isL7 && s.chunk.method === denial.method && s.chunk.status !== 'approved';
+    });
     if (alreadyCovered) return;
 
-    const isL7 = denial.method !== undefined && denial.path !== undefined;
     const chunkId = isL7
       ? `l7-${denial.host}-${denial.port}-${denial.method}-${Date.now()}`
       : `l4-${denial.host}-${denial.port}-${Date.now()}`;

--- a/packages/main/src/plugin/draft-policy/draft-policy-watcher.ts
+++ b/packages/main/src/plugin/draft-policy/draft-policy-watcher.ts
@@ -1,0 +1,592 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { Emitter } from '/@/plugin/events/emitter.js';
+import { OpenshellSdkClientManager } from '/@/plugin/openshell-cli/openshell-sdk-client-manager.js';
+import type { AcpFlowDraftPolicyChunk } from '/@api/acp-session-info.js';
+import type { IDisposable } from '/@api/disposable.js';
+
+import { generalizeDenialPath } from './forge-path-generalizer.js';
+
+export interface DraftPolicyEvent {
+  sandboxId: string;
+  sandboxName: string;
+  chunks: AcpFlowDraftPolicyChunk[];
+  totalPending: number;
+}
+
+interface DenialLogEntry {
+  timestampMs: number;
+  host: string;
+  port: number;
+  method?: string;
+  path?: string;
+  binary?: string;
+  denyReason?: string;
+}
+
+interface SandboxWatchState {
+  sandboxName: string;
+  gatewayName?: string;
+  abortController: AbortController;
+  denialLogBuffer: DenialLogEntry[];
+  chunkState: Map<string, InternalChunkState>;
+  reconnectAttempt: number;
+  reconnectTimer?: ReturnType<typeof setTimeout>;
+}
+
+interface InternalChunkState {
+  chunk: AcpFlowDraftPolicyChunk;
+  isL4Proposal: boolean;
+  reviewToken?: string;
+  serverChunkId?: string;
+}
+
+const DENIAL_BUFFER_TTL_MS = 60_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+@injectable()
+export class DraftPolicyWatcher {
+  readonly #subscriptions = new Map<string, SandboxWatchState>();
+
+  readonly #onDraftPolicyUpdate = new Emitter<DraftPolicyEvent>();
+  readonly onDraftPolicyUpdate = this.#onDraftPolicyUpdate.event;
+
+  constructor(
+    @inject(OpenshellSdkClientManager)
+    private readonly sdkClientManager: OpenshellSdkClientManager,
+  ) {}
+
+  async watchSandbox(sandboxId: string, sandboxName: string, gatewayName?: string): Promise<IDisposable> {
+    if (this.#subscriptions.has(sandboxId)) {
+      console.log(`[DraftPolicy] already watching sandbox ${sandboxName} (${sandboxId}), skipping`);
+      return { dispose: () => this.unwatchSandbox(sandboxId) };
+    }
+
+    console.log(`[DraftPolicy] watching sandbox ${sandboxName} (id=${sandboxId}, gateway=${gatewayName ?? 'default'})`);
+
+    const state: SandboxWatchState = {
+      sandboxName,
+      gatewayName,
+      abortController: new AbortController(),
+      denialLogBuffer: [],
+      chunkState: new Map(),
+      reconnectAttempt: 0,
+    };
+    this.#subscriptions.set(sandboxId, state);
+
+    await this.#fetchExistingDrafts(sandboxId, state);
+    this.#startStream(sandboxId, state);
+
+    return { dispose: () => this.unwatchSandbox(sandboxId) };
+  }
+
+  unwatchSandbox(sandboxId: string): void {
+    const state = this.#subscriptions.get(sandboxId);
+    if (!state) return;
+
+    state.abortController.abort();
+    if (state.reconnectTimer) clearTimeout(state.reconnectTimer);
+    this.#subscriptions.delete(sandboxId);
+  }
+
+  unwatchSandboxByName(sandboxName: string): void {
+    for (const [sandboxId, state] of this.#subscriptions) {
+      if (state.sandboxName === sandboxName) {
+        this.unwatchSandbox(sandboxId);
+        return;
+      }
+    }
+  }
+
+  async approveDraftChunk(sandboxId: string, chunkId: string): Promise<void> {
+    const state = this.#subscriptions.get(sandboxId);
+    if (!state) throw new Error(`Not watching sandbox ${sandboxId}`);
+
+    const internal = state.chunkState.get(chunkId);
+    if (!internal) throw new Error(`Chunk ${chunkId} not found`);
+
+    const client = await this.sdkClientManager.getClient(state.gatewayName);
+
+    if (internal.isL4Proposal) {
+      await client.raw.approveDraftChunk({
+        name: state.sandboxName,
+        chunkId: internal.serverChunkId ?? chunkId,
+        reviewToken: internal.reviewToken ?? '',
+      });
+    } else {
+      await this.#applyPolicyUpdate(client, state.sandboxName, internal.chunk);
+    }
+
+    internal.chunk.status = 'approved';
+  }
+
+  async rejectDraftChunk(sandboxId: string, chunkId: string): Promise<void> {
+    const state = this.#subscriptions.get(sandboxId);
+    if (!state) throw new Error(`Not watching sandbox ${sandboxId}`);
+
+    const internal = state.chunkState.get(chunkId);
+    if (!internal) throw new Error(`Chunk ${chunkId} not found`);
+
+    if (internal.isL4Proposal) {
+      const client = await this.sdkClientManager.getClient(state.gatewayName);
+      await client.raw.rejectDraftChunk({
+        name: state.sandboxName,
+        chunkId: internal.serverChunkId ?? chunkId,
+        reason: 'Rejected by user',
+      });
+    }
+
+    internal.chunk.status = 'rejected';
+  }
+
+  async #applyPolicyUpdate(
+    client: Awaited<ReturnType<OpenshellSdkClientManager['getClient']>>,
+    sandboxName: string,
+    chunk: AcpFlowDraftPolicyChunk,
+  ): Promise<void> {
+    const config = await client.sandbox.getConfig(sandboxName);
+    const policy = config.policy;
+
+    const matchingEndpoint =
+      policy &&
+      Object.values(policy.networkPolicies)
+        .flatMap(rule => rule.endpoints)
+        .find(ep => ep.host === chunk.host && (ep.port === chunk.port || ep.ports.includes(chunk.port)));
+
+    if (matchingEndpoint && matchingEndpoint.protocol) {
+      // Endpoint has L7 inspection — append allow rules
+      await client.raw.updateConfig({
+        name: sandboxName,
+        mergeOperations: [
+          {
+            operation: {
+              case: 'addAllowRules',
+              value: {
+                host: chunk.host,
+                port: chunk.port,
+                rules: [
+                  {
+                    allow: {
+                      method: chunk.method ?? '*',
+                      path: chunk.path ?? '/**',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+    } else if (!matchingEndpoint) {
+      // Endpoint not in policy — create a new rule
+      const endpoint: { host: string; port: number; protocol?: string; enforcement?: string } = {
+        host: chunk.host,
+        port: chunk.port,
+      };
+      if (chunk.isL7) {
+        endpoint.protocol = 'rest';
+        endpoint.enforcement = 'enforce';
+      }
+
+      await client.raw.updateConfig({
+        name: sandboxName,
+        mergeOperations: [
+          {
+            operation: {
+              case: 'addRule',
+              value: {
+                ruleName: chunk.ruleName,
+                rule: {
+                  name: chunk.ruleName,
+                  endpoints: [endpoint],
+                  binaries: chunk.binaries.map(path => ({ path })),
+                },
+              },
+            },
+          },
+        ],
+      });
+    }
+    // else: endpoint exists as L4-only — already allowed, nothing to do
+  }
+
+  async #fetchExistingDrafts(sandboxId: string, state: SandboxWatchState): Promise<void> {
+    try {
+      console.log(`[DraftPolicy] fetching existing drafts for ${state.sandboxName}`);
+      const client = await this.sdkClientManager.getClient(state.gatewayName);
+      const response = await client.raw.getDraftPolicy({
+        name: state.sandboxName,
+        statusFilter: 'pending',
+      });
+
+      console.log(`[DraftPolicy] got ${response.chunks.length} existing draft chunks for ${state.sandboxName}`);
+
+      if (response.chunks.length > 0) {
+        const mapped = response.chunks.map(c => this.#policyChunkToFlowChunk(c));
+        for (const { chunk, reviewToken } of mapped) {
+          state.chunkState.set(chunk.chunkId, { chunk, isL4Proposal: true, reviewToken });
+        }
+        this.#onDraftPolicyUpdate.fire({
+          sandboxId,
+          sandboxName: state.sandboxName,
+          chunks: mapped.map(m => m.chunk),
+          totalPending: mapped.length,
+        });
+      }
+    } catch (err: unknown) {
+      console.error(`[DraftPolicy] failed to fetch existing drafts for ${state.sandboxName}:`, err);
+    }
+  }
+
+  #startStream(sandboxId: string, state: SandboxWatchState): void {
+    const iterate = async (): Promise<void> => {
+      try {
+        console.log(`[DraftPolicy] starting WatchSandbox stream for ${state.sandboxName} (id=${sandboxId})`);
+        const client = await this.sdkClientManager.getClient(state.gatewayName);
+        const stream = client.raw.watchSandbox(
+          {
+            id: sandboxId,
+            followLogs: true,
+            followStatus: true,
+            followEvents: false,
+            logSources: ['sandbox'],
+            logTailLines: 0,
+          },
+          { signal: state.abortController.signal },
+        );
+
+        console.log(`[DraftPolicy] WatchSandbox stream connected for ${state.sandboxName}`);
+        state.reconnectAttempt = 0;
+
+        for await (const event of stream) {
+          if (!event.payload) continue;
+
+          switch (event.payload.case) {
+            case 'draftPolicyUpdate':
+              console.log(
+                `[DraftPolicy] received draftPolicyUpdate for ${state.sandboxName}: newChunks=${event.payload.value.newChunks}, totalPending=${event.payload.value.totalPending}`,
+              );
+              await this.#handleDraftPolicyUpdate(sandboxId, state, event.payload.value);
+              break;
+            case 'sandbox':
+              console.log(
+                `[DraftPolicy] sandbox state changed for ${state.sandboxName}, checking for new draft chunks`,
+              );
+              await this.#handleSandboxStateChange(sandboxId, state);
+              break;
+            case 'log':
+              this.#handleLogLine(sandboxId, state, event.payload.value);
+              break;
+            default:
+              console.log(`[DraftPolicy] received event type: ${event.payload.case} for ${state.sandboxName}`);
+          }
+        }
+        console.log(`[DraftPolicy] WatchSandbox stream ended for ${state.sandboxName}`);
+      } catch (err: unknown) {
+        if (state.abortController.signal.aborted) {
+          console.log(`[DraftPolicy] stream aborted for ${state.sandboxName}`);
+          return;
+        }
+
+        const delay = Math.min(1000 * 2 ** state.reconnectAttempt, MAX_RECONNECT_DELAY_MS);
+        state.reconnectAttempt++;
+        console.error(
+          `[DraftPolicy] stream error for ${state.sandboxName}, reconnecting in ${delay}ms (attempt ${state.reconnectAttempt}):`,
+          err,
+        );
+        state.reconnectTimer = setTimeout(() => {
+          if (!state.abortController.signal.aborted) {
+            this.#startStream(sandboxId, state);
+          }
+        }, delay);
+      }
+    };
+
+    iterate().catch((err: unknown) => {
+      console.error(`[DraftPolicy] unexpected iterate error for ${state.sandboxName}:`, err);
+    });
+  }
+
+  async #handleDraftPolicyUpdate(
+    sandboxId: string,
+    state: SandboxWatchState,
+    update: { newChunks: number; totalPending: number; summary: string; draftVersion: bigint },
+  ): Promise<void> {
+    console.log(
+      `[DraftPolicy] fetching draft policy after update (version=${update.draftVersion}) for ${state.sandboxName}`,
+    );
+    await this.#refetchDraftPolicy(sandboxId, state);
+  }
+
+  async #handleSandboxStateChange(sandboxId: string, state: SandboxWatchState): Promise<void> {
+    await this.#refetchDraftPolicy(sandboxId, state);
+  }
+
+  async #refetchDraftPolicy(sandboxId: string, state: SandboxWatchState): Promise<void> {
+    try {
+      const client = await this.sdkClientManager.getClient(state.gatewayName);
+      const response = await client.raw.getDraftPolicy({
+        name: state.sandboxName,
+        statusFilter: 'pending',
+      });
+
+      console.log(
+        `[DraftPolicy] getDraftPolicy returned ${response.chunks.length} pending chunks for ${state.sandboxName}`,
+      );
+
+      const newChunks: AcpFlowDraftPolicyChunk[] = [];
+      for (const policyChunk of response.chunks) {
+        if (state.chunkState.has(policyChunk.id)) continue;
+
+        const endpoint = policyChunk.proposedRule?.endpoints?.[0];
+        const host = endpoint?.host ?? 'unknown';
+        const port = endpoint?.port ?? 0;
+
+        const existingEntry = Array.from(state.chunkState.entries()).find(
+          ([, s]) => s.chunk.host === host && s.chunk.port === port,
+        );
+        if (existingEntry) {
+          const [, existing] = existingEntry;
+          // Upgrade a client-side chunk with server data (binary, reviewToken) if still pending
+          if (!existing.isL4Proposal && existing.chunk.status === 'pending') {
+            const { chunk, reviewToken } = this.#policyChunkToFlowChunk(policyChunk);
+            existing.chunk.binaries = chunk.binaries;
+            existing.isL4Proposal = true;
+            existing.reviewToken = reviewToken;
+            existing.serverChunkId = chunk.chunkId;
+          }
+          continue;
+        }
+
+        const { chunk, reviewToken } = this.#policyChunkToFlowChunk(policyChunk);
+        this.#enrichWithDenialLogs(chunk, state);
+        state.chunkState.set(chunk.chunkId, { chunk, isL4Proposal: true, reviewToken });
+        newChunks.push(chunk);
+      }
+
+      if (newChunks.length > 0) {
+        console.log(
+          `[DraftPolicy] firing ${newChunks.length} new chunks for ${state.sandboxName}:`,
+          newChunks.map(c => `${c.host}:${c.port}`).join(', '),
+        );
+        this.#onDraftPolicyUpdate.fire({
+          sandboxId,
+          sandboxName: state.sandboxName,
+          chunks: newChunks,
+          totalPending: newChunks.length,
+        });
+      } else if (response.chunks.length > 0) {
+        console.log(`[DraftPolicy] no new chunks after filtering (${response.chunks.length} already known)`);
+      }
+    } catch (err: unknown) {
+      console.error(`[DraftPolicy] failed to fetch draft policy for ${state.sandboxName}:`, err);
+    }
+  }
+
+  #handleLogLine(
+    sandboxId: string,
+    state: SandboxWatchState,
+    logLine: { fields: { [key: string]: string }; timestampMs: bigint; message: string; level: string; source: string },
+  ): void {
+    const denial = this.#parseDenialFromLogLine(logLine);
+    if (!denial) return;
+
+    const layer = denial.isL7 ? 'L7' : 'L4';
+    const detail = denial.method ? ` ${denial.method} ${denial.path}` : '';
+    console.log(
+      `[DraftPolicy] denial detected for ${state.sandboxName}: ${layer} ${denial.host}:${denial.port}${detail}`,
+    );
+
+    const entry: DenialLogEntry = {
+      timestampMs: Number(logLine.timestampMs),
+      ...denial,
+    };
+
+    state.denialLogBuffer.push(entry);
+    this.#pruneBuffer(state);
+
+    this.#emitDenialFromLog(sandboxId, state, entry);
+  }
+
+  #parseDenialFromLogLine(logLine: { fields: { [key: string]: string }; message: string; level: string }):
+    | {
+        isL7: boolean;
+        host: string;
+        port: number;
+        method?: string;
+        path?: string;
+        binary?: string;
+        denyReason?: string;
+      }
+    | undefined {
+    const fields = logLine.fields;
+
+    // Try structured fields first (sandbox-pushed non-OCSF logs may populate them)
+    if (fields['l4_decision'] === 'deny' || fields['l7_decision'] === 'deny') {
+      const host = fields['dst_host'];
+      const portStr = fields['dst_port'];
+      if (!host || !portStr) return undefined;
+      const port = parseInt(portStr, 10);
+      if (isNaN(port)) return undefined;
+
+      return {
+        isL7: fields['l7_decision'] === 'deny',
+        host,
+        port,
+        method: fields['l7_action'],
+        path: fields['l7_target'],
+        binary: fields['binary'],
+        denyReason: fields['l7_deny_reason'] ?? fields['l4_deny_reason'],
+      };
+    }
+
+    // Parse OCSF shorthand message format:
+    //   NET:CONNECT [MED] DENIED proc(pid) -> host:port [policy:...] [reason:...]
+    //   HTTP:METHOD [MED] DENIED proc(pid) -> METHOD scheme://host:port/path [policy:...] [reason:...]
+    const msg = logLine.message;
+    if (!msg.includes('DENIED')) return undefined;
+
+    const reasonMatch = /\[reason:([^\]]+)\]/.exec(msg);
+    const denyReason = reasonMatch?.[1]?.trim();
+
+    // L7 HTTP denial: HTTP:POST [MED] DENIED proc(pid) -> POST https://host:port/path
+    const httpMatch = msg.startsWith('HTTP:')
+      ? /DENIED\s+(?:\S+\s+->\s+)?(\w+)\s+\w+:\/\/([^/:]+):(\d+)(\/\S*)?/.exec(msg)
+      : undefined;
+    if (httpMatch) {
+      return {
+        isL7: true,
+        host: httpMatch[2]!,
+        port: parseInt(httpMatch[3]!, 10),
+        method: httpMatch[1],
+        path: httpMatch[4] ?? '/',
+        denyReason,
+      };
+    }
+
+    // L4 network denial
+    const netMatch = /^NET:\w+\s+\[\w+\]\s+DENIED\s+(?:\S+\s+->\s+)?([^:\s]+):(\d+)/.exec(msg);
+    if (netMatch) {
+      return {
+        isL7: false,
+        host: netMatch[1]!,
+        port: parseInt(netMatch[2]!, 10),
+        denyReason,
+      };
+    }
+
+    return undefined;
+  }
+
+  #emitDenialFromLog(sandboxId: string, state: SandboxWatchState, denial: DenialLogEntry): void {
+    if (denial.denyReason?.includes('policy changed') || denial.denyReason?.includes('policy generation is stale'))
+      return;
+
+    const alreadyCovered = Array.from(state.chunkState.values()).some(
+      s => s.chunk.host === denial.host && s.chunk.port === denial.port,
+    );
+    if (alreadyCovered) return;
+
+    const isL7 = denial.method !== undefined && denial.path !== undefined;
+    const chunkId = isL7
+      ? `l7-${denial.host}-${denial.port}-${denial.method}-${Date.now()}`
+      : `l4-${denial.host}-${denial.port}-${Date.now()}`;
+    const sanitizedHost = denial.host.replace(/[.-]/g, '_').replace(/\W/g, '');
+    const ruleName = `allow_${sanitizedHost}_${denial.port}`;
+
+    const chunk: AcpFlowDraftPolicyChunk = {
+      chunkId,
+      ruleName,
+      status: 'pending',
+      host: denial.host,
+      port: denial.port,
+      binaries: denial.binary ? [denial.binary] : ['/**'],
+      rationale:
+        denial.denyReason ??
+        (isL7
+          ? `${denial.method} ${denial.path} was denied`
+          : `Connection to ${denial.host}:${denial.port} was denied`),
+      hasSecurityNotes: false,
+      isL7,
+      method: denial.method,
+      path: isL7 ? generalizeDenialPath(denial.host, denial.path!) : undefined,
+    };
+
+    state.chunkState.set(chunkId, { chunk, isL4Proposal: false });
+
+    this.#onDraftPolicyUpdate.fire({
+      sandboxId,
+      sandboxName: state.sandboxName,
+      chunks: [chunk],
+      totalPending: Array.from(state.chunkState.values()).filter(s => s.chunk.status === 'pending').length,
+    });
+  }
+
+  #enrichWithDenialLogs(chunk: AcpFlowDraftPolicyChunk, state: SandboxWatchState): void {
+    const match = state.denialLogBuffer.find(d => d.host === chunk.host && d.port === chunk.port && d.method && d.path);
+
+    if (match) {
+      chunk.isL7 = true;
+      chunk.method = match.method;
+      chunk.path = match.path;
+    }
+  }
+
+  #policyChunkToFlowChunk(policyChunk: {
+    id: string;
+    status: string;
+    ruleName: string;
+    proposedRule?: { endpoints: Array<{ host: string; port: number }>; binaries: Array<{ path: string }> };
+    rationale: string;
+    securityNotes: string;
+    confidence: number;
+    reviewToken?: string;
+  }): { chunk: AcpFlowDraftPolicyChunk; reviewToken?: string } {
+    const endpoint = policyChunk.proposedRule?.endpoints?.[0];
+    return {
+      chunk: {
+        chunkId: policyChunk.id,
+        ruleName: policyChunk.ruleName,
+        status:
+          policyChunk.status === 'pending' ? 'pending' : policyChunk.status === 'approved' ? 'approved' : 'rejected',
+        host: endpoint?.host ?? 'unknown',
+        port: endpoint?.port ?? 0,
+        binaries: policyChunk.proposedRule?.binaries?.map(b => b.path) ?? [],
+        rationale: policyChunk.rationale,
+        hasSecurityNotes: !!policyChunk.securityNotes,
+        isL7: false,
+      },
+      reviewToken: policyChunk.reviewToken,
+    };
+  }
+
+  #pruneBuffer(state: SandboxWatchState): void {
+    const cutoff = Date.now() - DENIAL_BUFFER_TTL_MS;
+    state.denialLogBuffer = state.denialLogBuffer.filter(e => e.timestampMs > cutoff);
+  }
+
+  dispose(): void {
+    for (const sandboxId of this.#subscriptions.keys()) {
+      this.unwatchSandbox(sandboxId);
+    }
+    this.#onDraftPolicyUpdate.dispose();
+  }
+}

--- a/packages/main/src/plugin/draft-policy/forge-path-generalizer.spec.ts
+++ b/packages/main/src/plugin/draft-policy/forge-path-generalizer.spec.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { generalizeDenialPath } from './forge-path-generalizer.js';
+
+test('GitHub REST API: generalizes repo path', () => {
+  expect(generalizeDenialPath('api.github.com', '/repos/octocat/hello-world/contents/hello_world.py')).toBe(
+    '/repos/octocat/hello-world/**',
+  );
+});
+
+test('GitHub REST API: generalizes deeply nested path', () => {
+  expect(generalizeDenialPath('api.github.com', '/repos/org/repo/git/refs/heads/main')).toBe('/repos/org/repo/**');
+});
+
+test('GitHub REST API: preserves exact repo path without subpath', () => {
+  expect(generalizeDenialPath('api.github.com', '/repos/org/repo')).toBe('/repos/org/*');
+});
+
+test('GitHub git: generalizes .git subpath', () => {
+  expect(generalizeDenialPath('github.com', '/org/repo.git/info/refs')).toBe('/org/repo.git/**');
+});
+
+test('GitHub git: generalizes git-receive-pack', () => {
+  expect(generalizeDenialPath('github.com', '/org/repo.git/git-receive-pack')).toBe('/org/repo.git/**');
+});
+
+test('GitLab API v4: generalizes project path', () => {
+  expect(generalizeDenialPath('gitlab.com', '/api/v4/projects/123/repository/branches')).toBe(
+    '/api/v4/projects/123/**',
+  );
+});
+
+test('GitLab API v4: generalizes namespaced project', () => {
+  expect(generalizeDenialPath('gitlab.com', '/api/v4/projects/org%2Frepo/merge_requests')).toBe(
+    '/api/v4/projects/org%2Frepo/**',
+  );
+});
+
+test('GitLab self-hosted subdomain', () => {
+  expect(generalizeDenialPath('code.gitlab.com', '/api/v4/projects/42/pipelines')).toBe('/api/v4/projects/42/**');
+});
+
+test('GitLab git: generalizes .git subpath', () => {
+  expect(generalizeDenialPath('gitlab.com', '/org/repo.git/info/refs')).toBe('/org/repo.git/**');
+});
+
+test('Bitbucket REST API: generalizes repo path', () => {
+  expect(generalizeDenialPath('api.bitbucket.org', '/2.0/repositories/org/repo/src/main/file.py')).toBe(
+    '/2.0/repositories/org/repo/**',
+  );
+});
+
+test('Bitbucket git: generalizes .git subpath', () => {
+  expect(generalizeDenialPath('bitbucket.org', '/org/repo.git/info/refs')).toBe('/org/repo.git/**');
+});
+
+test('Unknown host: falls back to last-segment generalization', () => {
+  expect(generalizeDenialPath('api.example.com', '/v1/resources/42')).toBe('/v1/resources/*');
+});
+
+test('Unknown host: single segment path stays unchanged', () => {
+  expect(generalizeDenialPath('api.example.com', '/health')).toBe('/health');
+});
+
+test('Unknown host: deep path generalizes last segment only', () => {
+  expect(generalizeDenialPath('custom.registry.io', '/v2/library/nginx/manifests/latest')).toBe(
+    '/v2/library/nginx/manifests/*',
+  );
+});

--- a/packages/main/src/plugin/draft-policy/forge-path-generalizer.ts
+++ b/packages/main/src/plugin/draft-policy/forge-path-generalizer.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+interface ForgePattern {
+  hostMatch: (host: string) => boolean;
+  pathRegex: RegExp;
+  generalize: (match: RegExpMatchArray) => string;
+}
+
+const FORGE_PATTERNS: ForgePattern[] = [
+  // GitHub REST API: /repos/{org}/{repo}/...
+  {
+    hostMatch: (h: string) => h === 'api.github.com',
+    pathRegex: /^(\/repos\/[^/]+\/[^/]+)\/.+/,
+    generalize: (m: RegExpMatchArray) => `${m[1]}/**`,
+  },
+  // GitHub git smart HTTP: /{org}/{repo}.git/...
+  {
+    hostMatch: (h: string) => h === 'github.com',
+    pathRegex: /^(\/[^/]+\/[^/]+\.git)\/.+/,
+    generalize: (m: RegExpMatchArray) => `${m[1]}/**`,
+  },
+  // GitLab API v4: /api/v4/projects/{id_or_namespace}/...
+  {
+    hostMatch: (h: string) => h === 'gitlab.com' || h.endsWith('.gitlab.com'),
+    pathRegex: /^(\/api\/v4\/projects\/[^/]+)\/.+/,
+    generalize: (m: RegExpMatchArray) => `${m[1]}/**`,
+  },
+  // GitLab git smart HTTP: /{org}/{repo}.git/...
+  {
+    hostMatch: (h: string) => h === 'gitlab.com' || h.endsWith('.gitlab.com'),
+    pathRegex: /^(\/[^/]+\/[^/]+\.git)\/.+/,
+    generalize: (m: RegExpMatchArray) => `${m[1]}/**`,
+  },
+  // Bitbucket REST API: /2.0/repositories/{org}/{repo}/...
+  {
+    hostMatch: (h: string) => h === 'api.bitbucket.org',
+    pathRegex: /^(\/2\.0\/repositories\/[^/]+\/[^/]+)\/.+/,
+    generalize: (m: RegExpMatchArray) => `${m[1]}/**`,
+  },
+  // Bitbucket git smart HTTP: /{org}/{repo}.git/...
+  {
+    hostMatch: (h: string) => h === 'bitbucket.org',
+    pathRegex: /^(\/[^/]+\/[^/]+\.git)\/.+/,
+    generalize: (m: RegExpMatchArray) => `${m[1]}/**`,
+  },
+];
+
+export function generalizeDenialPath(host: string, path: string): string {
+  for (const pattern of FORGE_PATTERNS) {
+    if (!pattern.hostMatch(host)) continue;
+    const match = pattern.pathRegex.exec(path);
+    if (match) {
+      return pattern.generalize(match);
+    }
+  }
+
+  // Fallback: generalize the last path segment only
+  const lastSlash = path.lastIndexOf('/');
+  if (lastSlash > 0) {
+    return `${path.substring(0, lastSlash)}/*`;
+  }
+  return path;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -58,6 +58,7 @@ import { AgentRegistry } from '/@/plugin/agent-registry.js';
 import { AgentWorkspaceManager } from '/@/plugin/agent-workspace/agent-workspace-manager.js';
 import { IPCHandle, IPCMainOn, WebContentsType } from '/@/plugin/api.js';
 import { ContainerfileParser } from '/@/plugin/containerfile-parser.js';
+import { DraftPolicyWatcher } from '/@/plugin/draft-policy/draft-policy-watcher.js';
 import { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionWatcher } from '/@/plugin/extension/extension-watcher.js';
@@ -607,6 +608,7 @@ export class PluginSystem {
     container.bind<OpenshellCli>(OpenshellCli).toSelf().inSingletonScope();
     container.bind<OpenshellGatewayConfig>(OpenshellGatewayConfig).toSelf();
     container.bind<OpenshellSdkClientManager>(OpenshellSdkClientManager).toSelf().inSingletonScope();
+    container.bind<DraftPolicyWatcher>(DraftPolicyWatcher).toSelf().inSingletonScope();
     container.bind<OpenshellGateway>(OpenshellGateway).toSelf().inSingletonScope();
     container.bind<OpenshellGatewayStateManager>(OpenshellGatewayStateManager).toSelf().inSingletonScope();
     container.bind<OpenshellImageBuilder>(OpenshellImageBuilder).toSelf().inSingletonScope();

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -540,6 +540,14 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('approveDraftChunk', async (sessionId: string, chunkId: string): Promise<void> => {
+    return ipcInvoke('acp:approveDraftChunk', sessionId, chunkId);
+  });
+
+  contextBridge.exposeInMainWorld('rejectDraftChunk', async (sessionId: string, chunkId: string): Promise<void> => {
+    return ipcInvoke('acp:rejectDraftChunk', sessionId, chunkId);
+  });
+
   contextBridge.exposeInMainWorld('createSecret', async (options: SecretCreateOptions): Promise<SecretName> => {
     return ipcInvoke('secret-manager:create', options);
   });

--- a/packages/renderer/src/lib/acp-sessions/AcpSessionDetail.svelte
+++ b/packages/renderer/src/lib/acp-sessions/AcpSessionDetail.svelte
@@ -18,6 +18,7 @@ import type {
 import AcpAtMentionCompletion from './AcpAtMentionCompletion.svelte';
 import AcpSlashCommandCompletion from './AcpSlashCommandCompletion.svelte';
 import AcpFlowAgentMessage from './flow/AcpFlowAgentMessage.svelte';
+import AcpFlowNetworkBlock from './flow/AcpFlowNetworkBlock.svelte';
 import AcpFlowPlan from './flow/AcpFlowPlan.svelte';
 import AcpFlowPrompt from './flow/AcpFlowPrompt.svelte';
 import AcpFlowThinking from './flow/AcpFlowThinking.svelte';
@@ -481,6 +482,8 @@ function handleKeyDown(e: KeyboardEvent): void {
         <AcpFlowToolCall {event} {sessionId} />
       {:else if event.kind === 'plan'}
         <AcpFlowPlan {event} />
+      {:else if event.kind === 'draft_policy_update'}
+        <AcpFlowNetworkBlock {event} {sessionId} />
       {/if}
     {/each}
 

--- a/packages/renderer/src/lib/acp-sessions/flow/AcpFlowNetworkBlock.svelte
+++ b/packages/renderer/src/lib/acp-sessions/flow/AcpFlowNetworkBlock.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+import { faBan, faCheck, faExclamationTriangle, faShieldAlt } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import type { AcpFlowDraftPolicyEvent } from '/@api/acp-session-info';
+
+interface Props {
+  event: AcpFlowDraftPolicyEvent;
+  sessionId: string;
+}
+
+let { event, sessionId }: Props = $props();
+let responding = $state<string | undefined>(undefined);
+
+async function handleApprove(chunkId: string): Promise<void> {
+  if (responding) return;
+  responding = chunkId;
+  try {
+    await window.approveDraftChunk(sessionId, chunkId);
+  } catch (err: unknown) {
+    console.error('Failed to approve draft chunk', err);
+  } finally {
+    responding = undefined;
+  }
+}
+
+async function handleReject(chunkId: string): Promise<void> {
+  if (responding) return;
+  responding = chunkId;
+  try {
+    await window.rejectDraftChunk(sessionId, chunkId);
+  } catch (err: unknown) {
+    console.error('Failed to reject draft chunk', err);
+  } finally {
+    responding = undefined;
+  }
+}
+</script>
+
+{#each event.chunks as chunk (chunk.chunkId)}
+  <div class="network-block rounded-[10px] overflow-hidden" class:network-block-pending={chunk.status === 'pending'} class:network-block-resolved={chunk.status !== 'pending'}>
+    <!-- Header -->
+    <div class="network-block-header flex items-center gap-2.5 px-4 py-3">
+      <div class="network-block-icon flex items-center justify-center w-8 h-8 rounded-lg shrink-0">
+        <Icon icon={faShieldAlt} class="text-[var(--pd-status-dead)] text-sm" />
+      </div>
+      <div class="flex flex-col flex-1 min-w-0 gap-0.5">
+        <span class="text-[13px] font-semibold text-[var(--pd-status-dead)]">Network request blocked</span>
+        <span class="text-[11px] text-[var(--pd-content-text)] opacity-50">
+          {new Date(event.timestamp).toLocaleTimeString()}
+        </span>
+      </div>
+    </div>
+
+    <!-- Body -->
+    <div class="px-4 py-3.5">
+      <p class="text-[13px] text-[var(--pd-content-text)] leading-relaxed mb-3.5">
+        The agent attempted to reach <strong class="text-[var(--pd-status-dead)]">{chunk.host}</strong> but the request was denied by the workspace network policy.
+      </p>
+
+      <!-- Details -->
+      <div class="network-block-details rounded-lg p-2.5 px-3.5 mb-3.5 flex flex-col gap-2">
+        {#if chunk.isL7 && chunk.method && chunk.path}
+          <div class="flex items-baseline gap-2.5 text-xs">
+            <span class="text-[var(--pd-content-text)] opacity-50 font-medium w-[72px] shrink-0">Request</span>
+            <code class="text-[var(--pd-content-text)] bg-[var(--pd-content-card-hover-bg)] px-1.5 py-0.5 rounded text-[11px]">
+              {chunk.method} {chunk.host}:{chunk.port}{chunk.path}
+            </code>
+          </div>
+        {:else}
+          <div class="flex items-baseline gap-2.5 text-xs">
+            <span class="text-[var(--pd-content-text)] opacity-50 font-medium w-[72px] shrink-0">Host</span>
+            <code class="text-[var(--pd-content-text)] bg-[var(--pd-content-card-hover-bg)] px-1.5 py-0.5 rounded text-[11px]">
+              {chunk.host}:{chunk.port}
+            </code>
+          </div>
+        {/if}
+        {#if chunk.rationale}
+          <div class="flex items-baseline gap-2.5 text-xs">
+            <span class="text-[var(--pd-content-text)] opacity-50 font-medium w-[72px] shrink-0">Reason</span>
+            <span class="text-[var(--pd-content-text)]">{chunk.rationale}</span>
+          </div>
+        {/if}
+        <div class="flex items-baseline gap-2.5 text-xs">
+          <span class="text-[var(--pd-content-text)] opacity-50 font-medium w-[72px] shrink-0">Policy</span>
+          <span class="text-[var(--pd-content-text)]">
+            <span class="network-policy-badge-deny inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider">Deny</span>
+            {#if chunk.isL7}
+              — method/path not in allow list
+            {:else}
+              — host not in allowed list
+            {/if}
+          </span>
+        </div>
+      </div>
+
+      <!-- Security warning -->
+      {#if chunk.hasSecurityNotes}
+        <div class="flex items-center gap-1.5 text-xs text-[var(--pd-status-waiting)] mb-3.5">
+          <Icon icon={faExclamationTriangle} class="text-xs" />
+          <span>This rule has security considerations — review carefully before approving.</span>
+        </div>
+      {/if}
+
+      <!-- Actions -->
+      {#if chunk.status === 'pending'}
+        <div class="flex items-center gap-2 flex-wrap">
+          <Button
+            type="primary"
+            onclick={(): void => { handleApprove(chunk.chunkId).catch((e: unknown) => console.error(e)); }}
+            disabled={responding === chunk.chunkId}
+          >
+            Allow {chunk.host}{chunk.isL7 && chunk.method ? ` (${chunk.method})` : ''}
+          </Button>
+          <Button
+            type="secondary"
+            onclick={(): void => { handleReject(chunk.chunkId).catch((e: unknown) => console.error(e)); }}
+            disabled={responding === chunk.chunkId}
+          >
+            Reject
+          </Button>
+        </div>
+      {:else if chunk.status === 'approved'}
+        <div class="flex items-center gap-1.5 text-xs">
+          <Icon icon={faCheck} class="text-[var(--pd-status-running)] text-xs" />
+          <span class="text-[var(--pd-status-running)]">Approved — policy updated</span>
+        </div>
+      {:else if chunk.status === 'rejected'}
+        <div class="flex items-center gap-1.5 text-xs">
+          <Icon icon={faBan} class="text-[var(--pd-status-dead)] text-xs" />
+          <span class="text-[var(--pd-status-dead)]">Rejected</span>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/each}
+
+<style>
+  .network-block {
+    margin: 4px 0 20px;
+  }
+  .network-block-pending {
+    border: 1px solid color-mix(in srgb, var(--pd-status-dead) 25%, transparent);
+    background: color-mix(in srgb, var(--pd-status-dead) 4%, transparent);
+  }
+  .network-block-resolved {
+    border: 1px solid var(--pd-content-divider);
+    background: var(--pd-content-card-bg);
+  }
+  .network-block-header {
+    background: color-mix(in srgb, var(--pd-status-dead) 6%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--pd-status-dead) 12%, transparent);
+  }
+  .network-block-resolved .network-block-header {
+    background: var(--pd-content-card-bg);
+    border-bottom-color: var(--pd-content-divider);
+  }
+  .network-block-icon {
+    background: color-mix(in srgb, var(--pd-status-dead) 12%, transparent);
+  }
+  .network-block-details {
+    background: color-mix(in srgb, black 20%, transparent);
+    border: 1px solid color-mix(in srgb, white 6%, transparent);
+  }
+  .network-policy-badge-deny {
+    background: color-mix(in srgb, var(--pd-status-dead) 15%, transparent);
+    color: var(--pd-status-dead);
+  }
+</style>

--- a/packages/renderer/src/lib/acp-sessions/flow/AcpFlowNetworkBlock.svelte
+++ b/packages/renderer/src/lib/acp-sessions/flow/AcpFlowNetworkBlock.svelte
@@ -12,14 +12,17 @@ interface Props {
 
 let { event, sessionId }: Props = $props();
 let responding = $state<string | undefined>(undefined);
+let errorByChunk = $state<Record<string, string>>({});
 
 async function handleApprove(chunkId: string): Promise<void> {
   if (responding) return;
   responding = chunkId;
+  errorByChunk[chunkId] = '';
   try {
     await window.approveDraftChunk(sessionId, chunkId);
   } catch (err: unknown) {
     console.error('Failed to approve draft chunk', err);
+    errorByChunk[chunkId] = err instanceof Error ? err.message : String(err);
   } finally {
     responding = undefined;
   }
@@ -28,10 +31,12 @@ async function handleApprove(chunkId: string): Promise<void> {
 async function handleReject(chunkId: string): Promise<void> {
   if (responding) return;
   responding = chunkId;
+  errorByChunk[chunkId] = '';
   try {
     await window.rejectDraftChunk(sessionId, chunkId);
   } catch (err: unknown) {
     console.error('Failed to reject draft chunk', err);
+    errorByChunk[chunkId] = err instanceof Error ? err.message : String(err);
   } finally {
     responding = undefined;
   }
@@ -61,7 +66,20 @@ async function handleReject(chunkId: string): Promise<void> {
 
       <!-- Details -->
       <div class="network-block-details rounded-lg p-2.5 px-3.5 mb-3.5 flex flex-col gap-2">
-        {#if chunk.isL7 && chunk.method && chunk.path}
+        {#if chunk.protocol === 'graphql' && chunk.operationType}
+          <div class="flex items-baseline gap-2.5 text-xs">
+            <span class="text-[var(--pd-content-text)] opacity-50 font-medium w-[72px] shrink-0">Request</span>
+            <code class="text-[var(--pd-content-text)] bg-[var(--pd-content-card-hover-bg)] px-1.5 py-0.5 rounded text-[11px]">
+              GraphQL {chunk.operationType}{chunk.operationName ? ` ${chunk.operationName}` : ''}{chunk.graphqlFields?.length ? ` (${chunk.graphqlFields.join(', ')})` : ''}
+            </code>
+          </div>
+          <div class="flex items-baseline gap-2.5 text-xs">
+            <span class="text-[var(--pd-content-text)] opacity-50 font-medium w-[72px] shrink-0">Host</span>
+            <code class="text-[var(--pd-content-text)] bg-[var(--pd-content-card-hover-bg)] px-1.5 py-0.5 rounded text-[11px]">
+              {chunk.host}:{chunk.port}
+            </code>
+          </div>
+        {:else if chunk.isL7 && chunk.method && chunk.path}
           <div class="flex items-baseline gap-2.5 text-xs">
             <span class="text-[var(--pd-content-text)] opacity-50 font-medium w-[72px] shrink-0">Request</span>
             <code class="text-[var(--pd-content-text)] bg-[var(--pd-content-card-hover-bg)] px-1.5 py-0.5 rounded text-[11px]">
@@ -86,7 +104,9 @@ async function handleReject(chunkId: string): Promise<void> {
           <span class="text-[var(--pd-content-text)] opacity-50 font-medium w-[72px] shrink-0">Policy</span>
           <span class="text-[var(--pd-content-text)]">
             <span class="network-policy-badge-deny inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider">Deny</span>
-            {#if chunk.isL7}
+            {#if chunk.protocol === 'graphql'}
+              — operation not in allow list
+            {:else if chunk.isL7}
               — method/path not in allow list
             {:else}
               — host not in allowed list
@@ -105,21 +125,29 @@ async function handleReject(chunkId: string): Promise<void> {
 
       <!-- Actions -->
       {#if chunk.status === 'pending'}
-        <div class="flex items-center gap-2 flex-wrap">
-          <Button
-            type="primary"
-            onclick={(): void => { handleApprove(chunk.chunkId).catch((e: unknown) => console.error(e)); }}
-            disabled={responding === chunk.chunkId}
-          >
-            Allow {chunk.host}{chunk.isL7 && chunk.method ? ` (${chunk.method})` : ''}
-          </Button>
-          <Button
-            type="secondary"
-            onclick={(): void => { handleReject(chunk.chunkId).catch((e: unknown) => console.error(e)); }}
-            disabled={responding === chunk.chunkId}
-          >
-            Reject
-          </Button>
+        <div class="flex flex-col gap-2">
+          <div class="flex items-center gap-2 flex-wrap">
+            <Button
+              type="primary"
+              onclick={(): void => { handleApprove(chunk.chunkId).catch((e: unknown) => console.error(e)); }}
+              disabled={responding === chunk.chunkId}
+            >
+              Allow {chunk.host}{chunk.protocol === 'graphql' && chunk.operationType ? ` (${chunk.operationType})` : chunk.isL7 && chunk.method ? ` (${chunk.method})` : ''}
+            </Button>
+            <Button
+              type="secondary"
+              onclick={(): void => { handleReject(chunk.chunkId).catch((e: unknown) => console.error(e)); }}
+              disabled={responding === chunk.chunkId}
+            >
+              Reject
+            </Button>
+          </div>
+          {#if errorByChunk[chunk.chunkId]}
+            <div class="flex items-start gap-1.5 text-xs text-[var(--pd-status-dead)]">
+              <Icon icon={faExclamationTriangle} class="text-xs mt-0.5 shrink-0" />
+              <span>Failed to update policy: {errorByChunk[chunk.chunkId]}</span>
+            </div>
+          {/if}
         </div>
       {:else if chunk.status === 'approved'}
         <div class="flex items-center gap-1.5 text-xs">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
       '@nvidia/openshell-sdk':
-        specifier: 0.0.106
-        version: 0.0.106
+        specifier: 0.0.113
+        version: 0.0.113
       '@oslojs/crypto':
         specifier: ^1.0.1
         version: 1.0.1
@@ -2068,8 +2068,8 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This functionality has been moved to @npmcli/fs
 
-  '@nvidia/openshell-sdk@0.0.106':
-    resolution: {integrity: sha512-dB4mLex23Pnw61caGMR2CMHQihy9bj7IK2elJJd718k3yevm+fOt/vG6dJg8/5us4la2BwcOdRwLvOia3tdwFw==, tarball: https://npm.pkg.github.com/download/@nvidia/openshell-sdk/0.0.106/dc32180ba1d658fc4ec309bdf89d2b162196928d}
+  '@nvidia/openshell-sdk@0.0.113':
+    resolution: {integrity: sha512-yrafyBasYflkXwNHQQgMmqZEncppKEruv6sYk8a98YtKEaM/Mq4cyNTaFRCan5KgPRHOj9a7/YWcKf8uHjfzmg==, tarball: https://npm.pkg.github.com/download/@nvidia/openshell-sdk/0.0.113/0dcdccd281cb1a80194e08de8d80c0014eadd209}
     engines: {node: '>=20.3'}
 
   '@open-draft/deferred-promise@2.2.0':
@@ -9169,7 +9169,7 @@ snapshots:
       mkdirp: 1.0.4
       rimraf: 3.0.2
 
-  '@nvidia/openshell-sdk@0.0.106':
+  '@nvidia/openshell-sdk@0.0.113':
     dependencies:
       '@bufbuild/protobuf': 2.14.0
       '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.14.0)


### PR DESCRIPTION
Detect network denials from OpenShell sandboxes in real-time via
WatchSandbox log stream, surface them as interactive cards in ACP chat,
and allow one-click Allow/Reject actions that apply policy changes via
the OpenShell SDK.

## What changed

- Add DraftPolicyWatcher service (packages/main/src/plugin/draft-policy/)
  with Emitter-based event bus, decoupled from ACP session management
- Parse both OCSF shorthand messages and structured log fields to detect
  L4 (NET:CONNECT) and L7 (HTTP:METHOD) denials from sandbox logs
- Generate client-side denial proposals immediately from log lines instead
  of waiting ~10s for OpenShell's mechanistic mapper to batch and flush
- Handle three policy update paths on approval:
  - L7-inspected endpoint exists: addAllowRules (append method/path rules)
  - No matching endpoint: addRule (create new rule with protocol/enforcement)
  - L4-only endpoint exists: approveDraftChunk RPC with reviewToken
- Upgrade client-side chunks with server proposal data (binary paths,
  reviewToken) when the mechanistic mapper's PolicyChunk arrives later
- Filter transient "policy changed" and "policy generation is stale"
  denials that occur during policy hot-reload
- Add forge-aware path generalization for GitHub, GitLab, and Bitbucket
  API patterns (e.g. /repos/{org}/{repo}/... -> /repos/{org}/{repo}/**)
- Add AcpFlowNetworkBlock.svelte component for denial cards in ACP chat
- Wire IPC handlers (acp:approveDraftChunk, acp:rejectDraftChunk) and
  preload bridge
- Auto-send retry message to agent after approval with 1s delay, gated
  on session status (running/idle/completed, not waiting_input)
- Bump @nvidia/openshell-sdk from 0.0.106 to 0.0.113 for reviewToken

## Design decisions

- Client-side denial detection from logs: OpenShell's denial aggregator
  batches every 10s before the mechanistic mapper runs. Parsing log lines
  directly gives instant feedback. The client-side chunk is later upgraded
  with server data (binary, reviewToken) when the PolicyChunk arrives.
- Event bus pattern (Emitter<DraftPolicyEvent>): DraftPolicyWatcher fires
  events that any consumer can subscribe to. Currently only AcpSessionManager
  listens, but workspace terminal view can be added as a second consumer.
- Dedup by host:port regardless of status: prevents duplicate cards when
  the same denial appears from both log lines and server proposals, or
  when the server re-proposes after rejection.
- Rule naming convention: allow_{sanitized_host}_{port} matches OpenShell's
  mechanistic mapper output (dots/dashes replaced with underscores).
- Default binaries to ["/**"] when log line has no binary info (OCSF
  shorthand only includes process name, not full path).
- Retry message gating: sent for running/idle/completed sessions (in ACP,
  completed means the agent finished its turn, not the session). Skipped
  for waiting_input to avoid interfering with the agent's permission flow.

## Known issues / future work

- L7 path generalization is limited to hardcoded forge patterns; unknown
  hosts get last-segment-only fallback
- No "Approve All" bulk action yet
- No workspace terminal view integration yet (deferred, second consumer)
- Debug console.log statements are still present in approveDraftChunk
  flow (to be removed before merge)
- The sandbox getConfig() call in #applyPolicyUpdate does not cache;
  each approval fetches the full config

fixes #2650 

I need to check https://github.com/openkaiden/kaiden/issues/2553 but I'm currently having issues with github secrets apparently
