### PR TITLE
fix(codex): route OpenAI through OpenShell inference

### DIFF
--- a/extensions/codex/src/extension.spec.ts
+++ b/extensions/codex/src/extension.spec.ts
@@ -126,11 +126,30 @@ describe('activate', () => {
       const agent = getRegisteredAgent();
 
       const configFile = createConfigFile();
-      await agent.preWorkspaceStart(createContext([configFile]));
+      const context = createContext([configFile]);
+      await agent.preWorkspaceStart(context);
 
       expect(configFile.updateMock).toHaveBeenCalledOnce();
+      expect(context.workspace.environment).toContainEqual({ name: 'OPENAI_API_KEY', value: 'unused' });
       const written = parseWrittenToml(configFile.updateMock);
-      expect(written).toEqual({ model: 'gpt-4o' });
+      expect(written).toEqual({
+        model: 'gpt-4o',
+        model_provider: 'openshell',
+        model_providers: {
+          openshell: {
+            name: 'OpenShell',
+            base_url: 'https://inference.local/v1',
+            env_key: 'OPENAI_API_KEY',
+            wire_api: 'responses',
+            supports_websockets: false,
+          },
+        },
+        projects: {
+          '/sandbox': {
+            trust_level: 'trusted',
+          },
+        },
+      });
     });
 
     test('preserves existing configuration fields', async () => {

--- a/extensions/codex/src/extension.ts
+++ b/extensions/codex/src/extension.ts
@@ -33,8 +33,15 @@ const McpServerEntrySchema = z.looseObject({
 
 const CodexConfigSchema = z.looseObject({
   model: z.string().optional(),
+  model_provider: z.string().optional(),
+  model_providers: z.record(z.string(), z.looseObject({})).optional(),
+  projects: z.record(z.string(), z.looseObject({ trust_level: z.string().optional() })).optional(),
   mcp_servers: z.record(z.string(), McpServerEntrySchema).optional(),
 });
+
+const OPENSHELL_PROVIDER = 'openshell';
+const OPENAI_API_KEY = 'OPENAI_API_KEY';
+const WORKSPACE_PATH = '/sandbox';
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
@@ -68,6 +75,27 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       const config = CodexConfigSchema.parse(raw ? parse(raw) : {});
 
       config.model = context.model.model.label;
+      config.model_provider = OPENSHELL_PROVIDER;
+      config.model_providers ??= {};
+      config.model_providers[OPENSHELL_PROVIDER] = {
+        name: 'OpenShell',
+        base_url: 'https://inference.local/v1',
+        env_key: OPENAI_API_KEY,
+        wire_api: 'responses',
+        supports_websockets: false,
+      };
+      config.projects ??= {};
+      config.projects[WORKSPACE_PATH] = {
+        ...config.projects[WORKSPACE_PATH],
+        trust_level: 'trusted',
+      };
+
+      context.workspace.environment ??= [];
+      const apiKeyIndex = context.workspace.environment.findIndex(entry => entry.name === OPENAI_API_KEY);
+      if (apiKeyIndex >= 0) {
+        context.workspace.environment.splice(apiKeyIndex, 1);
+      }
+      context.workspace.environment.push({ name: OPENAI_API_KEY, value: 'unused' });
 
       const mcpServers = context.workspace.mcp?.servers;
       const mcpCommands = context.workspace.mcp?.commands;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -953,6 +953,40 @@ describe('create – OpenShell mode', () => {
     });
   });
 
+  test('calls setInference for an OpenAI connection', async () => {
+    vi.mocked(secretManager.ensureSecretForModel).mockResolvedValue({ name: 'openai-conn-1', type: 'openai' });
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: {},
+      llmMetadataName: 'openai',
+    });
+    vi.mocked(secretManager.getConnectionProperties).mockReturnValue({
+      config: {} as Configuration,
+      connectionProperties: [],
+    });
+    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
+      connection: {
+        name: 'openai',
+        id: 'openai',
+        type: 'cloud',
+        sdk: {} as AISDKInferenceProvider,
+        credentials: (): Record<string, string> => ({}),
+        status: (): ProviderConnectionStatus => 'started',
+        models: [{ label: 'gpt-5.4-mini' }],
+      },
+      providerId: 'openai',
+    });
+    vi.mocked(providerRegistry.getProvider).mockReturnValue({
+      extensionId: 'kaiden.openai-compatible',
+    } as ProviderImpl);
+
+    await manager.create({ ...defaultOptions, model: 'openai::gpt-5.4-mini::' });
+
+    expect(openshellCli.setInference).toHaveBeenCalledWith({
+      provider: 'openai-conn-1',
+      model: 'gpt-5.4-mini',
+    });
+  });
+
   test('does not pass env when all environment values are filtered out', async () => {
     vi.spyOn(configWriter, 'writeWorkspaceConfig').mockResolvedValue({
       environment: [

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -987,6 +987,45 @@ describe('create – OpenShell mode', () => {
     });
   });
 
+  test('calls setInference for an OpenAI connection from workspace configuration secrets', async () => {
+    vi.mocked(secretManager.getSecretForModel).mockResolvedValue({ name: 'openai-conn-1', type: 'openai' });
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: {},
+      llmMetadataName: 'openai',
+    });
+    vi.mocked(secretManager.getConnectionProperties).mockReturnValue({
+      config: {} as Configuration,
+      connectionProperties: [],
+    });
+    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
+      connection: {
+        name: 'openai',
+        id: 'openai',
+        type: 'cloud',
+        sdk: {} as AISDKInferenceProvider,
+        credentials: (): Record<string, string> => ({}),
+        status: (): ProviderConnectionStatus => 'started',
+        models: [{ label: 'gpt-5.4-mini' }],
+      },
+      providerId: 'openai',
+    });
+    vi.mocked(providerRegistry.getProvider).mockReturnValue({
+      extensionId: 'kaiden.openai-compatible',
+    } as ProviderImpl);
+
+    await manager.create({
+      ...defaultOptions,
+      model: 'openai::gpt-5.4-mini::',
+      workspaceConfiguration: { secrets: ['openai-conn-1'] },
+    });
+
+    expect(secretManager.ensureSecretForModel).not.toHaveBeenCalled();
+    expect(openshellCli.setInference).toHaveBeenCalledWith({
+      provider: 'openai-conn-1',
+      model: 'gpt-5.4-mini',
+    });
+  });
+
   test('does not pass env when all environment values are filtered out', async () => {
     vi.spyOn(configWriter, 'writeWorkspaceConfig').mockResolvedValue({
       environment: [
@@ -1248,14 +1287,17 @@ describe('ensureModelSecret', () => {
     gateway: 'kaiden',
   };
 
-  test('skips when workspaceConfiguration already has secrets (e.g. onboarding)', async () => {
+  test('resolves the model secret when workspaceConfiguration already has secrets', async () => {
+    vi.mocked(secretManager.getSecretForModel).mockResolvedValue({ name: 'anthropic', type: 'anthropic' });
     const options = {
       ...baseOptions,
       model: 'anthropic::claude-sonnet-4-20250514::',
       workspaceConfiguration: { secrets: ['anthropic'] },
     } as AgentWorkspaceCreateOptions;
-    await manager.ensureModelSecret(options);
+    const result = await manager.ensureModelSecret(options);
 
+    expect(result).toBe('anthropic');
+    expect(secretManager.getSecretForModel).toHaveBeenCalledWith('anthropic::claude-sonnet-4-20250514::', 'kaiden');
     expect(secretManager.ensureSecretForModel).not.toHaveBeenCalled();
   });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -227,7 +227,7 @@ export class AgentWorkspaceManager implements Disposable {
         const provider = this.providerRegistry.getProvider(connection?.providerId);
         const { connectionProperties } = this.secretManager.getConnectionProperties(connection.connection, provider);
         const hasFlags = connectionProperties.find(([fullKey]) => fullKey.endsWith('._flags'));
-        if (hasFlags) {
+        if (hasFlags || connectionInfo?.llmMetadataName === 'openai') {
           await this.openshellCli.setInference({
             provider: secretName,
             model: modelName,

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -450,8 +450,10 @@ export class AgentWorkspaceManager implements Disposable {
    * model. Return undefined if there is no secret associated with this connection
 ·   */
   async ensureModelSecret(options: AgentWorkspaceCreateOptions): Promise<string | undefined> {
-    if (options.workspaceConfiguration?.secrets?.length) {
-      return undefined;
+    const configuredSecrets = options.workspaceConfiguration?.secrets;
+    if (configuredSecrets?.length) {
+      const secret = await this.secretManager.getSecretForModel(options.model, options.gateway);
+      return secret && configuredSecrets.includes(secret.name) ? secret.name : undefined;
     }
 
     return this.ensureModelSecretFromConfig(options);


### PR DESCRIPTION
## Summary

- configure Codex to use an HTTP-only OpenShell model provider
- select OpenAI connections as the active OpenShell inference route
- provide a non-secret API key placeholder while keeping credentials in OpenShell
- trust the Kaiden-managed `/sandbox` workspace to avoid the startup prompt

## Testing

- `pnpm run test:extensions:codex`

Fixes #2775