### PR TITLE
fix(gateway): use detected gateway instead of kaiden-local on same port

### DIFF
--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -185,6 +185,66 @@ describe('init', () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  test('treats gateway with 0.0.0.0 endpoint as local', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(openshellCli.listGateways).mockResolvedValue([
+      { name: 'openshell', endpoint: 'http://0.0.0.0:17670', active: false } as GatewayInfo,
+    ]);
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+
+    await gateway.init();
+
+    expect(openshellCli.selectGateway).toHaveBeenCalledWith('openshell');
+    expect(spawn).not.toHaveBeenCalled();
+    expect(openshellCli.addGateway).not.toHaveBeenCalled();
+  });
+
+  test('prefers external gateway over kaiden-local on same port and removes kaiden-local', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(openshellCli.listGateways).mockResolvedValue([
+      { name: 'kaiden-local', endpoint: 'http://127.0.0.1:17670', active: true, type: 'local' } as GatewayInfo,
+      { name: 'openshell', endpoint: 'http://127.0.0.1:17670', active: false, type: 'local' } as GatewayInfo,
+    ]);
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+
+    await gateway.init();
+
+    expect(openshellCli.selectGateway).toHaveBeenCalledWith('openshell');
+    expect(openshellCli.removeGateway).toHaveBeenCalledWith('kaiden-local');
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test('prioritizes same-port gateway over different-port gateway when both exist with kaiden-local', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(openshellCli.listGateways).mockResolvedValue([
+      { name: 'kaiden-local', endpoint: 'http://127.0.0.1:17670', active: true, type: 'local' } as GatewayInfo,
+      { name: 'other', endpoint: 'http://127.0.0.1:18000', active: false, type: 'local' } as GatewayInfo,
+      { name: 'openshell', endpoint: 'http://0.0.0.0:17670', active: false, type: 'local' } as GatewayInfo,
+    ]);
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+
+    await gateway.init();
+
+    expect(openshellCli.selectGateway).toHaveBeenCalledWith('openshell');
+    expect(openshellCli.removeGateway).toHaveBeenCalledWith('kaiden-local');
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test('keeps kaiden-local when external gateway runs on a different port', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(openshellCli.listGateways).mockResolvedValue([
+      { name: 'kaiden-local', endpoint: 'http://127.0.0.1:17670', active: true, type: 'local' } as GatewayInfo,
+      { name: 'other', endpoint: 'http://127.0.0.1:18000', active: false, type: 'local' } as GatewayInfo,
+    ]);
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+
+    await gateway.init();
+
+    expect(openshellCli.selectGateway).not.toHaveBeenCalled();
+    expect(openshellCli.removeGateway).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
   test('auto-starts local gateway when no gateways exist and port is free', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -105,10 +105,39 @@ export class OpenshellGateway implements Disposable {
         }),
       );
       if (localGateways.length > 0) {
-        for (const gw of localGateways) {
+        // When an unmanaged gateway runs on the kaiden-local default port, try it first
+        // so we select the user's gateway instead of the auto-registered one.
+        const kaidenLocal = localGateways.find(gw => gw.name === DEFAULT_GATEWAY_NAME);
+        const kaidenLocalPort = kaidenLocal ? this.getEndpointPort(kaidenLocal.endpoint) : undefined;
+        const hasSamePortDuplicate =
+          kaidenLocalPort !== undefined &&
+          localGateways.some(
+            gw => gw.name !== DEFAULT_GATEWAY_NAME && this.getEndpointPort(gw.endpoint) === kaidenLocalPort,
+          );
+        const ordered = hasSamePortDuplicate
+          ? [...localGateways].sort((a, b) => {
+              const rank = (gw: typeof kaidenLocal): number =>
+                gw!.name !== DEFAULT_GATEWAY_NAME && this.getEndpointPort(gw!.endpoint) === kaidenLocalPort
+                  ? 0
+                  : gw!.name === DEFAULT_GATEWAY_NAME
+                    ? 2
+                    : 1;
+              return rank(a) - rank(b);
+            })
+          : localGateways;
+        for (const gw of ordered) {
           if (await this.isEndpointHealthy(gw.endpoint)) {
             if (!gw.active) {
               await this.openshellCli.selectGateway(gw.name);
+            }
+            // Remove the redundant kaiden-local registration when another gateway on the
+            // same port is healthy, otherwise all CLI calls would target kaiden-local.
+            if (
+              gw.name !== DEFAULT_GATEWAY_NAME &&
+              kaidenLocal &&
+              kaidenLocalPort === this.getEndpointPort(gw.endpoint)
+            ) {
+              await this.openshellCli.removeGateway(DEFAULT_GATEWAY_NAME).catch(() => {});
             }
             console.log(`[openshell-gateway] gateway detected (${gw.endpoint}) and is healthy`);
             this._onDidGatewayStart.fire();
@@ -162,10 +191,19 @@ export class OpenshellGateway implements Disposable {
     return this.openshellCli.checkEndpointStatus(target);
   }
 
+  private getEndpointPort(endpoint: string): number | undefined {
+    try {
+      const port = new URL(endpoint).port;
+      return port ? Number(port) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   private isLocalEndpoint(endpoint: string): boolean {
     try {
       const url = new URL(endpoint);
-      return ['127.0.0.1', 'localhost', '::1'].includes(url.hostname);
+      return ['127.0.0.1', 'localhost', '::1', '0.0.0.0'].includes(url.hostname);
     } catch {
       return false;
     }

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -316,7 +316,7 @@ test('Expect selected gateway included when creating a workspace', async () => {
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(expect.objectContaining({ gateway: 'remote' }));
 });
 
-test('offers gateways while their reachability state is unavailable', () => {
+test('does not offer gateways while their reachability state is unavailable', () => {
   vi.mocked(openshellGatewaysStore).openshellGateways.set([
     { name: 'local', endpoint: 'http://localhost:17670', active: true },
     { name: 'remote', endpoint: 'https://remote.example.com', active: false },
@@ -324,8 +324,8 @@ test('offers gateways while their reachability state is unavailable', () => {
 
   render(AgentWorkspaceCreate);
 
-  expect(screen.getByRole('option', { name: /local/ })).toBeInTheDocument();
-  expect(screen.getByRole('option', { name: /remote/ })).toBeInTheDocument();
+  expect(screen.queryByRole('option', { name: /local/ })).not.toBeInTheDocument();
+  expect(screen.queryByRole('option', { name: /remote/ })).not.toBeInTheDocument();
 });
 
 test('does not offer unreachable gateways for workspace creation', () => {
@@ -355,6 +355,128 @@ test('does not offer unreachable gateways for workspace creation', () => {
   expect(screen.getByRole('option', { name: /local/ })).toBeInTheDocument();
   expect(screen.getByRole('option', { name: /remote/ })).toBeInTheDocument();
   expect(screen.queryByRole('option', { name: /stopped/ })).not.toBeInTheDocument();
+});
+
+test('user-selected gateway is preserved across store updates', async () => {
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'remote',
+      endpoint: 'https://remote.example.com',
+      active: false,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ]);
+  render(AgentWorkspaceCreate);
+
+  const gatewaySelector = screen.getByRole('combobox');
+  expect(gatewaySelector).toHaveValue('local');
+
+  await fireEvent.change(gatewaySelector, { target: { value: 'remote' } });
+  expect(gatewaySelector).toHaveValue('remote');
+
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'remote',
+      endpoint: 'https://remote.example.com',
+      active: false,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ]);
+
+  await waitFor(() => {
+    expect(gatewaySelector).toHaveValue('remote');
+  });
+});
+
+test('falls back to active gateway when selected gateway becomes unreachable', async () => {
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'remote',
+      endpoint: 'https://remote.example.com',
+      active: false,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'extra',
+      endpoint: 'https://extra.example.com',
+      active: false,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ]);
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.change(screen.getByRole('combobox'), { target: { value: 'remote' } });
+  expect(screen.getByRole('combobox')).toHaveValue('remote');
+
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'remote',
+      endpoint: 'https://remote.example.com',
+      active: false,
+      gatewayState: { reachable: false, health: 'unknown' },
+    },
+    {
+      name: 'extra',
+      endpoint: 'https://extra.example.com',
+      active: false,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ]);
+
+  await waitFor(() => {
+    expect(wizard.draft.selectedGateway).toBe('local');
+  });
+});
+
+test('clears selected gateway when all gateways become unreachable', async () => {
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ]);
+  render(AgentWorkspaceCreate);
+
+  expect(wizard.draft.selectedGateway).toBe('local');
+
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: false, health: 'unknown' },
+    },
+  ]);
+
+  await waitFor(() => {
+    expect(wizard.draft.selectedGateway).toBe('');
+  });
 });
 
 test('Expect Continue button rendered on step 1', () => {
@@ -562,8 +684,18 @@ test('Expect secrets empty state shown when vault is empty', async () => {
 
 test('Expect secrets listed from the selected gateway', async () => {
   vi.mocked(openshellGatewaysStore).openshellGateways.set([
-    { name: 'local', endpoint: 'http://localhost:17670', active: true },
-    { name: 'remote', endpoint: 'https://remote.example.com', active: false },
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'remote',
+      endpoint: 'https://remote.example.com',
+      active: false,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
   ]);
   vi.mocked(window.listSecrets).mockImplementation(async gateway =>
     gateway === 'remote'

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -2,7 +2,7 @@
 import { faLock } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
-import { onMount } from 'svelte';
+import { onMount, untrack } from 'svelte';
 import { toast } from 'svelte-sonner';
 
 import type { ModelInfo } from '/@/lib/chat/components/model-info';
@@ -208,15 +208,22 @@ onMount(async () => {
   }
 });
 let customHosts = $derived(wizard.draft.hostsByMode[wizard.draft.selectedNetwork] ?? []);
-let reachableGateways = $derived($openshellGateways.filter(gateway => gateway.gatewayState?.reachable !== false));
+let reachableGateways = $derived($openshellGateways.filter(gateway => gateway.gatewayState?.reachable === true));
 
 $effect.pre(() => {
-  const selectedGatewayExists = reachableGateways.some(gateway => gateway.name === wizard.draft.selectedGateway);
-  if (!selectedGatewayExists) {
-    const activeGateway = reachableGateways.find(gateway => gateway.active);
-    wizard.draft.selectedGateway =
-      activeGateway?.name ?? (reachableGateways.length === 1 ? (reachableGateways[0]?.name ?? '') : '');
+  const gateways = reachableGateways;
+  if (gateways.length === 0) {
+    wizard.draft.selectedGateway = '';
+    return;
   }
+
+  const selected = untrack(() => wizard.draft.selectedGateway);
+  if (selected && gateways.some(gateway => gateway.name === selected)) {
+    return;
+  }
+
+  const activeGateway = gateways.find(gateway => gateway.active);
+  wizard.draft.selectedGateway = activeGateway?.name ?? (gateways.length === 1 ? (gateways[0]?.name ?? '') : '');
 });
 
 function getDefaultSessionName(path: string): string {


### PR DESCRIPTION
Previously, a gateway at 0.0.0.0 was not recognized as local, so when
openshell was running there, init() would fall through, find the default
port healthy (because 0.0.0.0 accepts connections on 127.0.0.1), and
register kaiden-local — creating a duplicate pointing to the same
process. All subsequent CLI calls then targeted kaiden-local instead of
the user's gateway.

Changes:
- Add 0.0.0.0 to isLocalEndpoint() so gateways bound to all interfaces
  are recognized as local. This lets init() find openshell in the
  for loop and return early, so kaiden-local is never created.
- When kaiden-local already exists from a previous session and another
  gateway is healthy on the same port, try the other gateway first and
  remove the redundant kaiden-local registration.
- Fix the workspace creation dropdown to only show reachable gateways
  (reachable === true instead of !== false) and use untrack() to
  preserve the user's manual gateway selection across store updates.

kaiden-local is now only created when no other local gateway is running
on that port — i.e., Kaiden genuinely needs to start its own gateway.

fixes #2751