### PR TITLE
test: simplify workspace test gating and centralize terminal patterns

### DIFF
--- a/.agents/skills/playwright-testing/reference.md
+++ b/.agents/skills/playwright-testing/reference.md
@@ -242,7 +242,6 @@ npx playwright show-trace path/to/trace.zip
 | `OPENAI_API_KEY`          | OpenAI provider API key                                             |
 | `ANTHROPIC_API_KEY`       | Claude workspace provider tests                                     |
 | `PODMAN_ENABLED`          | Enable workspace provider + container-dependent tests               |
-| `WORKSPACE_TESTS_CI`      | Allow workspace tests when `CI=true`                                |
 | `OLLAMA_ENABLED`          | Enable Ollama provider tests                                        |
 | `RAMALAMA_ENABLED`        | Enable RamaLama provider tests                                      |
 | `OPENSHIFT_AI_TOKEN`      | OpenShift AI authentication                                         |
@@ -250,6 +249,7 @@ npx playwright show-trace path/to/trace.zip
 | `KAIDEN_BINARY`           | Path to production binary (vs dev mode)                             |
 | `KAIDEN_E2E_VERBOSE_LOGS` | Set `true` to print Electron main/renderer logs between test titles |
 | `CI`                      | CI environment flag (enables retries, mock keychain)                |
+| `GITHUB_ACTIONS`          | Auto-set by GitHub Actions; workspace tests skip when present       |
 | `KAIDEN_HOME_DIR`         | Test config directory (auto-set by fixtures)                        |
 
 ## Workspace Provider E2E

