### PR TITLE
fix(acp): restore messageTurn from persisted events on session resume

### DIFF
--- a/packages/main/src/plugin/acp/acp-session-manager.spec.ts
+++ b/packages/main/src/plugin/acp/acp-session-manager.spec.ts
@@ -636,6 +636,64 @@ describe('AcpSessionManager', () => {
       expect(sessions[0]!.id).toBe('session-resume');
     });
 
+    test('restores messageTurn from max turn in persisted events', async () => {
+      const { existsSync } = await import('node:fs');
+      const { readdir, readFile } = await import('node:fs/promises');
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdir).mockResolvedValue(['session-turn.json' as never]);
+
+      const events = [
+        { kind: 'prompt', text: 'hello', timestamp: 1000 },
+        { kind: 'agent_message', text: 'first response', messageId: 'msg-1', turn: 0, timestamp: 2000 },
+        { kind: 'tool_call', toolCallId: 'tc-1', title: 'tool', status: 'completed', timestamp: 3000 },
+        { kind: 'agent_message', text: 'after tool', messageId: 'msg-2', turn: 1, timestamp: 4000 },
+        { kind: 'prompt', text: 'follow up', timestamp: 5000 },
+        { kind: 'agent_message', text: 'second response', messageId: 'msg-3', turn: 2, timestamp: 6000 },
+      ];
+      const storedSession = {
+        info: {
+          id: 'session-turn',
+          sandboxName: 'sb',
+          sandboxId: 'sb-id',
+          prompt: 'hello',
+          status: 'completed',
+          createdAt: 1000,
+          updatedAt: 6000,
+        },
+        events,
+        acpSessionId: 'acp-456',
+        agentCommand: ['agent', 'acp'],
+        gatewayName: 'gw',
+      };
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(storedSession));
+
+      await manager.init();
+
+      const sessionEvents = manager.getSessionEvents('session-turn');
+      expect(sessionEvents).toHaveLength(6);
+      const agentMessages = sessionEvents.filter(e => e.kind === 'agent_message');
+      expect(agentMessages).toHaveLength(3);
+      const maxTurn = Math.max(...agentMessages.map(e => ('turn' in e ? (e.turn as number) : 0)));
+      expect(maxTurn).toBe(2);
+
+      // Simulate a new agent_message_chunk arriving after resume — its turn
+      // must be 3 (maxTurn + 1), not collide with any persisted event.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (manager as any).handleSessionUpdate('session-turn', {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          messageId: 'msg-new',
+          content: { type: 'text', text: 'new response' },
+        },
+      });
+
+      const updatedEvents = manager.getSessionEvents('session-turn');
+      const newMessage = updatedEvents.findLast(e => e.kind === 'agent_message' && 'turn' in e && e.turn === 3);
+      expect(newMessage).toBeDefined();
+      expect((newMessage as { text: string }).text).toBe('new response');
+    });
+
     test('handles missing resume fields in old persisted data', async () => {
       const { existsSync } = await import('node:fs');
       const { readdir, readFile } = await import('node:fs/promises');

--- a/packages/main/src/plugin/acp/acp-session-manager.ts
+++ b/packages/main/src/plugin/acp/acp-session-manager.ts
@@ -1245,15 +1245,20 @@ export class AcpSessionManager {
           info.updatedAt = Date.now();
         }
 
+        const events = data.events ?? [];
+        const maxTurn = events.reduce(
+          (max, e) => ('turn' in e && typeof e.turn === 'number' && e.turn > max ? e.turn : max),
+          -1,
+        );
         const session: AcpSession = {
           info,
           ptyProcess: undefined!,
           connection: undefined!,
           acpSessionId: data.acpSessionId,
-          events: data.events ?? [],
+          events,
           pendingRequests: new Map(),
           stderrLines: [],
-          messageTurn: 0,
+          messageTurn: maxTurn + 1,
           connectionClosed: true,
           agentCommand: data.agentCommand ?? [],
           gatewayName: data.gatewayName,


### PR DESCRIPTION
messageTurn was hardcoded to 0 in loadFromDisk(), causing resumed sessions
to reuse turn numbers from before the restart. New agent responses then
matched old agent_message events by turn and got appended to them instead
of creating separate message bubbles.

fixes #2657