### PR TITLE
feat(renderer): link gateway warning to settings

### DIFF
--- a/packages/renderer/src/lib/ui/NoUsableGatewayWarning.spec.ts
+++ b/packages/renderer/src/lib/ui/NoUsableGatewayWarning.spec.ts
@@ -18,14 +18,18 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen, waitFor } from '@testing-library/svelte';
-import { beforeEach, expect, test } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { openshellGateways, openshellGatewaysReady } from '/@/stores/openshell-gateways';
 
 import NoUsableGatewayWarning from './NoUsableGatewayWarning.svelte';
 
+vi.mock(import('tinro'));
+
 beforeEach(() => {
+  vi.resetAllMocks();
   openshellGateways.set([]);
   openshellGatewaysReady.set(false);
 });
@@ -42,6 +46,15 @@ test('shows a warning after gateways load with no results', async () => {
   openshellGatewaysReady.set(true);
 
   expect(await screen.findByRole('alert')).toHaveTextContent('No usable OpenShell gateways available.');
+});
+
+test('opens gateway settings from the warning', async () => {
+  openshellGatewaysReady.set(true);
+  render(NoUsableGatewayWarning);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Open gateway settings' }));
+
+  expect(router.goto).toHaveBeenCalledWith('/preferences/openshell/gateways');
 });
 
 test('shows a warning when all discoverable gateways are unreachable', () => {

--- a/packages/renderer/src/lib/ui/NoUsableGatewayWarning.svelte
+++ b/packages/renderer/src/lib/ui/NoUsableGatewayWarning.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+import { Button } from '@podman-desktop/ui-svelte';
+import { router } from 'tinro';
+
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { openshellGateways, openshellGatewaysReady } from '/@/stores/openshell-gateways';
 import type { GatewayInfo } from '/@api/openshell-gateway-info';
+
+const GATEWAY_SETTINGS_PATH = '/preferences/openshell/gateways';
 
 function noUsableGateways(gateways: GatewayInfo[]): boolean {
   return !gateways.some(gateway => gateway.gatewayState?.reachable === true);
@@ -9,7 +14,8 @@ function noUsableGateways(gateways: GatewayInfo[]): boolean {
 </script>
 
 {#if $openshellGatewaysReady && noUsableGateways($openshellGateways)}
-  <WarningMessage
-    class="shrink-0 px-3 py-2 bg-(--pd-content-card-bg)"
-    error="No usable OpenShell gateways available." />
+  <div class="shrink-0 px-3 py-2 bg-(--pd-content-card-bg) flex items-center justify-between gap-3">
+    <WarningMessage error="No usable OpenShell gateways available." />
+    <Button type="secondary" onclick={(): void => router.goto(GATEWAY_SETTINGS_PATH)}>Open gateway settings</Button>
+  </div>
 {/if}


### PR DESCRIPTION
## Summary

- add an Open gateway settings action to the no usable gateway banner
- navigate users to the existing OpenShell gateway settings page
- cover the navigation behavior with a renderer unit test

## Test plan

- `pnpm exec vitest --run --project=renderer packages/renderer/src/lib/ui/NoUsableGatewayWarning.spec.ts`
- `pnpm --filter renderer check`
- Svelte autofixer

Fixes #2647