### PR TITLE
ci: grant checks:write to reusable e2e workflow callers

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -43,6 +43,11 @@ on:
         default: ''
         type: string
 
+permissions:
+  contents: read
+  checks: write
+  packages: read
+
 jobs:
   windows-e2e-tests:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.platform == 'all' || github.event.inputs.platform == 'windows' }}

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -43,14 +43,13 @@ on:
         default: ''
         type: string
 
-permissions:
-  contents: read
-  checks: write
-  packages: read
-
 jobs:
   windows-e2e-tests:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.platform == 'all' || github.event.inputs.platform == 'windows' }}
+    permissions:
+      contents: read
+      checks: write
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +66,10 @@ jobs:
 
   linux-e2e-tests:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.platform == 'all' || github.event.inputs.platform == 'linux' }}
+    permissions:
+      contents: read
+      checks: write
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +93,10 @@ jobs:
 
   macos-e2e-tests:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.platform == 'all' || github.event.inputs.platform == 'macos' }}
+    permissions:
+      contents: read
+      checks: write
+      packages: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -27,6 +27,7 @@ concurrency:
 
 permissions:
   contents: read
+  checks: write
   packages: read
 
 jobs:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -27,7 +27,6 @@ concurrency:
 
 permissions:
   contents: read
-  checks: write
   packages: read
 
 jobs:


### PR DESCRIPTION
Follow-up to #2793.

#2793 added job-level `checks: write` to `e2e-test-job.yaml`, but neither
caller (`nightly-e2e.yaml`, `pr-check.yaml`) grants `checks: write` at the
workflow level. A reusable-workflow call can't exceed its caller's
permissions, so every call fails at startup:

> the nested job 'e2e-test' is requesting 'checks: write', but is only
> allowed 'checks: none'

https://github.com/openkaiden/kaiden/actions/runs/33883876062