### PR TITLE
fix: allow fullsend sandbox to reach npm.pkg.github.com

### DIFF
--- a/.fullsend/policies/kaiden.yaml
+++ b/.fullsend/policies/kaiden.yaml
@@ -68,21 +68,7 @@ network_policies:
         rules:
           - allow: { method: GET, path: /** }
     binaries:
-      - path: "**/npm"
-      - path: "**/npx"
-      - path: "**/yarn"
-      - path: "**/yarnpkg"
-      - path: "**/pnpm"
       - path: "**/node"
-      - path: "**/pip"
-      - path: "**/pip3"
-      - path: "**/python"
-      - path: "**/python3"
-      - path: "**/python3.*"
-      - path: "**/uv"
-      - path: "**/uvx"
-      - path: "**/go"
-      - path: "**/pre-commit"
 
   # proxy.spec.ts tests call fetch('https://podman-desktop.io') to exercise
   # the proxy subsystem — allow the sandbox to reach this domain.

--- a/.fullsend/policies/kaiden.yaml
+++ b/.fullsend/policies/kaiden.yaml
@@ -57,6 +57,33 @@ network_policies:
     binaries:
       - path: "**/node"
 
+  # @nvidia scoped packages are hosted on GitHub Packages
+  github_packages:
+    name: github-packages
+    endpoints:
+      - host: npm.pkg.github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: /** }
+    binaries:
+      - path: "**/npm"
+      - path: "**/npx"
+      - path: "**/yarn"
+      - path: "**/yarnpkg"
+      - path: "**/pnpm"
+      - path: "**/node"
+      - path: "**/pip"
+      - path: "**/pip3"
+      - path: "**/python"
+      - path: "**/python3"
+      - path: "**/python3.*"
+      - path: "**/uv"
+      - path: "**/uvx"
+      - path: "**/go"
+      - path: "**/pre-commit"
+
   # proxy.spec.ts tests call fetch('https://podman-desktop.io') to exercise
   # the proxy subsystem — allow the sandbox to reach this domain.
   podman_desktop:


### PR DESCRIPTION
## Summary
- Add `github_packages` network policy to `.fullsend/policies/kaiden.yaml` allowing GET requests to `npm.pkg.github.com:443`
- The `@nvidia` scoped packages (e.g. `@nvidia/openshell-sdk`) are hosted on GitHub Packages and were being denied by the sandbox during `pnpm install`
- Includes all standard package manager binaries in the allowlist

## Test plan
- [ ] Run fullsend in the OpenShell sandbox and verify `pnpm install` completes without `npm.pkg.github.com` denials in the sandbox log
