### PR TITLE
docs: add mandatory pre-commit quality checks to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,18 @@ pnpm run typecheck:renderer  # Renderer only
 pnpm run svelte:check        # Svelte component type checking
 ```
 
+#### Mandatory pre-commit checks
+
+Before committing, always run the following commands and fix any failures:
+
+1. `pnpm run format:fix` — auto-fix formatting
+2. `pnpm run lint:fix` — auto-fix linting
+3. `pnpm run typecheck` — type-check all packages
+4. `pnpm run svelte:check` — check Svelte components
+5. Run unit tests for affected packages (e.g., `pnpm run test:main` or `pnpm run test:renderer`)
+
+Re-stage any files modified by the fix commands before committing. Do not skip these checks — commit hooks are not always available.
+
 ### Building Distributables
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a "Mandatory pre-commit checks" section to AGENTS.md instructing
  contributors to run formatting, linting, typecheck, and unit tests
  before committing
- Fullsend code/fix agents bypass commit hooks, so these instructions
  ensure quality checks are still enforced via AGENTS.md (read by all agents)

## Test plan
- [ ] Verify AGENTS.md passes prettier formatting check
- [ ] Confirm fullsend code agent runs quality checks on next triggered issue