--- a/.agents/skills/playwright-testing/workspace-provider-e2e.md
+++ b/.agents/skills/playwright-testing/workspace-provider-e2e.md
@@ -14,12 +14,11 @@ Run from the **repo root** in a **single shell** (exports must persist into the 
 # 1. Required env — set in the same terminal session (never paste API keys into commands)
 export CI=true
 export PODMAN_ENABLED=true          # Required on macOS/Windows
-export WORKSPACE_TESTS_CI=true      # Required when CI=true
 export KAIDEN_BINARY="/path/to/Kaiden.app/Contents/MacOS/Kaiden"
 # OPENAI_API_KEY and ANTHROPIC_API_KEY must already be in the environment (user shell / secrets file)
 
 # 2. Verify secrets and gates (all must print "set" / a positive count)
-echo "PODMAN: ${PODMAN_ENABLED:+set}" "WORKSPACE_CI: ${WORKSPACE_TESTS_CI:+set}" "BINARY: ${KAIDEN_BINARY:+set}"
+echo "PODMAN: ${PODMAN_ENABLED:+set}" "BINARY: ${KAIDEN_BINARY:+set}"
 echo "OPENAI: ${OPENAI_API_KEY:+set}" "ANTHROPIC: ${ANTHROPIC_API_KEY:+set}"
 
 pnpm exec playwright test -c tests/playwright/playwright.config.ts \
@@ -65,7 +64,7 @@ Expect passes (not skips). Then scale up to `--grep @workspace-sandbox` or the f
 
 | Symptom                                                 | Likely cause                                                                         | Fix                                                                                               |
 | ------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `No tests found`                                        | `PODMAN_ENABLED` unset, or `CI=true` without `WORKSPACE_TESTS_CI`                    | Export both Podman vars; re-run `--list`                                                          |
+| `No tests found`                                        | `PODMAN_ENABLED` unset, or `GITHUB_ACTIONS` env var present                          | Export `PODMAN_ENABLED` locally; tests skip in GitHub Actions (run on Azure VMs via workflow)     |
 | All tests **skipped**, exit 0                           | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` missing in this shell                         | Use the terminal where keys are loaded, or `test:e2e:pde2e:workspaces:*` on Windows               |
 | `40 skipped` for a tag grep                             | Same as above, or intentional `skipReason` (full-system / unrestricted on OpenShell) | Check skip reason in output; see [Expected results](#expected-results-on-openshell-macos--podman) |
 | Create fails: `mkdir: cannot create directory '/Users'` | Bad custom mount target (absolute host + empty target)                               | Use `$SOURCES/...` hosts; see [Custom mount conventions](#custom-mount-conventions)               |
@@ -77,11 +76,11 @@ Expect passes (not skips). Then scale up to `--grep @workspace-sandbox` or the f
 
 Agents can **invoke** Playwright and interpret results, but often **cannot get real passes** without inference API keys in the same shell.
 
-| Agent can do                                                | Agent often cannot do                                                                                  |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Read this runbook and run `--list` / `--grep` commands      | Access `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the user's 1Password, `.zshrc`, or IDE-only secrets |
-| Set `PODMAN_ENABLED`, `WORKSPACE_TESTS_CI`, `KAIDEN_BINARY` | Treat `N skipped` + exit 0 as success when keys are missing                                            |
-| Diagnose skips using the troubleshooting table              | Run unattended full matrix (~15+ min) without user approval/timeouts                                   |
+| Agent can do                                           | Agent often cannot do                                                                                  |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| Read this runbook and run `--list` / `--grep` commands | Access `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the user's 1Password, `.zshrc`, or IDE-only secrets |
+| Set `PODMAN_ENABLED`, `KAIDEN_BINARY`                  | Treat `N skipped` + exit 0 as success when keys are missing                                            |
+| Diagnose skips using the troubleshooting table         | Run unattended full matrix (~15+ min) without user approval/timeouts                                   |
 
 **If pre-flight shows `OPENAI: ` / `ANTHROPIC: ` empty:** stop and ask the user to run the command in a terminal where keys are already loaded, or trigger CI/MAPT (`test:e2e:pde2e:workspaces:*` on Windows with deferred secrets). Do not paste API keys into chat or commit them.
 
@@ -214,7 +213,7 @@ Most scenarios pass; full-system and unrestricted scenarios are skipped (see [Sk
 
 **Report hierarchy (HTML):** `OpenCode` → `FS-NONE-NET-DEVELOPER` → `[01] creation` … `[05] removal` (no duplicated scenario ID in step titles).
 
-**Terminal output:** With `WORKSPACE_TESTS_CI=true` (default for workspace runs), the compact list reporter prints only `test.title` — no truncation:
+**Terminal output:** When running in GitHub Actions workspace e2e workflow, the compact list reporter prints only `test.title` — no truncation:
 
 ```
 ✓ 1 WKS-OPENAI [FS-NONE-NET-DEVELOPER] creation (5.6s)
@@ -274,7 +273,7 @@ PDE2E variants (`test:e2e:pde2e:workspaces:*`) restore deferred API keys from `~
 
 ## Playwright Project Config
 
-The `Workspace-Provider` project is defined in `tests/playwright/playwright.config.ts`. It matches `**/provider-specs/workspaces/*.spec.ts` and is gated by `PODMAN_ENABLED` (plus `WORKSPACE_TESTS_CI` when `CI=true`). If the gate is unmet, Playwright reports "No tests found."
+The `Workspace-Provider` project is defined in `tests/playwright/playwright.config.ts`. It matches `**/provider-specs/workspaces/*.spec.ts` and is gated by `PODMAN_ENABLED` and skips when `GITHUB_ACTIONS` is set (GitHub Actions runners). Workspace tests run locally or on Azure VMs via workspace-e2e workflow. If the gate is unmet, Playwright reports "No tests found."
 
 ## Skip Conditions
 

--- a/.github/workflows/workspace-e2e.yaml
+++ b/.github/workflows/workspace-e2e.yaml
@@ -52,7 +52,7 @@ on:
           - 'test:e2e:workspaces:copilot'
         required: true
       env_vars:
-        default: 'PODMAN_ENABLED=true,WORKSPACE_TESTS_CI=true'
+        default: 'PODMAN_ENABLED=true'
         description: 'Env. Variables passed into target machine, ie: VAR1=xxx,VAR2=true'
         type: string
         required: true
@@ -165,7 +165,7 @@ jobs:
       env:
         DEFAULT_REPO_BRANCH: 'FORK=openkaiden,BRANCH=main'
         DEFAULT_NPM_TARGET: 'test:e2e:workspaces'
-        DEFAULT_ENV_VARS: 'PODMAN_ENABLED=true,WORKSPACE_TESTS_CI=true,NPM_CONFIG_LOGLEVEL=warn'
+        DEFAULT_ENV_VARS: 'PODMAN_ENABLED=true,NPM_CONFIG_LOGLEVEL=warn'
         DEFAULT_IMAGE_VERSION: 'v0.1.1'
         DEFAULT_TARGET_REPO: 'kaiden'
         DEFAULT_TARGET_APP_NAME: 'Kaiden'

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -36,9 +36,7 @@ if (podmanAvailable) {
   console.log('Podman enabled - running container-dependent tests');
 }
 
-const useCompactListReporter =
-  process.env.KAIDEN_E2E_COMPACT_REPORTER === 'true' ||
-  (process.env.WORKSPACE_TESTS_CI === 'true' && process.env.KAIDEN_E2E_COMPACT_REPORTER !== 'false');
+const useCompactListReporter = process.env.KAIDEN_E2E_COMPACT_REPORTER === 'true';
 
 const config: PlaywrightTestConfig & {
   projects?: Array<{
@@ -97,7 +95,7 @@ const config: PlaywrightTestConfig & {
         video: 'retain-on-failure',
         screenshot: 'on',
       },
-      testIgnore: podmanAvailable && (!process.env.CI || process.env.WORKSPACE_TESTS_CI) ? [] : ['**/*'],
+      testIgnore: podmanAvailable && !process.env.GITHUB_ACTIONS ? [] : ['**/*'],
     },
     {
       name: 'OpenShift-AI-Provider',

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -229,6 +229,14 @@ export const CODING_AGENT = {
 export const CODING_AGENTS = Object.values(CODING_AGENT);
 export type CodingAgent = (typeof CODING_AGENT)[keyof typeof CODING_AGENT];
 
+export const TERMINAL_READY_PATTERNS = {
+  OPENCODE: [/Ask anything/i, /opencode/i],
+  CLAUDE: [/Claude Code/],
+  COPILOT: [/Copilot/i],
+  GOOSE: [/goose/i],
+  OPENCLAW: [/openclaw/i],
+} as const;
+
 export const ENABLED_CODING_AGENTS = [
   CODING_AGENT.OPENCODE,
   CODING_AGENT.CLAUDE,

--- a/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-lifecycle-helper.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-lifecycle-helper.ts
@@ -58,7 +58,7 @@ export interface WorkspaceLifecycleConfig {
   agent: CodingAgent;
   requiredResource?: ResourceId;
   selectModel: (createPage: AgentWorkspaceCreatePage) => Promise<string | undefined>;
-  terminalReadyPatterns: RegExp[];
+  terminalReadyPatterns: readonly RegExp[];
   prePrompts?: { command: string; expectedResponse: RegExp }[];
   promptTimeout?: number;
   promptTest: {

--- a/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-sandbox-matrix.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/helpers/workspace-sandbox-matrix.ts
@@ -89,7 +89,7 @@ export interface SandboxAgentSetup {
   requiredResource: ResourceId;
   workspacePrefix: string;
   selectModel: (createPage: AgentWorkspaceCreatePage) => Promise<string | undefined>;
-  terminalReadyPatterns: RegExp[];
+  terminalReadyPatterns: readonly RegExp[];
   promptTest: {
     prompt: string;
     expectedResponse: RegExp;

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-claude-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-claude-smoke.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { expect, test } from '/@/fixtures/provider-fixtures';
-import { CODING_AGENT } from '/@/model/core/types';
+import { CODING_AGENT, TERMINAL_READY_PATTERNS } from '/@/model/core/types';
 
 import { registerWorkspaceLifecycleTests } from './helpers/workspace-lifecycle-helper';
 
@@ -32,7 +32,7 @@ test.describe
         await createPage.verifyModelRuntimes('Claude');
         return createPage.selectDefaultModel();
       },
-      terminalReadyPatterns: [/Claude Code/],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.CLAUDE,
       promptTest: {
         prompt: 'what is 2+2? reply with just the number',
         expectedResponse: /4|insufficient|balance|credit/i,
@@ -52,7 +52,7 @@ test.describe
         await createPage.verifyModelRuntimes('Claude');
         return createPage.selectDefaultModel();
       },
-      terminalReadyPatterns: [/Claude Code/],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.CLAUDE,
       promptTest: {
         prompt: 'what is 2+2? reply with just the number',
         expectedResponse: /4|insufficient|balance|credit/i,

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-copilot-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-copilot-smoke.spec.ts
@@ -17,11 +17,9 @@
  ***********************************************************************/
 
 import { expect, test } from '/@/fixtures/provider-fixtures';
-import { CODING_AGENT } from '/@/model/core/types';
+import { CODING_AGENT, TERMINAL_READY_PATTERNS } from '/@/model/core/types';
 
 import { registerWorkspaceLifecycleTests } from './helpers/workspace-lifecycle-helper';
-
-const COPILOT_READY_PATTERNS = [/Copilot/i];
 
 test.describe
   .serial('GitHub Copilot agent workspace with OpenAI model', { tag: '@workspace-provider' }, () => {
@@ -31,7 +29,7 @@ test.describe
       agent: CODING_AGENT.COPILOT,
       requiredResource: 'openai',
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
-      terminalReadyPatterns: COPILOT_READY_PATTERNS,
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.COPILOT,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
         expectedResponse: /579|insufficient|balance|credit|quota exceeded/i,
@@ -47,7 +45,7 @@ test.describe
       agent: CODING_AGENT.COPILOT,
       requiredResource: 'claude',
       selectModel: async createPage => createPage.searchAndSelectDefault('claude', 'Claude'),
-      terminalReadyPatterns: COPILOT_READY_PATTERNS,
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.COPILOT,
       promptTest: {
         prompt: 'what is 2+2? reply with just the number',
         expectedResponse: /4|insufficient|balance|credit/i,

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-filesystem-network-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-filesystem-network-smoke.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { expect, test } from '/@/fixtures/provider-fixtures';
-import { CODING_AGENT, FILE_ACCESS_LEVEL, NETWORK_ACCESS_LEVEL } from '/@/model/core/types';
+import { CODING_AGENT, FILE_ACCESS_LEVEL, NETWORK_ACCESS_LEVEL, TERMINAL_READY_PATTERNS } from '/@/model/core/types';
 
 // Sandbox matrix lifecycle tests — see .agents/skills/playwright-testing/workspace-provider-e2e.md
 import {
@@ -39,7 +39,7 @@ const AGENT_SETUPS: SandboxAgentSetup[] = [
     requiredResource: 'openai',
     workspacePrefix: 'opencode',
     selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
-    terminalReadyPatterns: [/Ask anything/i, /openai/i],
+    terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCODE,
     promptTest: {
       prompt: 'what is 123+456? reply with just the number',
       expectedResponse: /579|insufficient|balance|credit|quota exceeded/i,
@@ -55,7 +55,7 @@ const AGENT_SETUPS: SandboxAgentSetup[] = [
       await createPage.verifyModelRuntimes('Claude');
       return createPage.selectDefaultModel();
     },
-    terminalReadyPatterns: [/Claude Code/],
+    terminalReadyPatterns: TERMINAL_READY_PATTERNS.CLAUDE,
     promptTest: {
       prompt: 'what is 2+2? reply with just the number',
       expectedResponse: /4|insufficient|balance|credit/i,

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-goose-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-goose-smoke.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { expect, test } from '/@/fixtures/provider-fixtures';
-import { CODING_AGENT } from '/@/model/core/types';
+import { CODING_AGENT, TERMINAL_READY_PATTERNS } from '/@/model/core/types';
 
 import { registerWorkspaceLifecycleTests } from './helpers/workspace-lifecycle-helper';
 
@@ -29,7 +29,7 @@ test.describe
       agent: CODING_AGENT.GOOSE,
       requiredResource: 'openai',
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
-      terminalReadyPatterns: [/goose/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.GOOSE,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
         expectedResponse: /579|insufficient|balance|credit|quota exceeded/i,
@@ -46,7 +46,7 @@ test.describe
       requiredResource: 'openai',
       noProjectFolder: true,
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
-      terminalReadyPatterns: [/goose/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.GOOSE,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
         expectedResponse: /579|insufficient|balance|credit|quota exceeded/i,
@@ -62,7 +62,7 @@ test.describe
       agent: CODING_AGENT.GOOSE,
       requiredResource: 'mistral',
       selectModel: async createPage => createPage.searchAndSelectDefault('mistral', 'Mistral'),
-      terminalReadyPatterns: [/goose/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.GOOSE,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
         expectedResponse: /579|insufficient|balance|credit/i,
@@ -80,7 +80,7 @@ test.describe
       agent: CODING_AGENT.GOOSE,
       requiredResource: 'ollama',
       selectModel: async createPage => createPage.searchAndSelectByRuntime('ollama', 'Ollama'),
-      terminalReadyPatterns: [/goose/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.GOOSE,
       promptTimeout: 120_000,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
@@ -97,7 +97,7 @@ test.describe
       agent: CODING_AGENT.GOOSE,
       requiredResource: 'ramalama',
       selectModel: async createPage => createPage.searchAndSelectByRuntime('ramalama', 'RamaLama'),
-      terminalReadyPatterns: [/goose/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.GOOSE,
       promptTimeout: 120_000,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-openclaw-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-openclaw-smoke.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { expect, test } from '/@/fixtures/provider-fixtures';
-import { CODING_AGENT } from '/@/model/core/types';
+import { CODING_AGENT, TERMINAL_READY_PATTERNS } from '/@/model/core/types';
 
 import { registerWorkspaceLifecycleTests } from './helpers/workspace-lifecycle-helper';
 
@@ -29,7 +29,7 @@ test.describe
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'ollama',
       selectModel: async createPage => createPage.searchAndSelectByRuntime('ollama', 'Ollama'),
-      terminalReadyPatterns: [/openclaw/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCLAW,
       prePrompts: [{ command: 'talk to agent', expectedResponse: /agent/i }],
       promptTimeout: 120_000,
       promptTest: {
@@ -47,7 +47,7 @@ test.describe
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'openai',
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
-      terminalReadyPatterns: [/openclaw/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCLAW,
       prePrompts: [{ command: 'talk to agent', expectedResponse: /agent/i }],
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
@@ -65,7 +65,7 @@ test.describe
       requiredResource: 'openai',
       noProjectFolder: true,
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
-      terminalReadyPatterns: [/openclaw/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCLAW,
       prePrompts: [{ command: 'talk to agent', expectedResponse: /agent/i }],
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
@@ -82,7 +82,7 @@ test.describe
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'claude',
       selectModel: async createPage => createPage.searchAndSelectDefault('claude', 'Claude'),
-      terminalReadyPatterns: [/openclaw/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCLAW,
       prePrompts: [{ command: 'talk to agent', expectedResponse: /agent/i }],
       promptTest: {
         prompt: 'what is 2+2? reply with just the number',
@@ -99,7 +99,7 @@ test.describe
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'gemini',
       selectModel: async createPage => createPage.searchAndSelectDefault('gemini', 'Gemini'),
-      terminalReadyPatterns: [/openclaw/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCLAW,
       prePrompts: [{ command: 'talk to agent', expectedResponse: /agent/i }],
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
@@ -116,7 +116,7 @@ test.describe
       agent: CODING_AGENT.OPENCLAW,
       requiredResource: 'mistral',
       selectModel: async createPage => createPage.searchAndSelectDefault('mistral', 'Mistral'),
-      terminalReadyPatterns: [/openclaw/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCLAW,
       prePrompts: [{ command: 'talk to agent', expectedResponse: /agent/i }],
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',

--- a/tests/playwright/src/specs/provider-specs/workspaces/workspace-opencode-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/workspaces/workspace-opencode-smoke.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { expect, test } from '/@/fixtures/provider-fixtures';
-import { CODING_AGENT, TIMEOUTS } from '/@/model/core/types';
+import { CODING_AGENT, TERMINAL_READY_PATTERNS, TIMEOUTS } from '/@/model/core/types';
 
 import { registerWorkspaceLifecycleTests } from './helpers/workspace-lifecycle-helper';
 
@@ -29,7 +29,7 @@ test.describe
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'openai',
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
-      terminalReadyPatterns: [/Ask anything/i, /openai/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCODE,
       promptTimeout: TIMEOUTS.MODEL_RESPONSE,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
@@ -47,7 +47,7 @@ test.describe
       requiredResource: 'openai',
       noProjectFolder: true,
       selectModel: async createPage => createPage.searchAndSelectDefault('chat'),
-      terminalReadyPatterns: [/Ask anything/i, /openai/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCODE,
       promptTimeout: TIMEOUTS.MODEL_RESPONSE,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
@@ -64,7 +64,7 @@ test.describe
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'gemini',
       selectModel: async createPage => createPage.searchAndSelectDefault('gemini', 'Gemini'),
-      terminalReadyPatterns: [/Ask anything/i, /gemini/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCODE,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
         expectedResponse: /579|insufficient|balance|credit/i,
@@ -80,7 +80,7 @@ test.describe
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'claude',
       selectModel: async createPage => createPage.searchAndSelectDefault('claude', 'Claude'),
-      terminalReadyPatterns: [/Ask anything/i, /claude/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCODE,
       promptTest: {
         prompt: 'what is 2+2? reply with just the number',
         expectedResponse: /4|insufficient|balance|credit/i,
@@ -96,7 +96,7 @@ test.describe
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'mistral',
       selectModel: async createPage => createPage.searchAndSelectDefault('mistral', 'Mistral'),
-      terminalReadyPatterns: [/Ask anything/i, /mistral/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCODE,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',
         expectedResponse: /579|insufficient|balance|credit/i,
@@ -112,7 +112,7 @@ test.describe
       agent: CODING_AGENT.OPENCODE,
       requiredResource: 'ollama',
       selectModel: async createPage => createPage.searchAndSelectByRuntime('ollama', 'Ollama'),
-      terminalReadyPatterns: [/Ask anything/i, /ollama/i],
+      terminalReadyPatterns: TERMINAL_READY_PATTERNS.OPENCODE,
       promptTimeout: 120_000,
       promptTest: {
         prompt: 'what is 123+456? reply with just the number',


### PR DESCRIPTION
## Summary
- Replace `WORKSPACE_TESTS_CI` env var with `GITHUB_ACTIONS` skip condition, consistent with existing patterns in guided-setup and workspaces smoke tests
- Centralize `TERMINAL_READY_PATTERNS` in `types.ts` for all agents (OpenCode, Claude, Copilot, Goose, OpenClaw)