### PR TITLE
fix(chat): keep sidebar height bounded so delete-all-chats stays visible

### DIFF
--- a/packages/renderer/src/lib/chat/components/ui/sidebar/sidebar-provider.svelte
+++ b/packages/renderer/src/lib/chat/components/ui/sidebar/sidebar-provider.svelte
@@ -36,7 +36,7 @@ const sidebar = setSidebar({
 		data-slot="sidebar-wrapper"
 		style="--sidebar-width: {SIDEBAR_WIDTH}; --sidebar-width-icon: {SIDEBAR_WIDTH_ICON}; {style}"
 		class={cn(
-			'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex w-full',
+			'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex h-full min-h-0 w-full',
 			className
 		)}
 		bind:this={ref}

--- a/packages/renderer/src/lib/chat/route/CustomChat.svelte
+++ b/packages/renderer/src/lib/chat/route/CustomChat.svelte
@@ -38,7 +38,7 @@ const hasModels = $derived(
 const forcedTheme = $derived($isDark ? 'dark' : 'light');
 </script>
 
-<div class="flex h-full w-full">
+<div class="flex h-full min-h-0 w-full overflow-hidden">
 <ThemeProvider attribute="class" disableTransitionOnChange {forcedTheme}>
 	<Toaster position="top-center" />
   {#await chatMessagesPromise}


### PR DESCRIPTION
## Summary
- Fixes the "Delete all chats" button being pushed out of view / requiring scrolling when the OpenShell gateway warning banner is shown and the chat list has many entries.
- The chat list now scrolls on its own; "Delete all chats" always stays visible at the bottom.
- Fixes the nightly E2E runs affected by this layout issue.

Fixes #2792