### PR TITLE
refactor(tests): remove redundant length assertions on navigation tabs

### DIFF
--- a/tests/playwright/src/specs/dashboard.spec.ts
+++ b/tests/playwright/src/specs/dashboard.spec.ts
@@ -28,10 +28,8 @@ test.describe
 
     test('[APP-01] Navigation bar is visible and contains all expected navigation links', async ({ navigationBar }) => {
       await expect(navigationBar.navigationLocator).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
-      const expectedLinksCount = 7; // Chat, MCP, Skills, Knowledges, Extensions, Workspaces, Settings
 
       const allLinks = navigationBar.getAllLinks();
-      expect(allLinks).toHaveLength(expectedLinksCount);
 
       for (const link of allLinks) {
         await expect(link).toBeVisible({ timeout: TIMEOUTS.DEFAULT });

--- a/tests/playwright/src/specs/settings-smoke.spec.ts
+++ b/tests/playwright/src/specs/settings-smoke.spec.ts
@@ -47,9 +47,6 @@ test.describe('Settings page navigation', { tag: '@smoke' }, () => {
 
   test('[SET-01] All settings tabs are visible', async ({ settingsPage }) => {
     const tabs = settingsPage.getAllTabs();
-    const expectedTabCount = 6; // Resources, CLI, Proxy, Coding agents, Models, Preferences
-
-    expect(tabs).toHaveLength(expectedTabCount);
 
     for (const tab of tabs) {
       await expect(tab).toBeVisible();


### PR DESCRIPTION
The hardcoded counts duplicate the locators already listed in the page objects, so they break on every navbar or tab change without catching real regressions. The visibility loop that follows is the meaningful check.