### PR TITLE
fix(openshell): support renamed sandbox release assets

### DIFF
--- a/extensions/openshell/src/openshell-download.spec.ts
+++ b/extensions/openshell/src/openshell-download.spec.ts
@@ -126,6 +126,10 @@ describe('downloadBinaries', () => {
     await downloadBinaries(OPENSHELL_DOWNLOAD, '0.0.55', 'linux', 'x64', '/output', digests);
 
     expect(vi.mocked(tar.extract)).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz'),
+      expect.any(Object),
+    );
   });
 
   test('extracts OpenShell archives and writes its version marker', async () => {
@@ -134,7 +138,7 @@ describe('downloadBinaries', () => {
     const digests = new Map([
       ['openshell-x86_64-unknown-linux-musl.tar.gz', 'abc123'],
       ['openshell-gateway-x86_64-unknown-linux-gnu.tar.gz', 'abc123'],
-      ['openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz', 'abc123'],
+      ['openshell-sandbox-x86_64-unknown-linux-musl.tar.gz', 'abc123'],
       ['openshell-driver-vm-x86_64-unknown-linux-gnu.tar.gz', 'abc123'],
     ]);
 

--- a/extensions/openshell/src/openshell-download.ts
+++ b/extensions/openshell/src/openshell-download.ts
@@ -31,7 +31,7 @@ export interface ReleaseInfo {
 }
 
 interface AssetSpec {
-  assetName: string;
+  assetName: string | string[];
   binaryName: string;
   subdir?: string;
 }
@@ -64,7 +64,10 @@ export const OPENSHELL_DOWNLOAD: GitHubArtifactDownload = {
         binaryName: 'openshell-gateway',
       },
       {
-        assetName: 'openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz',
+        assetName: [
+          'openshell-sandbox-x86_64-unknown-linux-musl.tar.gz',
+          'openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz',
+        ],
         binaryName: 'openshell-sandbox',
       },
       {
@@ -79,7 +82,10 @@ export const OPENSHELL_DOWNLOAD: GitHubArtifactDownload = {
         binaryName: 'openshell-gateway',
       },
       {
-        assetName: 'openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz',
+        assetName: [
+          'openshell-sandbox-aarch64-unknown-linux-musl.tar.gz',
+          'openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz',
+        ],
         binaryName: 'openshell-sandbox',
       },
       {
@@ -220,15 +226,17 @@ export async function downloadBinaries(
     const assetDir = asset.subdir ? join(outputDir, asset.subdir) : outputDir;
     await mkdir(assetDir, { recursive: true });
 
-    const url = `https://github.com/${downloadConfig.repository}/releases/download/v${version}/${asset.assetName}`;
-    const downloadPath = join(assetDir, asset.assetName);
+    const assetNames = Array.isArray(asset.assetName) ? asset.assetName : [asset.assetName];
+    const assetName = assetNames.find(name => digests.has(name)) ?? assetNames[0];
+    const url = `https://github.com/${downloadConfig.repository}/releases/download/v${version}/${assetName}`;
+    const downloadPath = join(assetDir, assetName);
     const binaryPath = join(assetDir, asset.binaryName);
 
     console.log(`downloading ${asset.binaryName} ${version} for ${platform}/${arch}...`);
     await download(url, downloadPath);
-    await verifyChecksum(digests, asset.assetName, downloadPath);
+    await verifyChecksum(digests, assetName, downloadPath);
 
-    if (asset.assetName.endsWith('.tar.gz')) {
+    if (assetName.endsWith('.tar.gz')) {
       console.log(`extracting ${asset.binaryName}...`);
       await extract(downloadPath, assetDir);
       await rm(downloadPath);


### PR DESCRIPTION
### What does this PR do?

Supports both the legacy `unknown-linux-gnu` and current `unknown-linux-musl` OpenShell sandbox archive names. The downloader selects the name present in the release digest map, preserving the current 0.0.113 build while allowing upgrades to 0.0.114 and newer.

This unblocks #2752.

### How was this tested?

- `pnpm exec vitest --run --project=openshell extensions/openshell/src/openshell-download.spec.ts`
- `pnpm run typecheck:extensions:openshell`