### PR TITLE
docs(contributing): consolidate pre-commit check commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,13 +144,12 @@ pnpm run svelte:check        # Svelte component type checking
 
 #### Mandatory pre-commit checks
 
-Before committing, always run the following commands and fix any failures:
+Before committing, stage files with `git add` so that `lint-staged` can operate on them, then run:
 
-1. `pnpm run format:fix` — auto-fix formatting
-2. `pnpm run lint:fix` — auto-fix linting
-3. `pnpm run typecheck` — type-check all packages
-4. `pnpm run svelte:check` — check Svelte components
-5. Run unit tests for affected packages (e.g., `pnpm run test:main` or `pnpm run test:renderer`)
+1. `pnpm lint-staged` — auto-fix formatting, linting
+2. `pnpm run typecheck` — type-check all packages
+3. `pnpm run svelte:check` — check Svelte components
+4. Run unit tests for affected packages (e.g., `pnpm run test:main` or `pnpm run test:renderer`)
 
 Re-stage any files modified by the fix commands before committing. Do not skip these checks — commit hooks are not always available.
 


### PR DESCRIPTION
## Summary
Replace separate `format:fix` and `lint:fix` commands with a single
`lint-staged` command in the pre-commit checks section of AGENTS.md.
`lint-staged` runs formatters and linters only on staged files, making
checks faster and more focused.

## Changes
- Consolidated `pnpm run format:fix` and `pnpm run lint:fix` into `pnpm lint-staged`
- Improved introductory wording to clarify that files must be staged before running checks

## Testing
Read through the updated AGENTS.md and verify the instructions are clear and accurate.