### PR TITLE
fix: resolve remaining sandbox network denials for pnpm install

### DIFF
--- a/.fullsend/policies/kaiden.yaml
+++ b/.fullsend/policies/kaiden.yaml
@@ -28,6 +28,18 @@ network_policies:
   nodegyp_releases:
     name: nodegyp-releases
     endpoints:
+      - host: github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: POST, path: /electron/node-gyp.git/git-upload-pack }
+      - host: release-assets.githubusercontent.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: /** }
       - host: codeload.github.com
         port: 443
         protocol: rest
@@ -65,8 +77,22 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
+        allow_encoded_slash: true
         rules:
           - allow: { method: GET, path: /** }
+    binaries:
+      - path: "**/node"
+
+  # pnpm runs an optional security audit during install
+  npm_audit:
+    name: npm-audit
+    endpoints:
+      - host: registry.npmjs.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: POST, path: /-/npm/v1/security/advisories/bulk }
     binaries:
       - path: "**/node"
 


### PR DESCRIPTION
## Summary
Follow-up to #2841. Fixes four additional sandbox network denials observed during `pnpm install` in the OpenShell sandbox:

- **`npm.pkg.github.com`** — add `allow_encoded_slash: true` for scoped package URLs containing `%2F`
- **`github.com`** — allow POST to `/electron/node-gyp.git/git-upload-pack` (git clone for node-gyp)
- **`release-assets.githubusercontent.com`** — allow GET for electron header/binary downloads
- **`registry.npmjs.org`** — allow POST to `/-/npm/v1/security/advisories/bulk` (npm audit)

## Test plan
- [ ] Run fullsend in the OpenShell sandbox and verify `pnpm install` completes without DENIED entries for these four hosts
