### PR TITLE
fix(acp): show "Thought for <duration>" when thinking completes

### DIFF
--- a/packages/main/src/plugin/acp/acp-session-manager.ts
+++ b/packages/main/src/plugin/acp/acp-session-manager.ts
@@ -563,9 +563,8 @@ export class AcpSessionManager {
           messageId?: string | null;
         };
         if (rawUpdate.sessionUpdate === 'agent_thought_chunk' && rawUpdate.content?.type === 'text') {
-          const existing = session.events.findLast(
-            (e): e is Extract<AcpFlowEvent, { kind: 'thinking' }> => e.kind === 'thinking',
-          );
+          const lastEvent = session.events.at(-1);
+          const existing = lastEvent?.kind === 'thinking' ? lastEvent : undefined;
           if (existing) {
             existing.text += rawUpdate.content.text;
             this.emitEvent(sessionId, existing);

--- a/packages/renderer/src/lib/acp-sessions/AcpSessionDetail.svelte
+++ b/packages/renderer/src/lib/acp-sessions/AcpSessionDetail.svelte
@@ -482,7 +482,10 @@ function handleKeyDown(e: KeyboardEvent): void {
       {:else if event.kind === 'agent_message'}
         <AcpFlowAgentMessage {event} />
       {:else if event.kind === 'thinking'}
-        <AcpFlowThinking {event} />
+        {@const nextEvent = events[i + 1]}
+        {@const isThinkingComplete = !!nextEvent || session?.status !== 'running'}
+        {@const thinkingDurationMs = nextEvent ? nextEvent.timestamp - event.timestamp : undefined}
+        <AcpFlowThinking {event} isComplete={isThinkingComplete} durationMs={thinkingDurationMs} />
       {:else if event.kind === 'tool_call'}
         <AcpFlowToolCall {event} {sessionId} />
       {:else if event.kind === 'plan'}

--- a/packages/renderer/src/lib/acp-sessions/flow/AcpFlowThinking.spec.ts
+++ b/packages/renderer/src/lib/acp-sessions/flow/AcpFlowThinking.spec.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { AcpFlowThinkingEvent } from '/@api/acp-session-info';
+
+import AcpFlowThinking from './AcpFlowThinking.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const THINKING_EVENT: AcpFlowThinkingEvent = {
+  kind: 'thinking',
+  text: 'Some internal reasoning',
+  timestamp: 1000,
+};
+
+describe('AcpFlowThinking', () => {
+  test('should show "Thinking…" when not complete', () => {
+    render(AcpFlowThinking, {
+      event: THINKING_EVENT,
+      isComplete: false,
+    });
+
+    expect(screen.getByText('Thinking…')).toBeInTheDocument();
+    expect(screen.queryByText(/^Thought for/)).not.toBeInTheDocument();
+  });
+
+  test('should show "Thought for <duration>" when complete with duration', () => {
+    render(AcpFlowThinking, {
+      event: THINKING_EVENT,
+      isComplete: true,
+      durationMs: 5000,
+    });
+
+    expect(screen.getByText('Thought for 5 seconds')).toBeInTheDocument();
+    expect(screen.queryByText('Thinking…')).not.toBeInTheDocument();
+  });
+
+  test('should show "Thought for a few seconds" when complete without duration', () => {
+    render(AcpFlowThinking, {
+      event: THINKING_EVENT,
+      isComplete: true,
+    });
+
+    expect(screen.getByText('Thought for a few seconds')).toBeInTheDocument();
+  });
+
+  test('should default to not complete when isComplete is omitted', () => {
+    render(AcpFlowThinking, {
+      event: THINKING_EVENT,
+    });
+
+    expect(screen.getByText('Thinking…')).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/acp-sessions/flow/AcpFlowThinking.svelte
+++ b/packages/renderer/src/lib/acp-sessions/flow/AcpFlowThinking.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
 import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
+import humanizeDuration from 'humanize-duration';
 
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 import type { AcpFlowThinkingEvent } from '/@api/acp-session-info';
 
 interface Props {
   event: AcpFlowThinkingEvent;
+  isComplete?: boolean;
+  durationMs?: number;
 }
 
-let { event }: Props = $props();
+let { event, isComplete = false, durationMs }: Props = $props();
 let expanded = $state(false);
+
+const label = $derived(
+  isComplete
+    ? durationMs !== undefined
+      ? `Thought for ${humanizeDuration(durationMs, { round: true, largest: 2 })}`
+      : 'Thought for a few seconds'
+    : 'Thinking…',
+);
 </script>
 
 <div class="rounded-lg border border-[var(--pd-content-divider)] bg-[var(--pd-content-card-bg)] overflow-hidden">
@@ -19,7 +30,7 @@ let expanded = $state(false);
     onclick={(): void => { expanded = !expanded; }}
   >
     <Icon icon={expanded ? faChevronDown : faChevronRight} class="text-[10px]" />
-    <span class="italic">Thinking…</span>
+    <span class="italic">{label}</span>
   </button>
   {#if expanded}
     <div class="border-t border-[var(--pd-content-divider)] px-4 py-3 text-sm text-[var(--pd-content-text)] opacity-70">


### PR DESCRIPTION
AcpFlowThinking now shows elapsed time instead of staying on "Thinking…"
after thinking finishes, and agent_thought_chunk events create a new
thinking block per turn instead of appending to the first one.

<img width="893" height="654" alt="Screenshot 2026-09-07 at 15 37 48" src="https://github.com/user-attachments/assets/8a41ba36-a22b-4bfb-a5eb-c2f6cb12a6eb" />

fixes #2794 