### PR TITLE
chore: remove GitHub Packages registry configuration

### DIFF
--- a/.fullsend/policies/kaiden.yaml
+++ b/.fullsend/policies/kaiden.yaml
@@ -69,26 +69,6 @@ network_policies:
     binaries:
       - path: "**/node"
 
-  # @nvidia scoped packages are hosted on GitHub Packages
-  github_packages:
-    name: github-packages
-    endpoints:
-      - host: npm.pkg.github.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        allow_encoded_slash: true
-        rules:
-          - allow: { method: GET, path: /** }
-      - host: ghcr.io
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        rules:
-          - allow: { method: GET, path: /** }
-    binaries:
-      - path: "**/node"
-
   # proxy.spec.ts tests call fetch('https://podman-desktop.io') to exercise
   # the proxy subsystem — allow the sandbox to reach this domain.
   podman_desktop:

--- a/.github/workflows/daily-testing-build.yaml
+++ b/.github/workflows/daily-testing-build.yaml
@@ -33,7 +33,6 @@ env:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   tag:

--- a/.github/workflows/e2e-test-job.yaml
+++ b/.github/workflows/e2e-test-job.yaml
@@ -71,7 +71,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      packages: read
     env:
       PODMAN_ENABLED: ${{ startsWith(inputs.instance, 'ubuntu') && 'true' || '' }}
     steps:

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -43,7 +43,6 @@ jobs:
       id-token: write
       contents: write
       issues: write
-      packages: read
       pull-requests: write
     uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@4665685a1d9d471a7a044908a68f00bed78caba7 # v0.42.0
 

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -29,7 +29,6 @@ env:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
 

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -49,7 +49,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -69,7 +68,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -96,7 +94,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      packages: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/npmjs-publish.yaml
+++ b/.github/workflows/npmjs-publish.yaml
@@ -27,7 +27,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   prepare-version:
@@ -83,7 +82,6 @@ jobs:
     environment: ${{ needs.prepare-version.outputs.is-tag == 'true' && 'npmjs-publication' || '' }}
     permissions:
       contents: read
-      packages: read
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -27,7 +27,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   windows:
@@ -276,7 +275,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      packages: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,6 @@ env:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
 

--- a/.github/workflows/workspace-e2e.yaml
+++ b/.github/workflows/workspace-e2e.yaml
@@ -134,7 +134,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      packages: read
     env:
       WINDOWS_VERSION: '11'
       WINDOWS_FEATUREPACK: '25h2-ent'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,9 +71,6 @@ Extensions interact with Kaiden through `@openkaiden/api` (`packages/extension-a
 ### Setup and Installation
 
 ```bash
-# Install dependencies (requires GITHUB_TOKEN with read:packages for @nvidia/openshell-sdk)
-# If your token lacks read:packages, run: gh auth refresh -s read:packages
-export GITHUB_TOKEN=$(gh auth token)
 pnpm install
 
 # Start in watch/development mode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,14 +101,9 @@ git clone https://github.com/<you>/kaiden && cd kaiden
 
 ### Step 2. Install dependencies
 
-Kaiden depends on `@nvidia/openshell-sdk` which is published to GitHub Packages. A GitHub token with `read:packages` scope is required for `pnpm install` to succeed:
-
 ```sh
-export GITHUB_TOKEN=$(gh auth token)
 pnpm install
 ```
-
-If `gh auth token` does not include `read:packages`, run `gh auth refresh -s read:packages` first.
 
 ### Step 3. Start in watch mode
 

--- a/README.md
+++ b/README.md
@@ -65,14 +65,9 @@ git clone https://github.com/openkaiden/kaiden && cd kaiden
 
 ### Step 2. Install dependencies
 
-Kaiden depends on `@nvidia/openshell-sdk` which is published to GitHub Packages. A GitHub token with `read:packages` scope is required for `pnpm install` to succeed:
-
 ```sh
-export GITHUB_TOKEN=$(gh auth token)
 pnpm install
 ```
-
-If `gh auth token` does not include `read:packages`, run `gh auth refresh -s read:packages` first.
 
 ### Step 3. Start in watch mode
 


### PR DESCRIPTION
## Summary

Now that `@nvidia/openshell-sdk` resolves from the public npm registry via pnpm alias (see #2866), remove all the supporting configuration that was only needed for GitHub Packages access.

## Changes

- Remove `@nvidia:registry` and `_authToken` lines from `.npmrc`
- Remove `github_packages` sandbox network policy from `.fullsend/policies/kaiden.yaml` (`npm.pkg.github.com` and `ghcr.io` endpoints)
- Remove `packages: read` permission from 10 CI workflow files
- Remove `GITHUB_TOKEN` / `read:packages` setup instructions from `AGENTS.md`, `README.md`, and `CONTRIBUTING.md`

## Testing

- `pnpm install` succeeds without `GITHUB_TOKEN`
- `pnpm run typecheck`, `pnpm run lint:check`, and `pnpm run format:check` all pass
- Unit tests for openshell SDK client manager pass